### PR TITLE
🐛 Fix preview mode overlay positioning and update menu shortcut

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1316,7 +1316,7 @@ fn build_app_menu(app: &tauri::AppHandle, detached_windows: &HashMap<String, Det
     
     // Notes menu
     let notes_menu = Submenu::new(app, "Notes", true).map_err(|e| e.to_string())?;
-    let new_note_item = MenuItem::with_id(app, "new-note", "New Note", true, Some("Cmd+N")).map_err(|e| e.to_string())?;
+    let new_note_item = MenuItem::with_id(app, "new-note", "New Note", true, Some("Cmd+Ctrl+Alt+Shift+N")).map_err(|e| e.to_string())?;
     let separator5 = PredefinedMenuItem::separator(app).map_err(|e| e.to_string())?;
     
     notes_menu.append(&new_note_item).map_err(|e| e.to_string())?;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ import { markdownToPlainText, truncateText } from './lib/utils';
 function App() {
   const { config, updateConfig } = useConfigStore();
   const [sidebarVisible, setSidebarVisible] = useState(true);
-  const [isPreviewMode, setIsPreviewMode] = useState(false);
+  const [isPreviewMode, setIsPreviewMode] = useState(false); // Start in edit mode
   const [currentView, setCurrentView] = useState<'notes' | 'settings'>('notes');
 
   // Window detection states
@@ -519,7 +519,7 @@ function App() {
                     {/* Preview overlay */}
                     {isPreviewMode && selectedNote && (
                       <div 
-                        className="w-full h-full overflow-y-auto prose prose-invert max-w-none cursor-text"
+                        className="absolute inset-0 w-full h-full overflow-y-auto prose prose-invert max-w-none cursor-text bg-background z-10"
                         onDoubleClick={() => setIsPreviewMode(false)}
                         title="Double-click to edit"
                         style={{ 


### PR DESCRIPTION
- Fix preview overlay not properly covering textarea by adding absolute positioning
- Add background and z-index to ensure preview mode works correctly
- Update menu accelerator to use Hyper+N (Cmd+Ctrl+Alt+Shift+N) to avoid conflicts
- Ensure notes start in edit mode by default for better user experience

This fixes the issue where notes appeared to be in preview mode but couldn't be edited, and aligns the menu shortcuts with the global shortcut configuration.