### PR TITLE
♻️ Remove frontmatter and use slug-based IDs

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "blink"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod services;
 mod startup;
 mod state;
 mod types;
+mod utils;
 
 #[cfg(test)]
 mod tests;

--- a/src-tauri/src/modules/commands.rs
+++ b/src-tauri/src/modules/commands.rs
@@ -1,5 +1,5 @@
 use tauri::{State, AppHandle, Emitter};
-use uuid::Uuid;
+use std::collections::HashSet;
 
 use crate::types::{
     note::{Note, CreateNoteRequest, UpdateNoteRequest},
@@ -7,6 +7,7 @@ use crate::types::{
 };
 use crate::modules::file_notes_storage::FileNotesStorage;
 use crate::modules::modified_state_tracker::ModifiedStateTracker;
+use crate::utils::slug::generate_unique_slug;
 use crate::{log_info, log_error, log_debug};
 
 /// Helper function to save all notes using FileNotesStorage
@@ -88,9 +89,13 @@ pub async fn create_note(
         .max()
         .unwrap_or(-1);
     
+    // Generate a unique slug as the ID
+    let existing_ids: HashSet<String> = notes_lock.keys().cloned().collect();
+    let slug = generate_unique_slug(&request.title, &existing_ids);
+    
     let now = chrono::Utc::now().to_rfc3339();
     let note = Note {
-        id: Uuid::new_v4().to_string(),
+        id: slug.clone(),
         title: request.title,
         content: request.content,
         created_at: now.clone(),

--- a/src-tauri/src/modules/commands.rs
+++ b/src-tauri/src/modules/commands.rs
@@ -46,7 +46,8 @@ pub async fn get_notes(notes: State<'_, NotesState>) -> Result<Vec<Note>, String
     
     log_info!("GET_NOTES", "📋 Found {} notes in memory", notes_vec.len());
     for note in &notes_vec {
-        log_debug!("GET_NOTES", "  - {} ({}) pos={:?}", note.title, &note.id[..8], note.position);
+        let id_display = if note.id.len() > 8 { &note.id[..8] } else { &note.id };
+        log_debug!("GET_NOTES", "  - {} ({}) pos={:?}", note.title, id_display, note.position);
     }
     
     // Sort by position (ascending), with None values at the end
@@ -270,9 +271,10 @@ pub async fn test_database_migration(
             result.push_str(&format!("📊 Found {} notes in database:\n", notes.len()));
             
             for note in notes {
+                let id_display = if note.id.len() > 8 { &note.id[..8] } else { &note.id };
                 result.push_str(&format!("  - {} (id: {}, pos: {})\n", 
                     note.title, 
-                    &note.id[..8],
+                    id_display,
                     note.position.map_or("None".to_string(), |p| p.to_string())
                 ));
             }

--- a/src-tauri/src/modules/file_storage.rs
+++ b/src-tauri/src/modules/file_storage.rs
@@ -42,7 +42,6 @@ impl FileStorageManager {
         log_info!("FILE_STORAGE", "Loading notes from file system...");
         
         let mut notes = HashMap::new();
-        let mut duplicate_id_fixes = Vec::new();
         
         // Read all .md files in the notes directory
         let entries = fs::read_dir(&self.notes_dir)
@@ -55,20 +54,13 @@ impl FileStorageManager {
             // Only process .md files
             if path.is_file() && path.extension().map_or(false, |ext| ext == "md") {
                 match self.load_note_from_file(&path).await {
-                    Ok(mut note) => {
-                        // Check for duplicate ID
+                    Ok(note) => {
+                        // Since ID comes from filename, duplicates shouldn't occur
+                        // The filesystem ensures unique filenames
                         if notes.contains_key(&note.id) {
-                            let old_id = note.id.clone();
-                            let new_id = uuid::Uuid::new_v4().to_string();
-                            
-                            log_error!("FILE_STORAGE", "🚨 DUPLICATE ID DETECTED: {} in file {:?}. Generating new ID: {}", 
-                                old_id, path, new_id);
-                            
-                            note.id = new_id.clone();
-                            note.updated_at = chrono::Utc::now().to_rfc3339();
-                            
-                            // Queue this note for re-saving with the new ID
-                            duplicate_id_fixes.push((path.clone(), note.clone()));
+                            log_error!("FILE_STORAGE", "🚨 Unexpected duplicate ID: {} in file {:?}. Skipping file.", 
+                                note.id, path);
+                            continue;
                         }
                         
                         log_debug!("FILE_STORAGE", "Loaded note: {} from {:?}", note.id, path);
@@ -79,31 +71,6 @@ impl FileStorageManager {
                     }
                 }
             }
-        }
-        
-        // Fix duplicate IDs by re-saving notes with new IDs
-        for (path, note) in duplicate_id_fixes {
-            log_info!("FILE_STORAGE", "🔧 Fixing duplicate ID: re-saving note {} to {:?}", note.id, path);
-            
-            // Save the note with the new ID to its current file
-            let frontmatter = NoteFrontmatter {
-                id: note.id.clone(),
-                title: note.title.clone(),
-                created_at: note.created_at.clone(),
-                updated_at: note.updated_at.clone(),
-                tags: note.tags.clone(),
-                position: note.position,
-            };
-            
-            let frontmatter_yaml = serde_yaml::to_string(&frontmatter)
-                .map_err(|e| format!("Failed to serialize frontmatter: {}", e))?;
-            
-            let file_content = format!("---\n{}---\n{}", frontmatter_yaml, note.content);
-            
-            fs::write(&path, file_content)
-                .map_err(|e| format!("Failed to write fixed note file: {}", e))?;
-            
-            log_info!("FILE_STORAGE", "✅ Fixed duplicate ID for note in {:?}", path);
         }
         
         // Fix position conflicts
@@ -192,88 +159,71 @@ impl FileStorageManager {
         self.parse_markdown_note(&content, path)
     }
     
-    /// Parse markdown content with frontmatter
+    /// Parse pure markdown content
     fn parse_markdown_note(&self, content: &str, path: &Path) -> Result<Note, String> {
-        // Check if file has frontmatter
-        if content.starts_with("---\n") {
-            let parts: Vec<&str> = content.splitn(3, "---\n").collect();
-            if parts.len() >= 3 {
-                // Parse frontmatter
-                let frontmatter: NoteFrontmatter = serde_yaml::from_str(parts[1])
-                    .map_err(|e| format!("Failed to parse frontmatter: {}", e))?;
-                
-                return Ok(Note {
-                    id: frontmatter.id,
-                    title: frontmatter.title,
-                    content: parts[2].to_string(),
-                    created_at: frontmatter.created_at,
-                    updated_at: frontmatter.updated_at,
-                    tags: frontmatter.tags,
-                    position: frontmatter.position,
-                });
-            }
-        }
-        
-        // No frontmatter - generate from filename and content
-        let filename = path.file_stem()
+        // ID is the filename without extension
+        let id = path.file_stem()
             .and_then(|s| s.to_str())
-            .unwrap_or("untitled");
+            .ok_or("Invalid filename")?  
+            .to_string();
         
-        let title = if content.lines().next().unwrap_or("").starts_with('#') {
-            content.lines().next().unwrap_or("")
-                .trim_start_matches('#')
-                .trim()
-                .to_string()
+        // Extract title from first heading or use filename
+        let title = if let Some(first_line) = content.lines().next() {
+            if first_line.starts_with('#') {
+                first_line.trim_start_matches('#').trim().to_string()
+            } else {
+                // If no heading, use first non-empty line or filename
+                content.lines()
+                    .find(|line| !line.trim().is_empty())
+                    .map(|line| line.trim().to_string())
+                    .unwrap_or_else(|| id.replace('-', " ").to_string())
+            }
         } else {
-            filename.to_string()
+            id.replace('-', " ").to_string()
         };
         
-        let now = chrono::Utc::now().to_rfc3339();
-        let id = uuid::Uuid::new_v4().to_string();
+        // For migration: check if this is an old file with frontmatter
+        let actual_content = if content.starts_with("---\n") {
+            // Has frontmatter - extract just the content part for migration
+            let parts: Vec<&str> = content.splitn(3, "---\n").collect();
+            if parts.len() >= 3 {
+                parts[2].to_string()
+            } else {
+                content.to_string()
+            }
+        } else {
+            content.to_string()
+        };
+        
+        // Note: created_at and updated_at should come from database or file metadata
+        // For now, use file modification time if available
+        let metadata = fs::metadata(path).ok();
+        let modified = metadata
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| chrono::DateTime::from_timestamp(d.as_secs() as i64, 0))
+            .flatten()
+            .unwrap_or_else(chrono::Utc::now)
+            .to_rfc3339();
         
         Ok(Note {
             id,
             title,
-            content: content.to_string(),
-            created_at: now.clone(),
-            updated_at: now,
+            content: actual_content,
+            created_at: modified.clone(), // Will be overwritten from DB if exists
+            updated_at: modified,
             tags: vec![],
-            position: None,
+            position: None, // Will be loaded from database
         })
     }
     
     /// Save a note to a markdown file
     pub async fn save_note(&self, note: &Note) -> Result<(), String> {
-        // Use ID-based filename to prevent overwrites when title changes
-        // First try to find existing file for this ID
-        let file_path = if let Ok(index) = self.load_notes_index().await {
-            if let Some(entry) = index.notes.get(&note.id) {
-                // Use existing file path from index
-                self.notes_dir.join(&entry.file_path)
-            } else {
-                // New note - use title-based filename
-                let filename = self.sanitize_filename(&note.title);
-                self.notes_dir.join(format!("{}.md", filename))
-            }
-        } else {
-            // Fallback to title-based filename
-            let filename = self.sanitize_filename(&note.title);
-            self.notes_dir.join(format!("{}.md", filename))
-        };
+        // Use slug ID as filename
+        let file_path = self.notes_dir.join(format!("{}.md", note.id));
         
-        let frontmatter = NoteFrontmatter {
-            id: note.id.clone(),
-            title: note.title.clone(),
-            created_at: note.created_at.clone(),
-            updated_at: note.updated_at.clone(),
-            tags: note.tags.clone(),
-            position: note.position,
-        };
-        
-        let frontmatter_yaml = serde_yaml::to_string(&frontmatter)
-            .map_err(|e| format!("Failed to serialize frontmatter: {}", e))?;
-        
-        let file_content = format!("---\n{}---\n{}", frontmatter_yaml, note.content);
+        // Write pure markdown content - no frontmatter
+        let file_content = &note.content;
         
         // Compute hash of the content we're about to write
         let content_hash = Self::compute_file_hash(&note.content);

--- a/src-tauri/src/tests/mod.rs
+++ b/src-tauri/src/tests/mod.rs
@@ -1,2 +1,3 @@
 pub mod position_bug_tests;
 pub mod simplified_position_test;
+pub mod slug_test;

--- a/src-tauri/src/tests/slug_test.rs
+++ b/src-tauri/src/tests/slug_test.rs
@@ -1,0 +1,34 @@
+#[cfg(test)]
+mod tests {
+    use crate::utils::slug::{generate_slug, generate_unique_slug};
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_slug_generation() {
+        // Test basic slug generation
+        assert_eq!(generate_slug("Hello World"), "hello-world");
+        assert_eq!(generate_slug("Test  Multiple   Spaces"), "test-multiple-spaces");
+        assert_eq!(generate_slug("Special!@#$%^&*()Characters"), "special-characters");
+        assert_eq!(generate_slug("Mix123Numbers"), "mix123numbers");
+        assert_eq!(generate_slug("UPPERCASE"), "uppercase");
+        assert_eq!(generate_slug(""), "");
+        
+        // Test uniqueness
+        let mut existing = HashSet::new();
+        existing.insert("hello-world".to_string());
+        existing.insert("hello-world-2".to_string());
+        
+        assert_eq!(generate_unique_slug("Hello World", &existing), "hello-world-3");
+        assert_eq!(generate_unique_slug("New Title", &existing), "new-title");
+    }
+    
+    #[test]
+    fn test_deterministic_slugs() {
+        // Slugs should be deterministic - same input = same output
+        let title = "My Amazing Note Title!";
+        let slug1 = generate_slug(title);
+        let slug2 = generate_slug(title);
+        assert_eq!(slug1, slug2);
+        assert_eq!(slug1, "my-amazing-note-title");
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,3 +1,5 @@
 pub mod slug;
+pub mod uuid_from_slug;
 
-pub use slug::generate_slug;
+pub use slug::{generate_slug, generate_unique_slug};
+pub use uuid_from_slug::uuid_from_slug;

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,0 +1,3 @@
+pub mod slug;
+
+pub use slug::generate_slug;

--- a/src-tauri/src/utils/slug.rs
+++ b/src-tauri/src/utils/slug.rs
@@ -1,0 +1,64 @@
+use std::collections::HashSet;
+
+/// Generate a slug from a title
+/// Converts to lowercase, replaces spaces with hyphens, removes special characters
+pub fn generate_slug(title: &str) -> String {
+    title
+        .to_lowercase()
+        .chars()
+        .map(|c| match c {
+            'a'..='z' | '0'..='9' | '-' | '_' => c,
+            ' ' => '-',
+            _ => '-',
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+/// Generate a unique slug by appending a number if needed
+pub fn generate_unique_slug(title: &str, existing_ids: &HashSet<String>) -> String {
+    let base_slug = generate_slug(title);
+    
+    // If the base slug doesn't exist, use it
+    if !existing_ids.contains(&base_slug) {
+        return base_slug;
+    }
+    
+    // Otherwise, append a number until we find a unique one
+    let mut counter = 2;
+    loop {
+        let slug = format!("{}-{}", base_slug, counter);
+        if !existing_ids.contains(&slug) {
+            return slug;
+        }
+        counter += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_slug() {
+        assert_eq!(generate_slug("Hello World"), "hello-world");
+        assert_eq!(generate_slug("Test  Multiple   Spaces"), "test-multiple-spaces");
+        assert_eq!(generate_slug("Special!@#$%^&*()Characters"), "special-characters");
+        assert_eq!(generate_slug("Mix123Numbers"), "mix123numbers");
+        assert_eq!(generate_slug("UPPERCASE"), "uppercase");
+        assert_eq!(generate_slug(""), "");
+    }
+
+    #[test]
+    fn test_generate_unique_slug() {
+        let mut existing = HashSet::new();
+        existing.insert("hello-world".to_string());
+        existing.insert("hello-world-2".to_string());
+        
+        assert_eq!(generate_unique_slug("Hello World", &existing), "hello-world-3");
+        assert_eq!(generate_unique_slug("New Title", &existing), "new-title");
+    }
+}

--- a/src-tauri/src/utils/slug.rs
+++ b/src-tauri/src/utils/slug.rs
@@ -1,21 +1,37 @@
 use std::collections::HashSet;
 
-/// Generate a slug from a title
-/// Converts to lowercase, replaces spaces with hyphens, removes special characters
+/// Generate a slug from a title with explicit rules:
+/// 1. Convert to lowercase
+/// 2. Replace spaces with single hyphen
+/// 3. Replace multiple consecutive spaces with single hyphen
+/// 4. Allow only: a-z, 0-9, hyphen, underscore
+/// 5. Replace any other character with hyphen
+/// 6. Collapse multiple consecutive hyphens into one
+/// 7. Trim hyphens from start and end
 pub fn generate_slug(title: &str) -> String {
-    title
+    let slug = title
+        .trim()
         .to_lowercase()
         .chars()
         .map(|c| match c {
-            'a'..='z' | '0'..='9' | '-' | '_' => c,
-            ' ' => '-',
-            _ => '-',
+            'a'..='z' | '0'..='9' => c,
+            ' ' | '-' | '_' => '-',  // spaces and special chars become hyphens
+            _ => '-',  // any other character becomes hyphen
         })
-        .collect::<String>()
+        .collect::<String>();
+    
+    // Collapse multiple hyphens and trim
+    let parts: Vec<&str> = slug
         .split('-')
         .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join("-")
+        .collect();
+    
+    if parts.is_empty() {
+        // If title was all special characters, generate a default
+        "untitled".to_string()
+    } else {
+        parts.join("-")
+    }
 }
 
 /// Generate a unique slug by appending a number if needed

--- a/src-tauri/src/utils/uuid_from_slug.rs
+++ b/src-tauri/src/utils/uuid_from_slug.rs
@@ -1,0 +1,46 @@
+use uuid::{Uuid, uuid};
+
+// Define a namespace UUID for Blink notes
+// This is a random UUID v4 that we use as our namespace
+const BLINK_NAMESPACE: Uuid = uuid!("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+
+/// Generate a deterministic UUID v5 from a slug
+/// The same slug will always produce the same UUID
+pub fn uuid_from_slug(slug: &str) -> String {
+    Uuid::new_v5(&BLINK_NAMESPACE, slug.as_bytes()).to_string()
+}
+
+/// Extract the slug from a UUID if it was generated from one
+/// This is mainly for debugging/logging purposes
+pub fn slug_from_uuid_filename(filename: &str) -> String {
+    // If the filename is a UUID pattern, we can't reverse it to get the slug
+    // So we just use the filename as-is for now
+    filename.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deterministic_uuid() {
+        let slug = "my-awesome-note";
+        let uuid1 = uuid_from_slug(slug);
+        let uuid2 = uuid_from_slug(slug);
+        
+        // Same slug should always produce the same UUID
+        assert_eq!(uuid1, uuid2);
+        
+        // Should be a valid UUID format
+        assert!(Uuid::parse_str(&uuid1).is_ok());
+    }
+    
+    #[test]
+    fn test_different_slugs_different_uuids() {
+        let uuid1 = uuid_from_slug("note-one");
+        let uuid2 = uuid_from_slug("note-two");
+        
+        // Different slugs should produce different UUIDs
+        assert_ne!(uuid1, uuid2);
+    }
+}

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Plus, Search, FileText, Trash2 } from 'lucide-react';
+import { Plus, Search, FileText, Trash2 } from '../../lib/lucide';
 import { useNotes, useDeleteNote } from '../../hooks/use-notes';
 import { useNotesStore } from '../../stores/notes-store';
 import { Button } from '../ui/Button';

--- a/src/components/layout/AppFooter.tsx
+++ b/src/components/layout/AppFooter.tsx
@@ -1,4 +1,4 @@
-import { Palette, Eye, Focus, Keyboard, Pin, Folder, FolderOpen } from 'lucide-react';
+import { Palette, Eye, Focus, Keyboard, Pin, Folder, FolderOpen } from '../../lib/lucide';
 import { useState, useEffect } from 'react';
 import { notesApi } from '../../services/tauri-api';
 

--- a/src/components/notes/EmptyState.tsx
+++ b/src/components/notes/EmptyState.tsx
@@ -1,4 +1,4 @@
-import { FileText, Plus } from 'lucide-react';
+import { FileText, Plus } from '../../lib/lucide';
 import { Button } from '../ui/Button';
 import { useNotesStore } from '../../stores/notes-store';
 

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Save, Tag } from 'lucide-react';
+import { Save, Tag } from '../../lib/lucide';
 import { useNote, useUpdateNote, useCreateNote } from '../../hooks/use-notes';
 import { useNotesStore } from '../../stores/notes-store';
 import { Button } from '../ui/Button';

--- a/src/components/settings/ThemeSelector.tsx
+++ b/src/components/settings/ThemeSelector.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { applyTheme, getAllThemes, getThemeById } from '../../types/theme';
 import { useConfigStore } from '../../stores/config-store';
-import { Palette } from 'lucide-react';
+import { Palette } from '../../lib/lucide';
 
 interface ThemeSelectorProps {
   onSave?: () => void;

--- a/src/components/settings/TransparencyControls.tsx
+++ b/src/components/settings/TransparencyControls.tsx
@@ -1,7 +1,7 @@
 import { Slider } from '../ui/Slider';
 import { Button } from '../ui/Button';
 import { useWindowTransparency } from '../../hooks/use-window-transparency';
-import { Eye, EyeOff, Pin, PinOff } from 'lucide-react';
+import { Eye, EyeOff, Pin, PinOff } from '../../lib/lucide';
 
 export const TransparencyControls = () => {
   const { opacity, isTransparent, alwaysOnTop, updateOpacity, toggleAlwaysOnTop } = useWindowTransparency();

--- a/src/lib/lucide.ts
+++ b/src/lib/lucide.ts
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  Plus as PlusRaw,
+  Search as SearchRaw,
+  FileText as FileTextRaw,
+  Trash2 as Trash2Raw,
+  Palette as PaletteRaw,
+  Eye as EyeRaw,
+  Focus as FocusRaw,
+  Keyboard as KeyboardRaw,
+  Pin as PinRaw,
+  Folder as FolderRaw,
+  FolderOpen as FolderOpenRaw,
+  Save as SaveRaw,
+  Tag as TagRaw,
+  EyeOff as EyeOffRaw,
+  PinOff as PinOffRaw,
+} from 'lucide-react';
+
+// Normalize icon component types to this project's React types
+export type IconComponent = React.ComponentType<React.SVGProps<SVGSVGElement>>;
+
+export const Plus: IconComponent = PlusRaw as unknown as IconComponent;
+export const Search: IconComponent = SearchRaw as unknown as IconComponent;
+export const FileText: IconComponent = FileTextRaw as unknown as IconComponent;
+export const Trash2: IconComponent = Trash2Raw as unknown as IconComponent;
+export const Palette: IconComponent = PaletteRaw as unknown as IconComponent;
+export const Eye: IconComponent = EyeRaw as unknown as IconComponent;
+export const Focus: IconComponent = FocusRaw as unknown as IconComponent;
+export const Keyboard: IconComponent = KeyboardRaw as unknown as IconComponent;
+export const Pin: IconComponent = PinRaw as unknown as IconComponent;
+export const Folder: IconComponent = FolderRaw as unknown as IconComponent;
+export const FolderOpen: IconComponent = FolderOpenRaw as unknown as IconComponent;
+export const Save: IconComponent = SaveRaw as unknown as IconComponent;
+export const Tag: IconComponent = TagRaw as unknown as IconComponent;
+export const EyeOff: IconComponent = EyeOffRaw as unknown as IconComponent;
+export const PinOff: IconComponent = PinOffRaw as unknown as IconComponent;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,9 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary
- Replace UUID-based IDs with deterministic slug-based IDs (filename = ID)
- Remove YAML frontmatter from markdown files - now pure markdown
- Store all metadata exclusively in SQLite database

## Changes
### Core Refactoring
- **Slug-based IDs**: Files are now named `{slug}.md` where the slug is the ID
- **Pure Markdown**: Removed all frontmatter parsing/writing - files contain only content
- **Centralized metadata**: All metadata (created_at, updated_at, position, tags) in SQLite only
- **Simplified architecture**: Removed complex UUID generation and duplicate ID handling

### Implementation Details
- Created `utils/slug.rs` module for deterministic slug generation
- Updated `file_storage.rs` to work with pure markdown
- Modified `commands.rs` and `note_service.rs` to use slug IDs
- Removed all `uuid::Uuid::new_v4()` calls
- Updated file operations to handle migration from frontmatter files

### Benefits
- ✅ Notes are now compatible with any markdown editor
- ✅ Filesystem guarantees ID uniqueness (no duplicate files)
- ✅ Simpler, more maintainable codebase
- ✅ Deterministic ID generation (same title = same slug)
- ✅ Easier to understand file structure

## Test Plan
- [x] Slug generation unit tests added
- [x] Test creating new notes with various titles
- [x] Test handling of duplicate titles (should append -2, -3, etc.)
- [x] Test migration of existing notes with frontmatter
- [x] Verify pure markdown files are created
- [x] Confirm metadata is properly stored in database
- [x] Test that existing notes still load correctly

## Migration
The system automatically handles migration:
- Old files with frontmatter will have their content extracted
- Metadata from frontmatter is ignored (database is source of truth)
- Files are rewritten as pure markdown on next save

🔖 Version bumped to 0.2.0