### PR TITLE
✨ Ship Blink 2.0.3 interface polish

### DIFF
--- a/Sources/BlinkApp/AppDelegate.swift
+++ b/Sources/BlinkApp/AppDelegate.swift
@@ -52,11 +52,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             }
         }
 
+        // Light/dark: resolve the config's appearance axis before the first
+        // theme pass, and re-theme AppKit surfaces on a system-driven flip
+        // (the SwiftUI popover observes AppearanceManager itself).
+        AppearanceManager.shared.apply(BlinkConfigStore.shared.config.appearance)
+        AppearanceManager.shared.onChange = { [weak self] _ in
+            self?.panelManager.applyTheme(BlinkConfigStore.shared.config)
+        }
+
         // Agent-first config: hot-apply file edits to every live surface.
         BlinkConfigStore.shared.onChange = { [weak self] config in
+            // Appearance first, so applyTheme paints the resolved scheme.
+            AppearanceManager.shared.apply(config.appearance)
             self?.panelManager.applyTheme(config)
             self?.applyHotkeys(config)
             self?.applyLoginItem(config)
+            // Reflect an appearance change (or any state) in the menu checkmarks.
+            self?.contextMenu = self?.buildContextMenu()
         }
 
         Task {
@@ -247,7 +259,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         let popover = NSPopover()
         popover.behavior = .transient
         popover.delegate = self
-        popover.appearance = NSAppearance(named: .darkAqua)
+        popover.appearance = NSAppearance(named: AppearanceManager.shared.scheme.nsAppearanceName)
         popover.contentSize = CapturePopoverView.contentSize
         let host = NSHostingController(
             rootView: CapturePopoverView(
@@ -314,6 +326,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         backgroundItem.submenu = backgroundMenu
         menu.addItem(backgroundItem)
 
+        // Appearance: light/dark override (or Auto to follow macOS), without a
+        // trip through config.json. Mirrors config.appearance.
+        let appearanceItem = NSMenuItem(title: "Appearance", action: nil, keyEquivalent: "")
+        let appearanceMenu = NSMenu()
+        let current = BlinkConfigStore.shared.config.appearance.lowercased()
+        let activeAppearance = (current == "light" || current == "dark") ? current : "auto"
+        for (title, value) in [("Auto", "auto"), ("Light", "light"), ("Dark", "dark")] {
+            let item = NSMenuItem(title: title, action: #selector(menuAppearance(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = value
+            item.state = (activeAppearance == value) ? .on : .off
+            appearanceMenu.addItem(item)
+        }
+        appearanceItem.submenu = appearanceMenu
+        menu.addItem(appearanceItem)
+
         menu.addItem(.separator())
 
         let settingsItem = NSMenuItem(title: "Settings…", action: #selector(menuSettings), keyEquivalent: ",")
@@ -353,6 +381,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
+    @objc private func menuAppearance(_ sender: NSMenuItem) {
+        guard let value = sender.representedObject as? String else { return }
+        BlinkConfigStore.shared.update { $0.appearance = value }
+    }
+
     @objc private func menuNewNote() {
         newNote()
     }
@@ -373,7 +406,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             let window = NSWindow(contentViewController: host)
             window.title = "Blink Settings"
             window.styleMask = [.titled, .closable]
-            window.appearance = NSAppearance(named: .darkAqua)
+            // No explicit appearance — inherit NSApp.appearance, which
+            // AppearanceManager pins (light/dark) or clears (auto → the OS).
             window.isReleasedWhenClosed = false
             window.setFrameAutosaveName("blink.settings")
             if window.frame.origin == .zero { window.center() }

--- a/Sources/BlinkApp/AppDelegate.swift
+++ b/Sources/BlinkApp/AppDelegate.swift
@@ -211,6 +211,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
 
         if event.type == .rightMouseUp {
+            // Rebuild so live state (e.g. the Background checkmark) is current.
+            contextMenu = buildContextMenu()
             contextMenu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 4), in: button)
             return
         }
@@ -297,6 +299,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         menu.addItem(.separator())
 
+        // Background: quick control over the drape (the full-screen blur/dim
+        // behind the notes) without a trip through config.json.
+        let backgroundItem = NSMenuItem(title: "Background", action: nil, keyEquivalent: "")
+        let backgroundMenu = NSMenu()
+        let level = drapeLevel(BlinkConfigStore.shared.config)
+        for (title, target) in [("Off", DrapeLevel.off), ("Light", .light), ("Full", .full)] {
+            let item = NSMenuItem(title: title, action: #selector(menuBackgroundLevel(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = target.rawValue
+            item.state = (level == target) ? .on : .off
+            backgroundMenu.addItem(item)
+        }
+        backgroundItem.submenu = backgroundMenu
+        menu.addItem(backgroundItem)
+
+        menu.addItem(.separator())
+
         let settingsItem = NSMenuItem(title: "Settings…", action: #selector(menuSettings), keyEquivalent: ",")
         settingsItem.target = self
         menu.addItem(settingsItem)
@@ -308,6 +327,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         menu.addItem(quitItem)
 
         return menu
+    }
+
+    /// The three quick background presets. `Off` kills the drape; `Light` and
+    /// `Full` set its overall presence (opacity) but leave `dim`/`material` as
+    /// configured, so a tuned drape keeps its character.
+    private enum DrapeLevel: String {
+        case off, light, full
+    }
+
+    private func drapeLevel(_ config: BlinkConfig) -> DrapeLevel {
+        guard config.drape.enabled else { return .off }
+        return config.drape.opacity <= 0.7 ? .light : .full
+    }
+
+    @objc private func menuBackgroundLevel(_ sender: NSMenuItem) {
+        guard let raw = sender.representedObject as? String,
+              let level = DrapeLevel(rawValue: raw) else { return }
+        BlinkConfigStore.shared.update { config in
+            switch level {
+            case .off:   config.drape.enabled = false
+            case .light: config.drape.enabled = true; config.drape.opacity = 0.4
+            case .full:  config.drape.enabled = true; config.drape.opacity = 1.0
+            }
+        }
     }
 
     @objc private func menuNewNote() {

--- a/Sources/BlinkApp/AppearanceManager.swift
+++ b/Sources/BlinkApp/AppearanceManager.swift
@@ -1,0 +1,98 @@
+import AppKit
+import Combine
+
+/// Blink's effective light/dark decision. The config's `appearance` axis is a
+/// string ("auto" | "light" | "dark"); this resolves it — against the live OS
+/// setting when "auto" — into a concrete `AppScheme` the surfaces paint by.
+enum AppScheme: Equatable {
+    case light, dark
+
+    /// The window/appearance name a surface adopts so its system materials
+    /// (glass, blur) and standard controls render in the right mode.
+    var nsAppearanceName: NSAppearance.Name {
+        self == .dark ? .darkAqua : .aqua
+    }
+
+    var isDark: Bool { self == .dark }
+}
+
+/// Owns the app-wide light/dark decision and keeps every surface in sync.
+///
+/// `config.appearance` is the source of truth: "light"/"dark" pin `NSApp`'s
+/// appearance; "auto" clears it so windows inherit the OS — and we KVO the OS's
+/// effective appearance so a system light/dark flip re-themes Blink live.
+///
+/// Two notification paths, on purpose:
+/// - `@Published scheme` drives SwiftUI surfaces (the popover) automatically.
+/// - `onChange` re-themes the AppKit surfaces (panels, overlays) that pick
+///   colors by scheme and can't observe an ObservableObject. It fires ONLY on a
+///   system-driven flip; the config-driven path re-themes explicitly via its own
+///   `applyTheme`, so an override change never double-applies.
+@MainActor
+final class AppearanceManager: ObservableObject {
+    static let shared = AppearanceManager()
+
+    /// The resolved scheme every surface paints by. Published for SwiftUI.
+    @Published private(set) var scheme: AppScheme = .dark
+
+    /// Fired after a *system-driven* flip changes `scheme` (auto mode only), so
+    /// AppKit surfaces can re-apply. SwiftUI observes `scheme` instead.
+    var onChange: ((AppScheme) -> Void)?
+
+    /// Normalized config value: "auto" | "light" | "dark".
+    private var mode = "auto"
+    private var systemObserver: NSKeyValueObservation?
+
+    private init() {}
+
+    /// Apply the config's `appearance` axis. Pins or clears `NSApp.appearance`,
+    /// arms system observation only in auto, and recomputes `scheme`. Does NOT
+    /// fire `onChange` — the config path re-themes explicitly right after.
+    func apply(_ appearance: String) {
+        mode = Self.normalize(appearance)
+        switch mode {
+        case "light": NSApp.appearance = NSAppearance(named: .aqua)
+        case "dark":  NSApp.appearance = NSAppearance(named: .darkAqua)
+        default:      NSApp.appearance = nil  // "auto": inherit the OS
+        }
+        observeSystem(mode == "auto")
+        scheme = resolvedScheme()  // @Published — SwiftUI picks it up
+    }
+
+    /// KVO `NSApp.effectiveAppearance` so an OS light/dark flip re-themes live.
+    /// Armed only in auto; pinned light/dark ignore the system entirely.
+    private func observeSystem(_ on: Bool) {
+        systemObserver?.invalidate()
+        systemObserver = nil
+        guard on else { return }
+        systemObserver = NSApp.observe(\.effectiveAppearance) { [weak self] _, _ in
+            MainActor.assumeIsolated { self?.systemDidChange() }
+        }
+    }
+
+    private func systemDidChange() {
+        let next = resolvedScheme()
+        guard next != scheme else { return }
+        scheme = next        // @Published → SwiftUI surfaces
+        onChange?(next)      // AppKit surfaces re-theme
+    }
+
+    private func resolvedScheme() -> AppScheme {
+        switch mode {
+        case "light": return .light
+        case "dark":  return .dark
+        default:
+            let matched = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua])
+            return matched == .darkAqua ? .dark : .light
+        }
+    }
+
+    private static func normalize(_ raw: String) -> String {
+        switch raw.lowercased() {
+        case "light": return "light"
+        case "dark": return "dark"
+        // "system" is an accepted alias for "auto".
+        default: return "auto"
+        }
+    }
+}

--- a/Sources/BlinkApp/BlinkConfig.swift
+++ b/Sources/BlinkApp/BlinkConfig.swift
@@ -99,6 +99,10 @@ struct BlinkConfig: Codable, Equatable {
         var dim: Double = 0.45  // 0–1 black tint over the blurred backdrop
         var opacity: Double = 1  // 0–1 overall presence; lower = a lighter veil
         var material: String = "hud"  // hud | underWindow | popover | sidebar | menu
+        /// Suppress the drape while a single note is on screen — a lone note
+        /// reads better clean over the desktop; the backdrop earns its keep only
+        /// once the notes form a set. Off restores "behind every note".
+        var soloSuppressed: Bool = true
 
         init() {}
         init(from decoder: Decoder) throws {
@@ -107,6 +111,7 @@ struct BlinkConfig: Codable, Equatable {
             dim = try c.decodeIfPresent(Double.self, forKey: .dim) ?? 0.45
             opacity = try c.decodeIfPresent(Double.self, forKey: .opacity) ?? 1
             material = try c.decodeIfPresent(String.self, forKey: .material) ?? "hud"
+            soloSuppressed = try c.decodeIfPresent(Bool.self, forKey: .soloSuppressed) ?? true
         }
 
         var visualEffectMaterial: NSVisualEffectView.Material {
@@ -141,6 +146,36 @@ struct BlinkConfig: Codable, Equatable {
             durationMs = try c.decodeIfPresent(Double.self, forKey: .durationMs) ?? 260
             staggerMs = try c.decodeIfPresent(Double.self, forKey: .staggerMs) ?? 40
             enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        }
+    }
+
+    /// Panel physics: momentum fling with edge bounce, and shake-to-shade —
+    /// how a panel behaves under the hand, as opposed to `motion`, which owns
+    /// show/hide choreography. Read at gesture time (no hot-apply needed).
+    /// Reduce Motion turns the physics gestures off entirely.
+    struct Physics: Codable, Equatable {
+        /// Master switch for the fling: release a fast drag and the panel
+        /// glides on, bouncing off the edges of the screen it's mostly on.
+        var flingEnabled: Bool = true
+        /// Exponential glide friction (1/s); higher = heavier, stops sooner.
+        /// Total glide distance is ~releaseSpeed / flingFriction.
+        var flingFriction: Double = 3.2
+        /// Release speed (pt/s) that starts a glide; below it the panel stays put.
+        var flingMinVelocity: Double = 900
+        /// Fraction of velocity kept after an edge bounce (0…1).
+        var bounceDamping: Double = 0.6
+        /// Shake the panel side-to-side during a drag to fold it into its top
+        /// band (shade); shake again — or double-click the band — to restore.
+        var shakeEnabled: Bool = true
+
+        init() {}
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            flingEnabled = try c.decodeIfPresent(Bool.self, forKey: .flingEnabled) ?? true
+            flingFriction = try c.decodeIfPresent(Double.self, forKey: .flingFriction) ?? 3.2
+            flingMinVelocity = try c.decodeIfPresent(Double.self, forKey: .flingMinVelocity) ?? 900
+            bounceDamping = try c.decodeIfPresent(Double.self, forKey: .bounceDamping) ?? 0.6
+            shakeEnabled = try c.decodeIfPresent(Bool.self, forKey: .shakeEnabled) ?? true
         }
     }
 
@@ -222,6 +257,7 @@ struct BlinkConfig: Codable, Equatable {
     var focus = Focus()
     var drape = Drape()
     var motion = Motion()
+    var physics = Physics()
     var editor = Editor()
     /// Named presentation presets, referenced by a note's `blink.style`.
     var styles: [String: Treatment]?
@@ -235,6 +271,7 @@ struct BlinkConfig: Codable, Equatable {
         focus = try c.decodeIfPresent(Focus.self, forKey: .focus) ?? Focus()
         drape = try c.decodeIfPresent(Drape.self, forKey: .drape) ?? Drape()
         motion = try c.decodeIfPresent(Motion.self, forKey: .motion) ?? Motion()
+        physics = try c.decodeIfPresent(Physics.self, forKey: .physics) ?? Physics()
         editor = try c.decodeIfPresent(Editor.self, forKey: .editor) ?? Editor()
         styles = try c.decodeIfPresent([String: Treatment].self, forKey: .styles)
     }

--- a/Sources/BlinkApp/BlinkConfig.swift
+++ b/Sources/BlinkApp/BlinkConfig.swift
@@ -251,6 +251,10 @@ struct BlinkConfig: Codable, Equatable {
         }
     }
 
+    /// App-wide light/dark axis: "auto" (follow macOS) | "light" | "dark".
+    /// Resolved to an effective `AppScheme` by `AppearanceManager`; every
+    /// surface paints by that. "auto" is the default and tracks the OS live.
+    var appearance = "auto"
     var behavior = Behavior()
     var hotkeys = Hotkeys()
     var panel = Panel()
@@ -265,6 +269,7 @@ struct BlinkConfig: Codable, Equatable {
     init() {}
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        appearance = try c.decodeIfPresent(String.self, forKey: .appearance) ?? "auto"
         behavior = try c.decodeIfPresent(Behavior.self, forKey: .behavior) ?? Behavior()
         hotkeys = try c.decodeIfPresent(Hotkeys.self, forKey: .hotkeys) ?? Hotkeys()
         panel = try c.decodeIfPresent(Panel.self, forKey: .panel) ?? Panel()
@@ -323,15 +328,28 @@ struct BlinkConfig: Codable, Equatable {
     }
 
     /// Map editor settings onto the web bundle's CSS variable contract
-    /// (see web/editor/README.md). Only non-default values are sent; the
-    /// stylesheet's own defaults cover the rest.
-    var editorThemeVars: [String: String] {
+    /// (see web/editor/README.md). The bundle's own `:root` defaults are dark;
+    /// in light mode we push a full "paper" palette (dark ink on light) BEFORE
+    /// the user's explicit `editor.*` colors, which always win. Only non-default
+    /// values are sent; the stylesheet covers the rest.
+    func editorThemeVars(scheme: AppScheme) -> [String: String] {
         var vars: [String: String] = [
             "--blink-font-size": "\(editor.fontSize)px",
             "--blink-line-height": "\(editor.lineHeight)",
             "--blink-pad-x": "\(editor.paddingX)px",
             "--blink-pad-y": "\(editor.paddingY)px",
         ]
+        if scheme == .light {
+            // Light "paper" defaults — dark ink on the now-light glass. Any
+            // explicit editor.* color below overrides these per note/theme.
+            vars["--blink-text"] = "rgba(28,26,24,0.86)"
+            vars["--blink-text-strong"] = "rgba(18,17,16,0.98)"
+            vars["--blink-text-muted"] = "rgba(60,56,52,0.55)"
+            vars["--blink-accent"] = "#c2410c"  // deepened amber; reads on light
+            vars["--blink-code-bg"] = "rgba(20,18,16,0.06)"
+            vars["--blink-caret"] = "#c2410c"
+            vars["--blink-selection"] = "rgba(194,65,12,0.22)"
+        }
         if let v = editor.fontFamily { vars["--blink-font-family"] = v }
         if let v = editor.monoFamily { vars["--blink-mono-family"] = v }
         if let v = editor.textColor { vars["--blink-text"] = v }

--- a/Sources/BlinkApp/CapturePopoverView.swift
+++ b/Sources/BlinkApp/CapturePopoverView.swift
@@ -22,7 +22,17 @@ struct CapturePopoverView: View {
     @State private var canvasExpanded = false
     @FocusState private var fieldFocused: Bool
 
-    private let amber = Color(red: 0.96, green: 0.58, blue: 0.08)
+    // Design tokens from "Capture Window.dc.html" (Talkie capture refinement).
+    // Sharp, thin-monospace terminal look; accent is Talkie's #ff5822.
+    private let amber = Color(red: 1.0, green: 0.345, blue: 0.133)        // #ff5822
+    private let amberBright = Color(red: 1.0, green: 0.478, blue: 0.302)  // #ff7a4d
+    private let live = Color(red: 0.353, green: 0.820, blue: 0.608)       // #5ad19b
+
+    /// The design is set in IBM Plex Mono weight 200. SF Mono at a light weight
+    /// is the closest native match (bundling IBM Plex Mono would be exact).
+    private func mono(_ size: CGFloat, _ weight: Font.Weight = .light) -> Font {
+        .system(size: size, weight: weight, design: .monospaced)
+    }
 
     private var trimmedQuery: String {
         query.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -54,7 +64,7 @@ struct CapturePopoverView: View {
             HStack(spacing: 0) {
                 if !canvasExpanded {
                     recentSidebar
-                        .frame(width: 390)
+                        .frame(width: 262)
                     verticalHairline
                 }
                 canvasPane
@@ -64,6 +74,7 @@ struct CapturePopoverView: View {
         }
         .frame(width: Self.contentSize.width, height: Self.contentSize.height)
         .background(popoverBackground)
+        .overlay(PopoutCorners())
         .preferredColorScheme(.dark)
         .background(
             Button("") { createFromQuery() }
@@ -81,54 +92,88 @@ struct CapturePopoverView: View {
 
     private var popoverBackground: some View {
         ZStack {
-            Color(red: 0.055, green: 0.065, blue: 0.082)
-            LinearGradient(
+            Color(red: 0.039, green: 0.043, blue: 0.047)  // #0a0b0c panel base
+            RadialGradient(
                 colors: [
-                    Color(red: 0.16, green: 0.19, blue: 0.24).opacity(0.62),
-                    Color(red: 0.07, green: 0.08, blue: 0.105).opacity(0.82),
+                    Color(red: 0.090, green: 0.098, blue: 0.110),  // #17191c
+                    Color(red: 0.047, green: 0.055, blue: 0.063),  // #0c0e10
+                    Color(red: 0.020, green: 0.024, blue: 0.027),  // #050607
                 ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
+                center: UnitPoint(x: 0.78, y: 0.0),
+                startRadius: 0,
+                endRadius: 820
             )
+            TerminalGrid(step: 40, opacity: 0.02)
         }
     }
 
     private var searchHeader: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: 13) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 18, weight: .medium))
-                .foregroundStyle(.white.opacity(0.46))
+                .font(.system(size: 15, weight: .light))
+                .foregroundStyle(Color(red: 0.42, green: 0.44, blue: 0.45))  // #6b7072
 
             TextField("Search or capture…", text: $query)
                 .textFieldStyle(.plain)
-                .font(.system(size: 19, weight: .regular))
-                .foregroundStyle(.white.opacity(0.88))
+                .font(mono(15, .light))
+                .foregroundStyle(Color(red: 0.902, green: 0.91, blue: 0.902))  // #e6e8e6
                 .tint(amber)
                 .focused($fieldFocused)
                 .onSubmit { openFirstOrCreate() }
 
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(live)
+                    .frame(width: 6, height: 6)
+                    .shadow(color: live.opacity(0.8), radius: 4)
+                Text("LIVE")
+                    .font(mono(10.5))
+                    .tracking(1.6)
+                    .foregroundStyle(live)
+            }
+            .padding(.trailing, 4)
+
+            KeyBadge(text: "⌘K")
+
             Button(action: startSystemDictation) {
-                Image(systemName: "mic")
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.42))
+                Image(systemName: "mic.fill")
+                    .font(.system(size: 14, weight: .light))
+                    .foregroundStyle(amberBright)
                     .frame(width: 30, height: 30)
+                    .background(amber.opacity(0.18))
+                    .overlay(Rectangle().stroke(amber.opacity(0.65), lineWidth: 1))
             }
             .buttonStyle(.plain)
             .help("Dictate into capture")
         }
-        .padding(.horizontal, 28)
-        .frame(height: 74)
+        .padding(.horizontal, 18)
+        .frame(height: 56)
+    }
+
+    private var numberedNotes: [(index: Int, note: Note)] {
+        filtered.enumerated().map { (index: $0.offset + 1, note: $0.element) }
+    }
+    private var todayItems: [(index: Int, note: Note)] {
+        numberedNotes.filter { Calendar.current.isDateInToday($0.note.updatedAt) }
+    }
+    private var earlierItems: [(index: Int, note: Note)] {
+        numberedNotes.filter { !Calendar.current.isDateInToday($0.note.updatedAt) }
     }
 
     private var recentSidebar: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(trimmedQuery.isEmpty ? "RECENT" : "MATCHES")
-                .font(.system(size: 10, weight: .bold, design: .monospaced))
-                .tracking(4)
-                .foregroundStyle(.white.opacity(0.34))
-                .padding(.horizontal, 28)
-                .padding(.top, 23)
-                .padding(.bottom, 14)
+            HStack {
+                Text(trimmedQuery.isEmpty ? "LOG" : "MATCHES")
+                    .font(mono(10)).tracking(1.8).textCase(.uppercase)
+                    .foregroundStyle(Color(red: 0.42, green: 0.44, blue: 0.45))
+                Spacer()
+                Text("\(filtered.count) REC")
+                    .font(mono(10)).tracking(1)
+                    .foregroundStyle(Color(red: 0.263, green: 0.282, blue: 0.294))
+            }
+            .padding(.horizontal, 18)
+            .padding(.top, 15)
+            .padding(.bottom, 10)
 
             if model.notes.isEmpty {
                 emptyState("No notes yet — create your first thought.")
@@ -136,63 +181,88 @@ struct CapturePopoverView: View {
                 emptyState("No matches — Return creates “\(trimmedQuery)”.")
             } else {
                 ScrollView(.vertical) {
-                    LazyVStack(spacing: 2) {
-                        ForEach(filtered, id: \.id) { note in
-                            RecentNoteRow(
-                                note: note,
-                                accent: noteAccent(note),
-                                selected: note.id == selectedNote?.id,
-                                onSelect: { selectedNoteID = note.id },
-                                onOpen: { open(note) },
-                                onCopyMarkdown: { copyToPasteboard(note.content) },
-                                onCopyPath: {
-                                    copyToPasteboard(
-                                        AppDelegate.notesDirectory()
-                                            .appendingPathComponent("\(note.id).md").path
-                                    )
-                                },
-                                onDelete: { delete(note) }
-                            )
+                    LazyVStack(alignment: .leading, spacing: 1) {
+                        if !todayItems.isEmpty {
+                            sidebarSection("Today")
+                            ForEach(todayItems, id: \.note.id) { sidebarRow($0, earlier: false) }
+                        }
+                        if !earlierItems.isEmpty {
+                            sidebarSection("Earlier")
+                            ForEach(earlierItems, id: \.note.id) { sidebarRow($0, earlier: true) }
                         }
                     }
-                    .padding(.horizontal, 12)
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 12)
                 }
                 .background(SubtleScroller())
             }
         }
     }
 
+    private func sidebarSection(_ title: String) -> some View {
+        Text(title)
+            .font(mono(9)).tracking(2).textCase(.uppercase)
+            .foregroundStyle(Color(red: 0.239, green: 0.255, blue: 0.263))
+            .padding(.horizontal, 8)
+            .padding(.top, 12)
+            .padding(.bottom, 6)
+    }
+
+    @ViewBuilder
+    private func sidebarRow(_ item: (index: Int, note: Note), earlier: Bool) -> some View {
+        RecentNoteRow(
+            index: item.index,
+            note: item.note,
+            amber: amber,
+            selected: item.note.id == selectedNote?.id,
+            earlier: earlier,
+            onSelect: { selectedNoteID = item.note.id },
+            onOpen: { open(item.note) },
+            onCopyMarkdown: { copyToPasteboard(item.note.content) },
+            onCopyPath: {
+                copyToPasteboard(
+                    AppDelegate.notesDirectory()
+                        .appendingPathComponent("\(item.note.id).md").path
+                )
+            },
+            onDelete: { delete(item.note) }
+        )
+    }
+
     private var canvasPane: some View {
         VStack(spacing: 0) {
             HStack {
-                Text("CANVAS  \(filtered.count) \(filtered.count == 1 ? "NOTE" : "NOTES")")
-                    .font(.system(size: 10, weight: .bold, design: .monospaced))
-                    .tracking(4)
-                    .foregroundStyle(.white.opacity(0.32))
+                (
+                    Text("CANVAS ")
+                        .foregroundColor(Color(red: 0.498, green: 0.522, blue: 0.529))  // #7f8587
+                    + Text("/ ")
+                        .foregroundColor(Color(red: 0.239, green: 0.255, blue: 0.263))  // #3d4143
+                    + Text("\(String(format: "%02d", filtered.count)) NODES")
+                        .foregroundColor(amberBright)
+                )
+                .font(mono(10)).tracking(1.6)
 
                 Spacer()
 
                 CanvasModePicker(selection: $canvasMode, amber: amber)
 
+                Rectangle().fill(.white.opacity(0.1)).frame(width: 1, height: 14).padding(.horizontal, 4)
+
                 Button {
                     withAnimation(.easeInOut(duration: 0.18)) { canvasExpanded.toggle() }
                 } label: {
                     Image(systemName: canvasExpanded ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(.white.opacity(0.48))
-                        .frame(width: 38, height: 38)
-                        .background(.white.opacity(0.045), in: RoundedRectangle(cornerRadius: 11))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 11)
-                                .stroke(.white.opacity(0.08), lineWidth: 1)
-                        )
+                        .font(.system(size: 13, weight: .light))
+                        .foregroundStyle(Color(red: 0.769, green: 0.784, blue: 0.776))  // #c4c8c6
+                        .frame(width: 26, height: 26)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .help(canvasExpanded ? "Show recents" : "Expand canvas")
                 .accessibilityLabel(canvasExpanded ? "Show recents" : "Expand canvas")
             }
-            .padding(.horizontal, 24)
-            .frame(height: 78)
+            .padding(.horizontal, 20)
+            .frame(height: 42)
 
             Group {
                 if filtered.isEmpty {
@@ -211,7 +281,7 @@ struct CapturePopoverView: View {
                         NoteConstellation(
                             notes: filtered,
                             selectedNoteID: selectedNote?.id,
-                            accent: noteAccent,
+                            amber: amber,
                             onSelect: { selectedNoteID = $0.id },
                             onOpen: open
                         )
@@ -245,14 +315,14 @@ struct CapturePopoverView: View {
     }
 
     private var footer: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 7) {
             Button { createFromQuery() } label: {
-                HStack(spacing: 10) {
+                HStack(spacing: 7) {
                     KeyCap(symbol: "⌘")
-                    KeyCap(symbol: "↵")
-                    Text("new note")
-                        .font(.system(size: 11, weight: .medium, design: .monospaced))
-                        .foregroundStyle(.white.opacity(0.64))
+                    KeyCap(symbol: "↩")
+                    Text("New node")
+                        .font(mono(10.5)).tracking(1).textCase(.uppercase)
+                        .foregroundStyle(Color(red: 0.42, green: 0.44, blue: 0.45))
                 }
             }
             .buttonStyle(.plain)
@@ -260,26 +330,26 @@ struct CapturePopoverView: View {
 
             Spacer()
 
-            FooterAction(systemName: "house", label: "⌘H", help: "Settings", action: openSettings)
-            footerDivider
-            FooterAction(systemName: "eye", label: "⌥Space", help: "Blink notes", action: toggleBlink)
-            footerDivider
-            FooterAction(
-                systemName: "point.3.connected.trianglepath.dotted",
-                label: nil,
-                help: "Show spatial grid",
-                action: showGrid
-            )
-        }
-        .padding(.horizontal, 22)
-        .frame(height: 58)
-    }
+            Text("STATUS · READY")
+                .font(mono(10.5)).tracking(1)
+                .foregroundStyle(Color(red: 0.329, green: 0.349, blue: 0.357))
 
-    private var footerDivider: some View {
-        Rectangle()
-            .fill(.white.opacity(0.10))
-            .frame(width: 1, height: 26)
-            .padding(.horizontal, 4)
+            Button(action: toggleBlink) {
+                HStack(spacing: 6) {
+                    Image(systemName: "eye")
+                        .font(.system(size: 12, weight: .light))
+                    Text("⌥Space")
+                        .font(mono(10))
+                        .padding(.horizontal, 5).padding(.vertical, 1)
+                        .overlay(Rectangle().stroke(.white.opacity(0.1), lineWidth: 1))
+                }
+                .foregroundStyle(Color(red: 0.651, green: 0.675, blue: 0.682))  // #a6acae
+            }
+            .buttonStyle(.plain)
+            .help("Blink notes (⌥Space)")
+        }
+        .padding(.horizontal, 18)
+        .frame(height: 38)
     }
 
     private var hairline: some View {
@@ -374,39 +444,39 @@ private struct CanvasModePicker: View {
     let amber: Color
 
     var body: some View {
-        HStack(spacing: 2) {
+        HStack(spacing: 5) {
             ForEach(CanvasMode.allCases) { mode in
                 Button { selection = mode } label: {
                     Image(systemName: mode.icon)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(selection == mode ? amber : .white.opacity(0.42))
-                        .frame(width: 40, height: 34)
-                        .background(
-                            selection == mode ? amber.opacity(0.12) : Color.clear,
-                            in: RoundedRectangle(cornerRadius: 9)
+                        .font(.system(size: 13, weight: .light))
+                        .foregroundStyle(
+                            selection == mode
+                                ? Color(red: 1.0, green: 0.478, blue: 0.302)         // #ff7a4d
+                                : Color(red: 0.769, green: 0.784, blue: 0.776)        // #c4c8c6
                         )
+                        .frame(width: 24, height: 24)
+                        .background(selection == mode ? amber.opacity(0.1) : .clear)  // sharp
                         .overlay {
                             if selection == mode {
-                                RoundedRectangle(cornerRadius: 9)
-                                    .stroke(amber.opacity(0.55), lineWidth: 1)
+                                Rectangle().stroke(amber.opacity(0.3), lineWidth: 1)
                             }
                         }
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .help(mode.rawValue.capitalized)
                 .accessibilityLabel("\(mode.rawValue.capitalized) view")
             }
         }
-        .padding(3)
-        .background(.white.opacity(0.055), in: RoundedRectangle(cornerRadius: 12))
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(.white.opacity(0.08), lineWidth: 1))
     }
 }
 
 private struct RecentNoteRow: View {
+    let index: Int
     let note: Note
-    let accent: Color
+    let amber: Color
     let selected: Bool
+    let earlier: Bool
     var onSelect: () -> Void
     var onOpen: () -> Void
     var onCopyMarkdown: () -> Void
@@ -415,38 +485,51 @@ private struct RecentNoteRow: View {
 
     @State private var hovered = false
 
+    // Tiered ink: the active row is warm, today rows read clear, earlier ones recede.
+    private var numberColor: Color {
+        if selected { return Color(red: 1.0, green: 0.478, blue: 0.302) }   // #ff7a4d
+        return earlier ? Color(red: 0.239, green: 0.255, blue: 0.263)       // #3d4143
+                       : Color(red: 0.329, green: 0.349, blue: 0.357)       // #54595b
+    }
+    private var titleColor: Color {
+        if selected { return Color(red: 0.984, green: 0.933, blue: 0.910) } // #fbeee8
+        return earlier ? Color(red: 0.498, green: 0.522, blue: 0.529)       // #7f8587
+                       : Color(red: 0.824, green: 0.835, blue: 0.827)       // #d2d5d3
+    }
+    private var timeColor: Color {
+        if selected { return Color(red: 0.784, green: 0.576, blue: 0.373) } // #c8935f
+        return earlier ? Color(red: 0.329, green: 0.349, blue: 0.357)       // #54595b
+                       : Color(red: 0.42, green: 0.44, blue: 0.45)          // #6b7072
+    }
+
     var body: some View {
         Button(action: onSelect) {
-            HStack(spacing: 13) {
-                Circle()
-                    .fill(accent)
-                    .frame(width: 10, height: 10)
-                    .shadow(color: accent.opacity(selected ? 0.75 : 0), radius: 7)
+            HStack(spacing: 10) {
+                Text(String(format: "%02d", index))
+                    .font(.system(size: 10.5, weight: .light, design: .monospaced))
+                    .foregroundStyle(numberColor)
 
                 Text(note.title)
-                    .font(.system(size: 14, weight: selected ? .semibold : .regular))
-                    .foregroundStyle(.white.opacity(selected ? 0.94 : 0.72))
+                    .font(.system(size: 12, weight: .light, design: .monospaced))
+                    .foregroundStyle(titleColor)
                     .lineLimit(1)
+                    .truncationMode(.tail)
 
-                Spacer(minLength: 10)
+                Spacer(minLength: 8)
 
                 Text(note.updatedAt.blinkCompactRelative)
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(.white.opacity(0.30))
+                    .font(.system(size: 10.5, weight: .light, design: .monospaced))
+                    .foregroundStyle(timeColor)
                     .lineLimit(1)
             }
-            .padding(.horizontal, 16)
-            .frame(height: 44)
+            .padding(.horizontal, 10)
+            .frame(height: 32)
             .background(
-                selected ? accent.opacity(0.15) : (hovered ? .white.opacity(0.05) : .clear),
-                in: RoundedRectangle(cornerRadius: 11)
+                selected ? amber.opacity(0.08) : (hovered ? .white.opacity(0.04) : .clear)
             )
             .overlay(alignment: .leading) {
                 if selected {
-                    RoundedRectangle(cornerRadius: 1.5)
-                        .fill(accent)
-                        .frame(width: 3, height: 32)
-                        .offset(x: -1)
+                    Rectangle().fill(amber).frame(width: 2)  // inset left bar
                 }
             }
             .contentShape(Rectangle())
@@ -468,7 +551,7 @@ private struct RecentNoteRow: View {
 private struct NoteConstellation: View {
     let notes: [Note]
     let selectedNoteID: String?
-    let accent: (Note) -> Color
+    let amber: Color
     let onSelect: (Note) -> Void
     let onOpen: (Note) -> Void
 
@@ -486,18 +569,19 @@ private struct NoteConstellation: View {
                         path.addLine(to: end)
                         context.stroke(
                             path,
-                            with: .color(.white.opacity(0.105)),
+                            with: .color(.white.opacity(0.08)),
                             style: StrokeStyle(lineWidth: 1, dash: [5, 7])
                         )
                     }
                 }
                 .allowsHitTesting(false)
 
-                ForEach(notes, id: \.id) { note in
+                ForEach(Array(notes.enumerated()), id: \.element.id) { offset, note in
                     if let point = points[note.id] {
                         ConstellationNode(
+                            index: offset + 1,
                             note: note,
-                            accent: accent(note),
+                            amber: amber,
                             selected: note.id == selectedNoteID,
                             onSelect: { onSelect(note) },
                             onOpen: { onOpen(note) }
@@ -505,59 +589,113 @@ private struct NoteConstellation: View {
                         .position(point)
                     }
                 }
-
-                if let note = notes.first(where: { $0.id == selectedNoteID }),
-                   let point = points[note.id] {
-                    NotePreviewCard(
-                        note: note,
-                        accent: accent(note),
-                        coordinate: ConstellationLayout.label(for: point, in: geometry.size),
-                        onOpen: { onOpen(note) }
-                    )
-                    .frame(width: min(330, geometry.size.width * 0.54))
-                    .padding(16)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-                }
             }
-            .clipShape(RoundedRectangle(cornerRadius: 15))
+            .clipShape(Rectangle())
         }
     }
 }
 
 private struct ConstellationNode: View {
+    let index: Int
     let note: Note
-    let accent: Color
+    let amber: Color
     let selected: Bool
     let onSelect: () -> Void
     let onOpen: () -> Void
 
     @State private var hovered = false
 
+    // Recency tier drives prominence: A (freshest) → B → C recede into the board.
+    private var tier: Int { index <= 3 ? 0 : (index <= 6 ? 1 : 2) }
+
+    private var bgColor: Color {
+        if selected { return Color(red: 0.071, green: 0.063, blue: 0.067) }  // #121011
+        switch tier {
+        case 0: return Color(red: 0.055, green: 0.059, blue: 0.067)          // #0e0f11
+        case 1: return Color(red: 0.039, green: 0.043, blue: 0.047)          // #0a0b0c
+        default: return Color(red: 0.031, green: 0.035, blue: 0.039)         // #08090a
+        }
+    }
+    private var borderColor: Color {
+        if selected { return amber.opacity(0.55) }
+        switch tier {
+        case 0: return .white.opacity(hovered ? 0.25 : 0.11)
+        case 1: return .white.opacity(hovered ? 0.18 : 0.08)
+        default: return .white.opacity(hovered ? 0.12 : 0.05)
+        }
+    }
+    private var titleColor: Color {
+        if selected { return .white }
+        switch tier {
+        case 0: return Color(red: 0.902, green: 0.91, blue: 0.902)           // #e6e8e6
+        case 1: return Color(red: 0.514, green: 0.537, blue: 0.545)          // #83898b
+        default: return Color(red: 0.329, green: 0.349, blue: 0.357)         // #54595b
+        }
+    }
+    private var numberColor: Color {
+        if selected { return Color(red: 1.0, green: 0.478, blue: 0.302) }    // #ff7a4d
+        switch tier {
+        case 0: return Color(red: 0.329, green: 0.349, blue: 0.357)          // #54595b
+        case 1: return Color(red: 0.263, green: 0.282, blue: 0.294)          // #43484b
+        default: return Color(red: 0.2, green: 0.22, blue: 0.227)            // #33383a
+        }
+    }
+
     var body: some View {
         Button(action: onSelect) {
             HStack(spacing: 8) {
-                Circle().fill(accent).frame(width: 9, height: 9)
+                Text(String(format: "%02d", index))
+                    .font(.system(size: selected ? 10.5 : (tier == 0 ? 10 : 9.5), weight: .light, design: .monospaced))
+                    .foregroundStyle(numberColor)
                 Text(note.title)
-                    .font(.system(size: 13, weight: selected ? .semibold : .medium))
-                    .foregroundStyle(.white.opacity(selected ? 0.94 : 0.73))
+                    .font(.system(size: selected ? 12 : (tier == 0 ? 11.5 : 11), weight: .light, design: .monospaced))
+                    .foregroundStyle(titleColor)
                     .lineLimit(1)
+                if selected {
+                    Text(note.updatedAt.blinkCompactRelative)
+                        .font(.system(size: 10, weight: .light, design: .monospaced))
+                        .foregroundStyle(Color(red: 0.42, green: 0.44, blue: 0.45))
+                }
             }
-            .padding(.horizontal, 13)
-            .frame(height: 33)
-            .background(
-                selected ? accent.opacity(0.16) : Color(red: 0.11, green: 0.12, blue: 0.15).opacity(0.92),
-                in: RoundedRectangle(cornerRadius: 11)
+            .padding(.horizontal, selected ? 13 : (tier == 0 ? 12 : 11))
+            .padding(.vertical, selected ? 8 : (tier == 0 ? 7 : 6))
+            .background(bgColor)                                 // sharp corners
+            .overlay(Rectangle().stroke(borderColor, lineWidth: 1))
+            .overlay { if selected { CornerTicks(color: amber) } }
+            .shadow(
+                color: selected ? amber.opacity(0.35) : .black.opacity(0.2),
+                radius: selected ? 14 : 4, x: 0, y: selected ? 6 : 2
             )
-            .overlay(
-                RoundedRectangle(cornerRadius: 11)
-                    .stroke(selected ? accent.opacity(0.82) : .white.opacity(hovered ? 0.18 : 0.10), lineWidth: selected ? 1.5 : 1)
-            )
-            .shadow(color: selected ? accent.opacity(0.30) : .black.opacity(0.18), radius: selected ? 18 : 5)
+            .offset(y: hovered && !selected ? -2 : 0)
+            .animation(.easeOut(duration: 0.12), value: hovered)
         }
         .buttonStyle(.plain)
         .onHover { hovered = $0 }
         .simultaneousGesture(TapGesture(count: 2).onEnded(onOpen))
         .help("Double-click to open \(note.title)")
+    }
+}
+
+/// Amber L-brackets just outside a node's four corners — the "locked/active"
+/// framing from the design.
+private struct CornerTicks: View {
+    let color: Color
+    var len: CGFloat = 7
+    var lineWidth: CGFloat = 1.5
+    var out: CGFloat = 3
+
+    var body: some View {
+        GeometryReader { g in
+            let w = g.size.width, h = g.size.height
+            Path { p in
+                p.move(to: CGPoint(x: -out, y: -out + len)); p.addLine(to: CGPoint(x: -out, y: -out)); p.addLine(to: CGPoint(x: -out + len, y: -out))
+                p.move(to: CGPoint(x: w + out - len, y: -out)); p.addLine(to: CGPoint(x: w + out, y: -out)); p.addLine(to: CGPoint(x: w + out, y: -out + len))
+                p.move(to: CGPoint(x: -out, y: h + out - len)); p.addLine(to: CGPoint(x: -out, y: h + out)); p.addLine(to: CGPoint(x: -out + len, y: h + out))
+                p.move(to: CGPoint(x: w + out - len, y: h + out)); p.addLine(to: CGPoint(x: w + out, y: h + out)); p.addLine(to: CGPoint(x: w + out, y: h + out - len))
+            }
+            .stroke(color, lineWidth: lineWidth)
+        }
+        .allowsHitTesting(false)
     }
 }
 
@@ -779,6 +917,48 @@ private struct DotGrid: View {
     }
 }
 
+/// The faint 1px line grid that underlays the whole popout.
+private struct TerminalGrid: View {
+    var step: CGFloat = 40
+    var opacity: Double = 0.02
+
+    var body: some View {
+        Canvas { context, size in
+            let color = Color.white.opacity(opacity)
+            var x: CGFloat = 0
+            while x < size.width {
+                context.stroke(Path { $0.move(to: CGPoint(x: x, y: 0)); $0.addLine(to: CGPoint(x: x, y: size.height)) }, with: .color(color), lineWidth: 1)
+                x += step
+            }
+            var y: CGFloat = 0
+            while y < size.height {
+                context.stroke(Path { $0.move(to: CGPoint(x: 0, y: y)); $0.addLine(to: CGPoint(x: size.width, y: y)) }, with: .color(color), lineWidth: 1)
+                y += step
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+/// The four L-brackets framing the popout, per the design's terminal chrome.
+private struct PopoutCorners: View {
+    var len: CGFloat = 13
+    var body: some View {
+        let color = Color(red: 0.353, green: 0.376, blue: 0.388)  // #5a6063
+        GeometryReader { g in
+            let w = g.size.width, h = g.size.height
+            Path { p in
+                p.move(to: CGPoint(x: 0, y: len)); p.addLine(to: CGPoint(x: 0, y: 0)); p.addLine(to: CGPoint(x: len, y: 0))
+                p.move(to: CGPoint(x: w - len, y: 0)); p.addLine(to: CGPoint(x: w, y: 0)); p.addLine(to: CGPoint(x: w, y: len))
+                p.move(to: CGPoint(x: 0, y: h - len)); p.addLine(to: CGPoint(x: 0, y: h)); p.addLine(to: CGPoint(x: len, y: h))
+                p.move(to: CGPoint(x: w - len, y: h)); p.addLine(to: CGPoint(x: w, y: h)); p.addLine(to: CGPoint(x: w, y: h - len))
+            }
+            .stroke(color, lineWidth: 1)
+        }
+        .allowsHitTesting(false)
+    }
+}
+
 private struct FooterAction: View {
     let systemName: String
     let label: String?
@@ -811,11 +991,24 @@ private struct KeyCap: View {
 
     var body: some View {
         Text(symbol)
-            .font(.system(size: 11, weight: .semibold, design: .monospaced))
-            .foregroundStyle(.white.opacity(0.62))
-            .frame(minWidth: 23, minHeight: 23)
-            .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 6))
-            .overlay(RoundedRectangle(cornerRadius: 6).stroke(.white.opacity(0.09), lineWidth: 1))
+            .font(.system(size: 11, weight: .light, design: .monospaced))
+            .foregroundStyle(Color(red: 0.824, green: 0.835, blue: 0.827))  // #d2d5d3
+            .frame(minWidth: 20, minHeight: 20)
+            .overlay(Rectangle().stroke(.white.opacity(0.1), lineWidth: 1))   // sharp
+    }
+}
+
+/// A bordered inline key hint (e.g. ⌘K) — sharp, thin, per the design.
+private struct KeyBadge: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 10.5, weight: .light, design: .monospaced))
+            .foregroundStyle(Color(red: 0.42, green: 0.44, blue: 0.45))  // #6b7072
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .overlay(Rectangle().stroke(.white.opacity(0.1), lineWidth: 1))
     }
 }
 

--- a/Sources/BlinkApp/CapturePopoverView.swift
+++ b/Sources/BlinkApp/CapturePopoverView.swift
@@ -16,17 +16,21 @@ struct CapturePopoverView: View {
     var showGrid: () -> Void
     var beginDictation: () -> Void
 
+    @ObservedObject private var appearance = AppearanceManager.shared
+
     @State private var query = ""
     @State private var selectedNoteID: String?
     @State private var canvasMode: CanvasMode = .constellation
     @State private var canvasExpanded = false
     @FocusState private var fieldFocused: Bool
 
-    // Design tokens from "Capture Window.dc.html" (Talkie capture refinement).
-    // Sharp, thin-monospace terminal look; accent is Talkie's #ff5822.
-    private let amber = Color(red: 1.0, green: 0.345, blue: 0.133)        // #ff5822
-    private let amberBright = Color(red: 1.0, green: 0.478, blue: 0.302)  // #ff7a4d
-    private let live = Color(red: 0.353, green: 0.820, blue: 0.608)       // #5ad19b
+    /// The resolved palette for the current app scheme (from "Capture
+    /// Window.dc.html"; accent is Talkie's #ff5822). Follows a light/dark flip
+    /// live because `appearance` is observed.
+    private var pal: PopoverPalette { .forScheme(appearance.scheme) }
+    private var amber: Color { pal.accent }
+    private var amberBright: Color { pal.accentBright }
+    private var live: Color { pal.live }
 
     /// The design is set in IBM Plex Mono weight 200. SF Mono at a light weight
     /// is the closest native match (bundling IBM Plex Mono would be exact).
@@ -75,7 +79,8 @@ struct CapturePopoverView: View {
         .frame(width: Self.contentSize.width, height: Self.contentSize.height)
         .background(popoverBackground)
         .overlay(PopoutCorners())
-        .preferredColorScheme(.dark)
+        .environment(\.popoverPalette, pal)
+        .preferredColorScheme(appearance.scheme == .dark ? .dark : .light)
         .background(
             Button("") { createFromQuery() }
                 .keyboardShortcut(.return, modifiers: .command)
@@ -92,12 +97,12 @@ struct CapturePopoverView: View {
 
     private var popoverBackground: some View {
         ZStack {
-            Color(red: 0.039, green: 0.043, blue: 0.047)  // #0a0b0c panel base
+            pal.bgBase
             RadialGradient(
                 colors: [
-                    Color(red: 0.090, green: 0.098, blue: 0.110),  // #17191c
-                    Color(red: 0.047, green: 0.055, blue: 0.063),  // #0c0e10
-                    Color(red: 0.020, green: 0.024, blue: 0.027),  // #050607
+                    pal.bgGrad1,  // #17191c
+                    pal.bgGrad2,  // #0c0e10
+                    pal.bgGrad3,  // #050607
                 ],
                 center: UnitPoint(x: 0.78, y: 0.0),
                 startRadius: 0,
@@ -111,12 +116,12 @@ struct CapturePopoverView: View {
         HStack(spacing: 13) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 15, weight: .light))
-                .foregroundStyle(Color(red: 0.42, green: 0.44, blue: 0.45))  // #6b7072
+                .foregroundStyle(pal.inkMuted)  // #6b7072
 
             TextField("Search or capture…", text: $query)
                 .textFieldStyle(.plain)
                 .font(mono(15, .light))
-                .foregroundStyle(Color(red: 0.902, green: 0.91, blue: 0.902))  // #e6e8e6
+                .foregroundStyle(pal.inkBright)  // #e6e8e6
                 .tint(amber)
                 .focused($fieldFocused)
                 .onSubmit { openFirstOrCreate() }
@@ -165,11 +170,11 @@ struct CapturePopoverView: View {
             HStack {
                 Text(trimmedQuery.isEmpty ? "LOG" : "MATCHES")
                     .font(mono(10)).tracking(1.8).textCase(.uppercase)
-                    .foregroundStyle(Color(red: 0.42, green: 0.44, blue: 0.45))
+                    .foregroundStyle(pal.inkMuted)
                 Spacer()
                 Text("\(filtered.count) REC")
                     .font(mono(10)).tracking(1)
-                    .foregroundStyle(Color(red: 0.263, green: 0.282, blue: 0.294))
+                    .foregroundStyle(pal.inkGhost)
             }
             .padding(.horizontal, 18)
             .padding(.top, 15)
@@ -202,7 +207,7 @@ struct CapturePopoverView: View {
     private func sidebarSection(_ title: String) -> some View {
         Text(title)
             .font(mono(9)).tracking(2).textCase(.uppercase)
-            .foregroundStyle(Color(red: 0.239, green: 0.255, blue: 0.263))
+            .foregroundStyle(pal.inkGhost)
             .padding(.horizontal, 8)
             .padding(.top, 12)
             .padding(.bottom, 6)
@@ -234,9 +239,9 @@ struct CapturePopoverView: View {
             HStack {
                 (
                     Text("CANVAS ")
-                        .foregroundColor(Color(red: 0.498, green: 0.522, blue: 0.529))  // #7f8587
+                        .foregroundColor(pal.inkMid)  // #7f8587
                     + Text("/ ")
-                        .foregroundColor(Color(red: 0.239, green: 0.255, blue: 0.263))  // #3d4143
+                        .foregroundColor(pal.inkGhost)  // #3d4143
                     + Text("\(String(format: "%02d", filtered.count)) NODES")
                         .foregroundColor(amberBright)
                 )
@@ -246,14 +251,14 @@ struct CapturePopoverView: View {
 
                 CanvasModePicker(selection: $canvasMode, amber: amber)
 
-                Rectangle().fill(.white.opacity(0.1)).frame(width: 1, height: 14).padding(.horizontal, 4)
+                Rectangle().fill(pal.strokeBase.opacity(0.1)).frame(width: 1, height: 14).padding(.horizontal, 4)
 
                 Button {
                     withAnimation(.easeInOut(duration: 0.18)) { canvasExpanded.toggle() }
                 } label: {
                     Image(systemName: canvasExpanded ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
                         .font(.system(size: 13, weight: .light))
-                        .foregroundStyle(Color(red: 0.769, green: 0.784, blue: 0.776))  // #c4c8c6
+                        .foregroundStyle(pal.ink)  // #c4c8c6
                         .frame(width: 26, height: 26)
                         .contentShape(Rectangle())
                 }
@@ -305,10 +310,10 @@ struct CapturePopoverView: View {
         VStack(spacing: 10) {
             Image(systemName: "point.3.connected.trianglepath.dotted")
                 .font(.system(size: 30, weight: .light))
-                .foregroundStyle(.white.opacity(0.18))
+                .foregroundStyle(pal.strokeBase.opacity(0.18))
             Text(trimmedQuery.isEmpty ? "Your notes will gather here" : "No notes on this canvas")
                 .font(.system(size: 12))
-                .foregroundStyle(.white.opacity(0.36))
+                .foregroundStyle(pal.strokeBase.opacity(0.36))
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(CanvasSurface())
@@ -322,7 +327,7 @@ struct CapturePopoverView: View {
                     KeyCap(symbol: "↩")
                     Text("New node")
                         .font(mono(10.5)).tracking(1).textCase(.uppercase)
-                        .foregroundStyle(Color(red: 0.42, green: 0.44, blue: 0.45))
+                        .foregroundStyle(pal.inkMuted)
                 }
             }
             .buttonStyle(.plain)
@@ -332,7 +337,7 @@ struct CapturePopoverView: View {
 
             Text("STATUS · READY")
                 .font(mono(10.5)).tracking(1)
-                .foregroundStyle(Color(red: 0.329, green: 0.349, blue: 0.357))
+                .foregroundStyle(pal.inkFaint)
 
             Button(action: toggleBlink) {
                 HStack(spacing: 6) {
@@ -341,9 +346,9 @@ struct CapturePopoverView: View {
                     Text("⌥Space")
                         .font(mono(10))
                         .padding(.horizontal, 5).padding(.vertical, 1)
-                        .overlay(Rectangle().stroke(.white.opacity(0.1), lineWidth: 1))
+                        .overlay(Rectangle().stroke(pal.strokeBase.opacity(0.1), lineWidth: 1))
                 }
-                .foregroundStyle(Color(red: 0.651, green: 0.675, blue: 0.682))  // #a6acae
+                .foregroundStyle(pal.inkMid)  // #a6acae
             }
             .buttonStyle(.plain)
             .help("Blink notes (⌥Space)")
@@ -353,17 +358,17 @@ struct CapturePopoverView: View {
     }
 
     private var hairline: some View {
-        Rectangle().fill(.white.opacity(0.09)).frame(height: 1)
+        Rectangle().fill(pal.strokeBase.opacity(0.09)).frame(height: 1)
     }
 
     private var verticalHairline: some View {
-        Rectangle().fill(.white.opacity(0.09)).frame(width: 1)
+        Rectangle().fill(pal.strokeBase.opacity(0.09)).frame(width: 1)
     }
 
     private func emptyState(_ message: String) -> some View {
         Text(message)
             .font(.system(size: 11))
-            .foregroundStyle(.white.opacity(0.38))
+            .foregroundStyle(pal.strokeBase.opacity(0.38))
             .padding(.horizontal, 28)
             .padding(.vertical, 24)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -440,6 +445,7 @@ private enum CanvasMode: String, CaseIterable, Identifiable {
 }
 
 private struct CanvasModePicker: View {
+    @Environment(\.popoverPalette) private var pal
     @Binding var selection: CanvasMode
     let amber: Color
 
@@ -451,8 +457,8 @@ private struct CanvasModePicker: View {
                         .font(.system(size: 13, weight: .light))
                         .foregroundStyle(
                             selection == mode
-                                ? Color(red: 1.0, green: 0.478, blue: 0.302)         // #ff7a4d
-                                : Color(red: 0.769, green: 0.784, blue: 0.776)        // #c4c8c6
+                                ? pal.accentBright         // #ff7a4d
+                                : pal.ink        // #c4c8c6
                         )
                         .frame(width: 24, height: 24)
                         .background(selection == mode ? amber.opacity(0.1) : .clear)  // sharp
@@ -472,6 +478,7 @@ private struct CanvasModePicker: View {
 }
 
 private struct RecentNoteRow: View {
+    @Environment(\.popoverPalette) private var pal
     let index: Int
     let note: Note
     let amber: Color
@@ -487,19 +494,19 @@ private struct RecentNoteRow: View {
 
     // Tiered ink: the active row is warm, today rows read clear, earlier ones recede.
     private var numberColor: Color {
-        if selected { return Color(red: 1.0, green: 0.478, blue: 0.302) }   // #ff7a4d
-        return earlier ? Color(red: 0.239, green: 0.255, blue: 0.263)       // #3d4143
-                       : Color(red: 0.329, green: 0.349, blue: 0.357)       // #54595b
+        if selected { return pal.accentBright }   // #ff7a4d
+        return earlier ? pal.inkGhost       // #3d4143
+                       : pal.inkFaint       // #54595b
     }
     private var titleColor: Color {
-        if selected { return Color(red: 0.984, green: 0.933, blue: 0.910) } // #fbeee8
-        return earlier ? Color(red: 0.498, green: 0.522, blue: 0.529)       // #7f8587
-                       : Color(red: 0.824, green: 0.835, blue: 0.827)       // #d2d5d3
+        if selected { return pal.inkStrong } // #fbeee8
+        return earlier ? pal.inkMid       // #7f8587
+                       : pal.ink       // #d2d5d3
     }
     private var timeColor: Color {
-        if selected { return Color(red: 0.784, green: 0.576, blue: 0.373) } // #c8935f
-        return earlier ? Color(red: 0.329, green: 0.349, blue: 0.357)       // #54595b
-                       : Color(red: 0.42, green: 0.44, blue: 0.45)          // #6b7072
+        if selected { return pal.warmSel } // #c8935f
+        return earlier ? pal.inkFaint       // #54595b
+                       : pal.inkMuted          // #6b7072
     }
 
     var body: some View {
@@ -525,7 +532,7 @@ private struct RecentNoteRow: View {
             .padding(.horizontal, 10)
             .frame(height: 32)
             .background(
-                selected ? amber.opacity(0.08) : (hovered ? .white.opacity(0.04) : .clear)
+                selected ? amber.opacity(0.08) : (hovered ? pal.strokeBase.opacity(0.04) : .clear)
             )
             .overlay(alignment: .leading) {
                 if selected {
@@ -549,6 +556,7 @@ private struct RecentNoteRow: View {
 }
 
 private struct NoteConstellation: View {
+    @Environment(\.popoverPalette) private var pal
     let notes: [Note]
     let selectedNoteID: String?
     let amber: Color
@@ -569,7 +577,7 @@ private struct NoteConstellation: View {
                         path.addLine(to: end)
                         context.stroke(
                             path,
-                            with: .color(.white.opacity(0.08)),
+                            with: .color(pal.strokeBase.opacity(0.08)),
                             style: StrokeStyle(lineWidth: 1, dash: [5, 7])
                         )
                     }
@@ -596,6 +604,7 @@ private struct NoteConstellation: View {
 }
 
 private struct ConstellationNode: View {
+    @Environment(\.popoverPalette) private var pal
     let index: Int
     let note: Note
     let amber: Color
@@ -609,35 +618,35 @@ private struct ConstellationNode: View {
     private var tier: Int { index <= 3 ? 0 : (index <= 6 ? 1 : 2) }
 
     private var bgColor: Color {
-        if selected { return Color(red: 0.071, green: 0.063, blue: 0.067) }  // #121011
+        if selected { return pal.nodeSelBg }  // #121011
         switch tier {
-        case 0: return Color(red: 0.055, green: 0.059, blue: 0.067)          // #0e0f11
-        case 1: return Color(red: 0.039, green: 0.043, blue: 0.047)          // #0a0b0c
-        default: return Color(red: 0.031, green: 0.035, blue: 0.039)         // #08090a
+        case 0: return pal.nodeBg0          // paper card
+        case 1: return pal.nodeBg1
+        default: return pal.nodeBg2
         }
     }
     private var borderColor: Color {
         if selected { return amber.opacity(0.55) }
         switch tier {
-        case 0: return .white.opacity(hovered ? 0.25 : 0.11)
-        case 1: return .white.opacity(hovered ? 0.18 : 0.08)
-        default: return .white.opacity(hovered ? 0.12 : 0.05)
+        case 0: return pal.strokeBase.opacity(hovered ? 0.25 : 0.11)
+        case 1: return pal.strokeBase.opacity(hovered ? 0.18 : 0.08)
+        default: return pal.strokeBase.opacity(hovered ? 0.12 : 0.05)
         }
     }
     private var titleColor: Color {
-        if selected { return .white }
+        if selected { return pal.strokeBase }
         switch tier {
-        case 0: return Color(red: 0.902, green: 0.91, blue: 0.902)           // #e6e8e6
-        case 1: return Color(red: 0.514, green: 0.537, blue: 0.545)          // #83898b
-        default: return Color(red: 0.329, green: 0.349, blue: 0.357)         // #54595b
+        case 0: return pal.inkBright           // #e6e8e6
+        case 1: return pal.inkMid          // #83898b
+        default: return pal.inkFaint         // #54595b
         }
     }
     private var numberColor: Color {
-        if selected { return Color(red: 1.0, green: 0.478, blue: 0.302) }    // #ff7a4d
+        if selected { return pal.accentBright }    // #ff7a4d
         switch tier {
-        case 0: return Color(red: 0.329, green: 0.349, blue: 0.357)          // #54595b
-        case 1: return Color(red: 0.263, green: 0.282, blue: 0.294)          // #43484b
-        default: return Color(red: 0.2, green: 0.22, blue: 0.227)            // #33383a
+        case 0: return pal.inkFaint          // #54595b
+        case 1: return pal.inkGhost          // #43484b
+        default: return pal.inkGhost            // #33383a
         }
     }
 
@@ -654,7 +663,7 @@ private struct ConstellationNode: View {
                 if selected {
                     Text(note.updatedAt.blinkCompactRelative)
                         .font(.system(size: 10, weight: .light, design: .monospaced))
-                        .foregroundStyle(Color(red: 0.42, green: 0.44, blue: 0.45))
+                        .foregroundStyle(pal.inkMuted)
                 }
             }
             .padding(.horizontal, selected ? 13 : (tier == 0 ? 12 : 11))
@@ -699,62 +708,8 @@ private struct CornerTicks: View {
     }
 }
 
-private struct NotePreviewCard: View {
-    let note: Note
-    let accent: Color
-    let coordinate: String
-    let onOpen: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .firstTextBaseline) {
-                Text(note.title)
-                    .font(.system(size: 20, weight: .semibold, design: .serif).italic())
-                    .foregroundStyle(.white.opacity(0.94))
-                    .lineLimit(1)
-                Spacer(minLength: 12)
-                Text(coordinate)
-                    .font(.system(size: 10, weight: .bold, design: .monospaced))
-                    .foregroundStyle(accent.opacity(0.86))
-            }
-
-            Text(note.blinkExcerpt)
-                .font(.system(size: 13, weight: .regular))
-                .foregroundStyle(.white.opacity(0.59))
-                .lineLimit(2)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            HStack {
-                Text(note.updatedAt.blinkLongRelative)
-                    .font(.system(size: 10, weight: .medium, design: .monospaced))
-                    .foregroundStyle(.white.opacity(0.30))
-                Spacer()
-                Button(action: onOpen) {
-                    HStack(spacing: 8) {
-                        KeyCap(symbol: "↵")
-                        Text("open")
-                            .font(.system(size: 10, weight: .semibold, design: .monospaced))
-                    }
-                    .foregroundStyle(.white.opacity(0.72))
-                }
-                .buttonStyle(.plain)
-            }
-        }
-        .padding(16)
-        .background(
-            LinearGradient(
-                colors: [Color(red: 0.12, green: 0.125, blue: 0.15), Color(red: 0.085, green: 0.09, blue: 0.11)],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            ),
-            in: RoundedRectangle(cornerRadius: 15)
-        )
-        .overlay(RoundedRectangle(cornerRadius: 15).stroke(accent.opacity(0.34), lineWidth: 1))
-        .shadow(color: .black.opacity(0.35), radius: 18, y: 7)
-    }
-}
-
 private struct NoteCardGrid: View {
+    @Environment(\.popoverPalette) private var pal
     let notes: [Note]
     let selectedNoteID: String?
     let accent: (Note) -> Color
@@ -773,24 +728,24 @@ private struct NoteCardGrid: View {
                                 Circle().fill(accent(note)).frame(width: 9, height: 9)
                                 Text(note.title)
                                     .font(.system(size: 13, weight: .semibold))
-                                    .foregroundStyle(.white.opacity(0.84))
+                                    .foregroundStyle(pal.strokeBase.opacity(0.84))
                                     .lineLimit(1)
                                 Spacer()
                                 Text(note.updatedAt.blinkCompactRelative)
                                     .font(.system(size: 10, design: .monospaced))
-                                    .foregroundStyle(.white.opacity(0.28))
+                                    .foregroundStyle(pal.strokeBase.opacity(0.28))
                             }
                             Text(note.blinkExcerpt)
                                 .font(.system(size: 11))
-                                .foregroundStyle(.white.opacity(0.43))
+                                .foregroundStyle(pal.strokeBase.opacity(0.43))
                                 .lineLimit(3)
                                 .frame(maxWidth: .infinity, minHeight: 46, alignment: .topLeading)
                         }
                         .padding(14)
-                        .background(.white.opacity(note.id == selectedNoteID ? 0.075 : 0.035), in: RoundedRectangle(cornerRadius: 12))
+                        .background(pal.strokeBase.opacity(note.id == selectedNoteID ? 0.075 : 0.035), in: RoundedRectangle(cornerRadius: 12))
                         .overlay(
                             RoundedRectangle(cornerRadius: 12)
-                                .stroke(note.id == selectedNoteID ? accent(note).opacity(0.55) : .white.opacity(0.07), lineWidth: 1)
+                                .stroke(note.id == selectedNoteID ? accent(note).opacity(0.55) : pal.strokeBase.opacity(0.07), lineWidth: 1)
                         )
                     }
                     .buttonStyle(.plain)
@@ -805,6 +760,7 @@ private struct NoteCardGrid: View {
 }
 
 private struct CanvasNoteList: View {
+    @Environment(\.popoverPalette) private var pal
     let notes: [Note]
     let selectedNoteID: String?
     let accent: (Note) -> Color
@@ -821,24 +777,24 @@ private struct CanvasNoteList: View {
                             VStack(alignment: .leading, spacing: 3) {
                                 Text(note.title)
                                     .font(.system(size: 13, weight: .semibold))
-                                    .foregroundStyle(.white.opacity(0.82))
+                                    .foregroundStyle(pal.strokeBase.opacity(0.82))
                                     .lineLimit(1)
                                 Text(note.blinkExcerpt)
                                     .font(.system(size: 10))
-                                    .foregroundStyle(.white.opacity(0.35))
+                                    .foregroundStyle(pal.strokeBase.opacity(0.35))
                                     .lineLimit(1)
                             }
                             Spacer()
                             Text(note.updatedAt.blinkCompactRelative)
                                 .font(.system(size: 11, design: .monospaced))
-                                .foregroundStyle(.white.opacity(0.28))
+                                .foregroundStyle(pal.strokeBase.opacity(0.28))
                             Image(systemName: "arrow.up.forward.app")
                                 .font(.system(size: 11))
-                                .foregroundStyle(.white.opacity(0.28))
+                                .foregroundStyle(pal.strokeBase.opacity(0.28))
                         }
                         .padding(.horizontal, 14)
                         .frame(height: 50)
-                        .background(.white.opacity(note.id == selectedNoteID ? 0.07 : 0.025), in: RoundedRectangle(cornerRadius: 10))
+                        .background(pal.strokeBase.opacity(note.id == selectedNoteID ? 0.07 : 0.025), in: RoundedRectangle(cornerRadius: 10))
                     }
                     .buttonStyle(.plain)
                     .simultaneousGesture(TapGesture(count: 2).onEnded { onOpen(note) })
@@ -884,19 +840,21 @@ private final class SubtleScrollerProbe: NSView {
 }
 
 private struct CanvasSurface: View {
+    @Environment(\.popoverPalette) private var pal
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 15)
-                .fill(Color(red: 0.025, green: 0.031, blue: 0.041).opacity(0.93))
+                .fill(pal.canvasFill)
             DotGrid()
                 .clipShape(RoundedRectangle(cornerRadius: 15))
             RoundedRectangle(cornerRadius: 15)
-                .stroke(.white.opacity(0.065), lineWidth: 1)
+                .stroke(pal.strokeBase.opacity(0.065), lineWidth: 1)
         }
     }
 }
 
 private struct DotGrid: View {
+    @Environment(\.popoverPalette) private var pal
     var body: some View {
         Canvas { context, size in
             let step: CGFloat = 28
@@ -906,7 +864,7 @@ private struct DotGrid: View {
                 while y < size.height {
                     context.fill(
                         Path(ellipseIn: CGRect(x: x - 1, y: y - 1, width: 2, height: 2)),
-                        with: .color(.white.opacity(0.055))
+                        with: .color(pal.strokeBase.opacity(0.055))
                     )
                     y += step
                 }
@@ -919,12 +877,13 @@ private struct DotGrid: View {
 
 /// The faint 1px line grid that underlays the whole popout.
 private struct TerminalGrid: View {
+    @Environment(\.popoverPalette) private var pal
     var step: CGFloat = 40
     var opacity: Double = 0.02
 
     var body: some View {
         Canvas { context, size in
-            let color = Color.white.opacity(opacity)
+            let color = pal.strokeBase.opacity(opacity)
             var x: CGFloat = 0
             while x < size.width {
                 context.stroke(Path { $0.move(to: CGPoint(x: x, y: 0)); $0.addLine(to: CGPoint(x: x, y: size.height)) }, with: .color(color), lineWidth: 1)
@@ -942,9 +901,10 @@ private struct TerminalGrid: View {
 
 /// The four L-brackets framing the popout, per the design's terminal chrome.
 private struct PopoutCorners: View {
+    @Environment(\.popoverPalette) private var pal
     var len: CGFloat = 13
     var body: some View {
-        let color = Color(red: 0.353, green: 0.376, blue: 0.388)  // #5a6063
+        let color = pal.popoutCorner  // #5a6063
         GeometryReader { g in
             let w = g.size.width, h = g.size.height
             Path { p in
@@ -959,56 +919,31 @@ private struct PopoutCorners: View {
     }
 }
 
-private struct FooterAction: View {
-    let systemName: String
-    let label: String?
-    let help: String
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 8) {
-                Image(systemName: systemName)
-                    .font(.system(size: 15, weight: .medium))
-                if let label {
-                    Text(label)
-                        .font(.system(size: 12, weight: .medium, design: .monospaced))
-                        .padding(.horizontal, 8)
-                        .frame(height: 25)
-                        .background(.white.opacity(0.065), in: RoundedRectangle(cornerRadius: 6))
-                        .overlay(RoundedRectangle(cornerRadius: 6).stroke(.white.opacity(0.08), lineWidth: 1))
-                }
-            }
-            .foregroundStyle(.white.opacity(0.48))
-        }
-        .buttonStyle(.plain)
-        .help(help)
-    }
-}
-
 private struct KeyCap: View {
+    @Environment(\.popoverPalette) private var pal
     let symbol: String
 
     var body: some View {
         Text(symbol)
             .font(.system(size: 11, weight: .light, design: .monospaced))
-            .foregroundStyle(Color(red: 0.824, green: 0.835, blue: 0.827))  // #d2d5d3
+            .foregroundStyle(pal.ink)  // #d2d5d3
             .frame(minWidth: 20, minHeight: 20)
-            .overlay(Rectangle().stroke(.white.opacity(0.1), lineWidth: 1))   // sharp
+            .overlay(Rectangle().stroke(pal.strokeBase.opacity(0.1), lineWidth: 1))   // sharp
     }
 }
 
 /// A bordered inline key hint (e.g. ⌘K) — sharp, thin, per the design.
 private struct KeyBadge: View {
+    @Environment(\.popoverPalette) private var pal
     let text: String
 
     var body: some View {
         Text(text)
             .font(.system(size: 10.5, weight: .light, design: .monospaced))
-            .foregroundStyle(Color(red: 0.42, green: 0.44, blue: 0.45))  // #6b7072
+            .foregroundStyle(pal.inkMuted)  // #6b7072
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .overlay(Rectangle().stroke(.white.opacity(0.1), lineWidth: 1))
+            .overlay(Rectangle().stroke(pal.strokeBase.opacity(0.1), lineWidth: 1))
     }
 }
 
@@ -1151,5 +1086,106 @@ private extension Color {
             green: Double((number >> 8) & 0xff) / 255,
             blue: Double(number & 0xff) / 255
         )
+    }
+}
+
+// MARK: - Appearance palette
+
+/// The popover's full color set for one appearance. `strokeBase` collapses the
+/// terminal chrome — every hairline, border, dot, grid line, and hover fill is
+/// that color at some opacity, and it doubles as ink-on-surface text — so light
+/// mode is mostly "flip white → near-black." The opaque mono inks and the paper
+/// backgrounds carry explicit light values. Accents (amber, LIVE green) are
+/// shared: both read on paper as well as on black.
+private struct PopoverPalette {
+    let accent = Color(red: 1.0, green: 0.345, blue: 0.133)        // #ff5822
+    let accentBright = Color(red: 1.0, green: 0.478, blue: 0.302)  // #ff7a4d
+
+    var live: Color
+    /// White in dark, near-black in light: base for all opacity-based chrome
+    /// and for ink-on-surface text.
+    var strokeBase: Color
+
+    // Tiered mono ink, brightest → faintest.
+    var inkStrong: Color   // selected titles
+    var inkBright: Color   // input text, freshest node title
+    var ink: Color         // icons, keycaps, today rows
+    var inkMid: Color      // earlier titles, footer, mid-tier nodes
+    var inkMuted: Color    // magnifier, section labels, key badges
+    var inkFaint: Color    // row numbers, status line
+    var inkGhost: Color    // counts, receded numbers, the "/" divider
+    var warmSel: Color     // a selected row's timestamp (warm tan)
+
+    // Opaque surfaces.
+    var bgBase: Color
+    var bgGrad1: Color
+    var bgGrad2: Color
+    var bgGrad3: Color
+    var canvasFill: Color
+    var nodeSelBg: Color
+    var nodeBg0: Color
+    var nodeBg1: Color
+    var nodeBg2: Color
+    var popoutCorner: Color
+
+    static let dark = PopoverPalette(
+        live: Color(red: 0.353, green: 0.820, blue: 0.608),        // #5ad19b
+        strokeBase: .white,
+        inkStrong: Color(red: 0.984, green: 0.933, blue: 0.910),   // #fbeee8
+        inkBright: Color(red: 0.902, green: 0.910, blue: 0.902),   // #e6e8e6
+        ink: Color(red: 0.824, green: 0.835, blue: 0.827),         // #d2d5d3
+        inkMid: Color(red: 0.498, green: 0.522, blue: 0.529),      // #7f8587
+        inkMuted: Color(red: 0.420, green: 0.440, blue: 0.450),    // #6b7072
+        inkFaint: Color(red: 0.329, green: 0.349, blue: 0.357),    // #54595b
+        inkGhost: Color(red: 0.239, green: 0.255, blue: 0.263),    // #3d4143
+        warmSel: Color(red: 0.784, green: 0.576, blue: 0.373),     // #c8935f
+        bgBase: Color(red: 0.039, green: 0.043, blue: 0.047),      // #0a0b0c
+        bgGrad1: Color(red: 0.090, green: 0.098, blue: 0.110),     // #17191c
+        bgGrad2: Color(red: 0.047, green: 0.055, blue: 0.063),     // #0c0e10
+        bgGrad3: Color(red: 0.020, green: 0.024, blue: 0.027),     // #050607
+        canvasFill: Color(red: 0.025, green: 0.031, blue: 0.041).opacity(0.93),
+        nodeSelBg: Color(red: 0.071, green: 0.063, blue: 0.067),   // #121011
+        nodeBg0: Color(red: 0.055, green: 0.059, blue: 0.067),     // #0e0f11
+        nodeBg1: Color(red: 0.039, green: 0.043, blue: 0.047),     // #0a0b0c
+        nodeBg2: Color(red: 0.031, green: 0.035, blue: 0.039),     // #08090a
+        popoutCorner: Color(red: 0.353, green: 0.376, blue: 0.388)  // #5a6063
+    )
+
+    static let light = PopoverPalette(
+        live: Color(red: 0.106, green: 0.580, blue: 0.404),        // #1b9367
+        strokeBase: Color(red: 0.086, green: 0.078, blue: 0.070),  // warm near-black
+        inkStrong: Color(red: 0.090, green: 0.075, blue: 0.063),   // #17130f
+        inkBright: Color(red: 0.130, green: 0.116, blue: 0.102),   // #211d1a
+        ink: Color(red: 0.205, green: 0.185, blue: 0.165),         // #342f2a
+        inkMid: Color(red: 0.360, green: 0.335, blue: 0.310),      // #5c554f
+        inkMuted: Color(red: 0.460, green: 0.435, blue: 0.405),    // #756f67
+        inkFaint: Color(red: 0.560, green: 0.535, blue: 0.505),    // #8f8880
+        inkGhost: Color(red: 0.680, green: 0.655, blue: 0.622),    // #ada79e
+        warmSel: Color(red: 0.600, green: 0.380, blue: 0.180),     // #99612e
+        bgBase: Color(red: 0.949, green: 0.941, blue: 0.925),      // #f2f0ec paper
+        bgGrad1: Color(red: 0.988, green: 0.980, blue: 0.965),     // #fcfaf6
+        bgGrad2: Color(red: 0.949, green: 0.941, blue: 0.925),     // #f2f0ec
+        bgGrad3: Color(red: 0.910, green: 0.898, blue: 0.874),     // #e8e5df
+        canvasFill: Color(red: 1.0, green: 0.996, blue: 0.988).opacity(0.72),
+        nodeSelBg: Color(red: 1.0, green: 1.0, blue: 1.0),         // white card
+        nodeBg0: Color(red: 0.988, green: 0.984, blue: 0.973),     // #fcfbf8
+        nodeBg1: Color(red: 0.957, green: 0.949, blue: 0.933),     // #f4f2ee
+        nodeBg2: Color(red: 0.929, green: 0.918, blue: 0.898),     // #ede9e5
+        popoutCorner: Color(red: 0.660, green: 0.635, blue: 0.600)  // #a8a29a
+    )
+
+    static func forScheme(_ scheme: AppScheme) -> PopoverPalette {
+        scheme == .dark ? .dark : .light
+    }
+}
+
+private struct PopoverPaletteKey: EnvironmentKey {
+    static let defaultValue = PopoverPalette.dark
+}
+
+private extension EnvironmentValues {
+    var popoverPalette: PopoverPalette {
+        get { self[PopoverPaletteKey.self] }
+        set { self[PopoverPaletteKey.self] = newValue }
     }
 }

--- a/Sources/BlinkApp/DrapeOverlay.swift
+++ b/Sources/BlinkApp/DrapeOverlay.swift
@@ -27,7 +27,7 @@ final class DrapeOverlay {
             // above ordinary windows such as terminals, editors, and browsers.
             window.level = NSWindow.Level(rawValue: NSWindow.Level.floating.rawValue - 1)
             window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
-            window.appearance = NSAppearance(named: .darkAqua)
+            window.appearance = NSAppearance(named: AppearanceManager.shared.scheme.nsAppearanceName)
             window.hasShadow = false
 
             blur.material = .hudWindow
@@ -51,8 +51,14 @@ final class DrapeOverlay {
         }
 
         func applyTheme(dim: CGFloat, material: NSVisualEffectView.Material) {
-            dimView.layer?.backgroundColor = NSColor.black.withAlphaComponent(dim).cgColor
-            blur.material = material
+            // Follow the app scheme: a dark stage in dark mode, a bright one in
+            // light. `.hudWindow` stays dark even under aqua, so swap it for a
+            // light glass when the veil itself has gone light.
+            let scheme = AppearanceManager.shared.scheme
+            window.appearance = NSAppearance(named: scheme.nsAppearanceName)
+            let base: NSColor = scheme.isDark ? .black : .white
+            dimView.layer?.backgroundColor = base.withAlphaComponent(dim).cgColor
+            blur.material = (scheme == .light && material == .hudWindow) ? .popover : material
         }
 
         func show(frame: NSRect, opacity: CGFloat) {

--- a/Sources/BlinkApp/FocusOverlay.swift
+++ b/Sources/BlinkApp/FocusOverlay.swift
@@ -8,9 +8,14 @@ final class FocusOverlay {
     private let window: NSWindow
     private let dimView = NSView()
 
-    /// Themable dim strength (config.json → focus.dim).
+    /// Themable dim strength (config.json → focus.dim). The veil follows the app
+    /// scheme: black recedes the world in dark mode, white in light mode — same
+    /// "quiet the surroundings" job, mirrored.
     func applyTheme(dim: Double) {
-        dimView.layer?.backgroundColor = NSColor.black.withAlphaComponent(dim).cgColor
+        let scheme = AppearanceManager.shared.scheme
+        window.appearance = NSAppearance(named: scheme.nsAppearanceName)
+        let base: NSColor = scheme.isDark ? .black : .white
+        dimView.layer?.backgroundColor = base.withAlphaComponent(dim).cgColor
     }
 
     init() {
@@ -25,7 +30,7 @@ final class FocusOverlay {
         w.ignoresMouseEvents = true
         w.level = .floating
         w.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
-        w.appearance = NSAppearance(named: .darkAqua)
+        w.appearance = NSAppearance(named: AppearanceManager.shared.scheme.nsAppearanceName)
         w.hasShadow = false
 
         let blur = NSVisualEffectView()

--- a/Sources/BlinkApp/GridOverlay.swift
+++ b/Sources/BlinkApp/GridOverlay.swift
@@ -84,6 +84,12 @@ private final class GridOverlayView: NSView {
 
     override var isOpaque: Bool { false }
 
+    /// The guide "ink" follows the app scheme so the constellation reads on
+    /// either backdrop: luminous white in dark mode, near-black in light.
+    private var ink: NSColor {
+        AppearanceManager.shared.scheme.isDark ? .white : NSColor(white: 0.12, alpha: 1)
+    }
+
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
         NSColor.black.withAlphaComponent(0.15).setFill()
@@ -111,7 +117,7 @@ private final class GridOverlayView: NSView {
             }
             x += spacing
         }
-        NSColor.white.withAlphaComponent(0.08).setFill()
+        ink.withAlphaComponent(0.08).setFill()
         dots.fill()
     }
 
@@ -120,7 +126,7 @@ private final class GridOverlayView: NSView {
         let letterFont = NSFont.monospacedSystemFont(ofSize: 48, weight: .thin)
         let letterAttributes: [NSAttributedString.Key: Any] = [
             .font: letterFont,
-            .foregroundColor: NSColor.white.withAlphaComponent(0.09),
+            .foregroundColor: ink.withAlphaComponent(0.09),
         ]
 
         for slot in GridSlot.allCases {
@@ -128,7 +134,7 @@ private final class GridOverlayView: NSView {
             let outline = NSBezierPath(roundedRect: rect, xRadius: 16, yRadius: 16)
             outline.lineWidth = 1
             outline.setLineDash(dash, count: dash.count, phase: 0)
-            NSColor.white.withAlphaComponent(0.13).setStroke()
+            ink.withAlphaComponent(0.13).setStroke()
             outline.stroke()
 
             let label = slot.rawValue as NSString
@@ -146,7 +152,7 @@ private final class GridOverlayView: NSView {
             let outline = NSBezierPath(roundedRect: looseRect, xRadius: 14, yRadius: 14)
             outline.lineWidth = 1.2
             outline.lineCapStyle = .round
-            NSColor.white.withAlphaComponent(0.31).setStroke()
+            ink.withAlphaComponent(0.31).setStroke()
             outline.stroke()
 
             // A barely offset second pass keeps the line from reading as a
@@ -157,7 +163,7 @@ private final class GridOverlayView: NSView {
                 yRadius: 14
             )
             echo.lineWidth = 0.55
-            NSColor.white.withAlphaComponent(0.10).setStroke()
+            ink.withAlphaComponent(0.10).setStroke()
             echo.stroke()
         }
     }
@@ -186,10 +192,10 @@ private final class GridOverlayView: NSView {
             )
             threadPath.lineWidth = 1.5
             threadPath.lineCapStyle = .round
-            NSColor.white.withAlphaComponent(0.35).setStroke()
+            ink.withAlphaComponent(0.35).setStroke()
             threadPath.stroke()
 
-            NSColor.white.withAlphaComponent(0.45).setFill()
+            ink.withAlphaComponent(0.45).setFill()
             for point in [start, end] {
                 NSBezierPath(
                     ovalIn: NSRect(x: point.x - 2.5, y: point.y - 2.5, width: 5, height: 5)
@@ -268,7 +274,7 @@ final class GridOverlay {
         overlayWindow.ignoresMouseEvents = true
         overlayWindow.level = .floating
         overlayWindow.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
-        overlayWindow.appearance = NSAppearance(named: .darkAqua)
+        overlayWindow.appearance = NSAppearance(named: AppearanceManager.shared.scheme.nsAppearanceName)
         overlayWindow.hasShadow = false
         overlayWindow.contentView = drawingView
         window = overlayWindow

--- a/Sources/BlinkApp/NotePanel.swift
+++ b/Sources/BlinkApp/NotePanel.swift
@@ -38,6 +38,11 @@ final class NotePanel: NSPanel {
     /// many notes are visible.
     var onVisibilityChanged: (() -> Void)?
 
+    /// Supplies the latest complete markdown for context-menu copy. PanelManager
+    /// owns the truthful in-memory content (including unsaved edits), so the
+    /// panel asks rather than reading a potentially stale file from disk.
+    var markdownProvider: (() -> String?)?
+
     let modeState = PanelModeState()
     var currentMode: String { modeState.mode }
 
@@ -56,6 +61,8 @@ final class NotePanel: NSPanel {
 
     private var modePillView: NSView?
     private var noteIDView: NSView?
+    private var versionMetadataView: NSView?
+    private var styleMetadataView: NSView?
     private var focusGlyphView: NSView?
     private var closeButtonView: NSView?
     private var isHovered = false
@@ -102,9 +109,11 @@ final class NotePanel: NSPanel {
         isOpaque = false
         backgroundColor = .clear
         minSize = NSSize(width: 260, height: 120)
-        // Blink's glass is dark regardless of system appearance — the editor
-        // typography (white on transparent) and the studies assume it.
-        appearance = NSAppearance(named: .darkAqua)
+        // Follow the app-wide light/dark scheme (config.appearance, resolved by
+        // AppearanceManager): the glass material, tint, and editor palette all
+        // flip with it. A scheme change re-applies via `applyTheme`.
+        appearance = NSAppearance(named: AppearanceManager.shared.scheme.nsAppearanceName)
+        updateMetadata(theme)
 
         // Plain container is the contentView; the glass material is a sibling
         // BEHIND the content, not the content root. This lets flat sheets hide
@@ -117,7 +126,7 @@ final class NotePanel: NSPanel {
         container.layer?.cornerRadius = theme.panel.cornerRadius
         container.layer?.masksToBounds = true
 
-        glass.material = theme.panel.visualEffectMaterial
+        glass.material = Self.glassMaterial(theme, AppearanceManager.shared.scheme)
         glass.blendingMode = .behindWindow
         glass.state = .active
         glass.wantsLayer = true
@@ -134,7 +143,7 @@ final class NotePanel: NSPanel {
         hasShadow = theme.panel.shadow
 
         tintLayer.wantsLayer = true
-        tintLayer.layer?.backgroundColor = NSColor.black.cgColor
+        tintLayer.layer?.backgroundColor = Self.tintColor(AppearanceManager.shared.scheme)
         tintLayer.alphaValue = readTint
         tintLayer.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(tintLayer)
@@ -190,10 +199,36 @@ final class NotePanel: NSPanel {
         ])
         modePillView = pill
 
-        // Edit mode exposes the note's stable slug — the same identifier the
-        // CLI and agent APIs accept. Keep it quietly visible in the top band so
-        // the user can name the exact note/window in a prompt; clicking copies
-        // the untruncated value. Read mode remains presentation-clean.
+        // Edit mode exposes the stable slug at bottom-center — identity is one
+        // quiet, copyable anchor, separate from the note's treatment metadata.
+        let styleHost = NSHostingView(
+            rootView: StyleMetadataBadge(state: modeState) { [weak self] in
+                self?.showStylePicker()
+            }
+        )
+        styleHost.translatesAutoresizingMaskIntoConstraints = false
+        styleHost.alphaValue = 0.75
+        container.addSubview(styleHost)
+        NSLayoutConstraint.activate([
+            styleHost.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -30),
+            styleHost.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -6),
+            styleHost.leadingAnchor.constraint(greaterThanOrEqualTo: container.centerXAnchor, constant: 30),
+        ])
+        styleMetadataView = styleHost
+
+        let versionHost = NSHostingView(
+            rootView: AppVersionLabel(version: Self.appVersion)
+        )
+        versionHost.translatesAutoresizingMaskIntoConstraints = false
+        versionHost.alphaValue = 0.75
+        container.addSubview(versionHost)
+        NSLayoutConstraint.activate([
+            versionHost.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 9),
+            versionHost.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -6),
+            versionHost.trailingAnchor.constraint(lessThanOrEqualTo: container.centerXAnchor, constant: -30),
+        ])
+        versionMetadataView = versionHost
+
         let noteIDHost = NSHostingView(
             rootView: NoteIdentifierBadge(noteID: noteID) { [weak self] in
                 self?.copyNoteID()
@@ -204,9 +239,9 @@ final class NotePanel: NSPanel {
         container.addSubview(noteIDHost)
         NSLayoutConstraint.activate([
             noteIDHost.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-            noteIDHost.topAnchor.constraint(equalTo: container.topAnchor, constant: 6),
-            noteIDHost.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: 34),
-            noteIDHost.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -68),
+            noteIDHost.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -6),
+            noteIDHost.leadingAnchor.constraint(greaterThanOrEqualTo: versionHost.trailingAnchor, constant: 8),
+            noteIDHost.trailingAnchor.constraint(lessThanOrEqualTo: styleHost.leadingAnchor, constant: -8),
         ])
         noteIDView = noteIDHost
 
@@ -279,6 +314,25 @@ final class NotePanel: NSPanel {
         }
     }
 
+    /// The glass material for a scheme. `.hudWindow` is intentionally dark even
+    /// under `.aqua`, so in light mode the default swaps to `.popover` — a
+    /// light, appearance-adaptive glass. A material the user set explicitly to
+    /// something else adapts on its own and is left alone.
+    static func glassMaterial(
+        _ config: BlinkConfig, _ scheme: AppScheme
+    ) -> NSVisualEffectView.Material {
+        let material = config.panel.visualEffectMaterial
+        if scheme == .light, material == .hudWindow { return .popover }
+        return material
+    }
+
+    /// The contrast tint painted between glass and content: black deepens the
+    /// dark glass so white text reads; white lifts the light glass so dark ink
+    /// reads. Same job, mirrored per scheme.
+    static func tintColor(_ scheme: AppScheme) -> CGColor {
+        (scheme.isDark ? NSColor.black : NSColor.white).cgColor
+    }
+
     /// Reconcile the native surface with `sheetTemplate`.
     ///
     /// - glass/card: the glass material and tint stay ON (card draws its own
@@ -288,6 +342,12 @@ final class NotePanel: NSPanel {
     ///   drop the window shadow — the web layer paints everything on a fully
     ///   transparent page.
     private func applySheetAppearance(_ config: BlinkConfig) {
+        let scheme = AppearanceManager.shared.scheme
+        // Follow the app scheme first, so the glass/tint below render in the
+        // right mode even when only the appearance flipped.
+        appearance = NSAppearance(named: scheme.nsAppearanceName)
+        tintLayer.layer?.backgroundColor = Self.tintColor(scheme)
+
         let flat = Self.isFlatSheet(sheetTemplate)
         glassView.isHidden = flat
         tintLayer.isHidden = flat
@@ -297,7 +357,7 @@ final class NotePanel: NSPanel {
             // (drawn by the web layer) defines the shape.
             container.layer?.cornerRadius = 0
         } else {
-            glassView.material = config.panel.visualEffectMaterial
+            glassView.material = Self.glassMaterial(config, scheme)
             glassView.layer?.cornerRadius = config.panel.cornerRadius
             container.layer?.cornerRadius = config.panel.cornerRadius
             hasShadow = config.panel.shadow
@@ -372,6 +432,12 @@ final class NotePanel: NSPanel {
             noteIDView?.animator().alphaValue = currentMode == "edit"
                 ? (isHovered ? 1 : 0.55)
                 : 0
+            styleMetadataView?.animator().alphaValue = currentMode == "edit"
+                ? (isHovered ? 1 : 0.75)
+                : 0
+            versionMetadataView?.animator().alphaValue = currentMode == "edit"
+                ? (isHovered ? 1 : 0.75)
+                : 0
             // Active focus leaves a faint trace so the state stays legible.
             focusGlyphView?.animator().alphaValue = isHovered ? 1 : (modeState.focus ? 0.35 : 0)
         }
@@ -388,6 +454,10 @@ final class NotePanel: NSPanel {
         modeState.mode = mode
         noteIDView?.isHidden = mode != "edit"
         noteIDView?.alphaValue = mode == "edit" ? (isHovered ? 1 : 0.55) : 0
+        styleMetadataView?.isHidden = mode != "edit"
+        styleMetadataView?.alphaValue = mode == "edit" ? (isHovered ? 1 : 0.75) : 0
+        versionMetadataView?.isHidden = mode != "edit"
+        versionMetadataView?.alphaValue = mode == "edit" ? (isHovered ? 1 : 0.75) : 0
         guard !Self.isFlatSheet(sheetTemplate) else { return }
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.18
@@ -404,6 +474,7 @@ final class NotePanel: NSPanel {
         let theme = config.resolved(for: notePresentation)
         readTint = theme.panel.tintRead
         editTint = theme.panel.tintEdit
+        updateMetadata(theme)
 
         if theme.panel.sheet != sheetTemplate {
             sheetTemplate = theme.panel.sheet
@@ -416,7 +487,7 @@ final class NotePanel: NSPanel {
         if !Self.isFlatSheet(sheetTemplate) {
             tintLayer.alphaValue = currentMode == "edit" ? editTint : readTint
         }
-        editor.setTheme(theme.editorThemeVars)
+        editor.setTheme(theme.editorThemeVars(scheme: AppearanceManager.shared.scheme))
     }
 
     /// Change this note's sheet template live from the context menu: re-derive
@@ -429,16 +500,115 @@ final class NotePanel: NSPanel {
         applyTheme(BlinkConfigStore.shared.config)
     }
 
+    /// Reconcile externally-authored presentation metadata (agent/CLI/file
+    /// edits) into the live panel and its metadata rail.
+    func applyPresentation(_ presentation: NotePresentation) {
+        guard presentation != notePresentation else { return }
+        notePresentation = presentation
+        applyTheme(BlinkConfigStore.shared.config)
+    }
+
+    private func updateMetadata(_ theme: BlinkConfig) {
+        modeState.sheet = theme.panel.sheet
+        modeState.style = notePresentation.style
+        modeState.font = Self.displayFontName(theme.editor.fontFamily)
+        modeState.fontSize = theme.editor.fontSize
+    }
+
+    private static func displayFontName(_ cssFamily: String?) -> String {
+        guard let first = cssFamily?.split(separator: ",", maxSplits: 1).first else {
+            return "System"
+        }
+        return first.trimmingCharacters(in: CharacterSet(charactersIn: " \\\"'"))
+    }
+
+    private static var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "dev"
+    }
+
     // MARK: - Context menu
 
-    /// Rewrite WebKit's right-click menu into Blink's: drop the stock "Reload",
-    /// then offer a live style picker, a soft hide (re-show from the menubar
-    /// canvas), and a real close (removes the note from the open session).
+    /// Rewrite WebKit's right-click menu into a note-aware action surface. Keep
+    /// useful selection/edit commands, drop stock Reload, then group identity,
+    /// file, presentation, and window actions from least to most consequential.
     private func decorateContextMenu(_ menu: NSMenu) {
-        menu.items.removeAll { $0.identifier?.rawValue == "WKMenuItemIdentifierReload" }
+        let noisyWebKitGroups: Set<String> = [
+            "Spelling and Grammar", "Substitutions", "Transformations", "Font",
+            "Speech", "Paragraph Direction", "Selection Direction", "AutoFill",
+        ]
+        menu.items.removeAll { item in
+            if item.identifier?.rawValue == "WKMenuItemIdentifierReload" { return true }
+            if noisyWebKitGroups.contains(item.title) { return true }
+            // Context menus should not advertise actions that cannot currently
+            // act. Selection/link commands remain when WebKit enables them.
+            return !item.isEnabled && item.submenu == nil
+        }
+        normalizeMenuSeparators(menu)
         if !menu.items.isEmpty { menu.addItem(.separator()) }
 
+        menu.addItem(contextItem(
+            "Copy Note ID",
+            symbol: "number",
+            action: #selector(contextCopyNoteID(_:))
+        ))
+        let copyMarkdown = contextItem(
+            "Copy Entire Note as Markdown",
+            symbol: "doc.on.doc",
+            action: #selector(contextCopyMarkdown(_:))
+        )
+        copyMarkdown.isEnabled = markdownProvider != nil
+        menu.addItem(copyMarkdown)
+        menu.addItem(contextItem(
+            "Copy File Path",
+            symbol: "link",
+            action: #selector(contextCopyFilePath(_:))
+        ))
+
+        menu.addItem(.separator())
+        menu.addItem(contextItem(
+            "Open Markdown File",
+            symbol: "doc.text",
+            action: #selector(contextOpenMarkdownFile(_:))
+        ))
+        menu.addItem(contextItem(
+            "Reveal in Finder",
+            symbol: "folder",
+            action: #selector(contextRevealInFinder(_:))
+        ))
+
+        menu.addItem(.separator())
+        let nextMode = currentMode == "edit" ? "Read" : "Edit"
+        menu.addItem(contextItem(
+            "Switch to \(nextMode) Mode",
+            symbol: currentMode == "edit" ? "book" : "pencil",
+            action: #selector(contextToggleMode(_:))
+        ))
+        menu.addItem(contextItem(
+            "Focus Mode",
+            symbol: "circle.dashed",
+            action: #selector(contextToggleFocus(_:)),
+            state: focusEnabled ? .on : .off
+        ))
+
         let styleItem = NSMenuItem(title: "Style", action: nil, keyEquivalent: "")
+        styleItem.image = NSImage(systemSymbolName: "paintpalette", accessibilityDescription: nil)
+        styleItem.submenu = makeStyleMenu()
+        menu.addItem(styleItem)
+
+        menu.addItem(.separator())
+        menu.addItem(contextItem(
+            "Hide Note",
+            symbol: "eye.slash",
+            action: #selector(contextHideNote(_:))
+        ))
+        menu.addItem(contextItem(
+            "Close Note",
+            symbol: "xmark",
+            action: #selector(contextCloseNote(_:))
+        ))
+    }
+
+    private func makeStyleMenu() -> NSMenu {
         let styleMenu = NSMenu()
         for sheet in Self.availableSheets {
             let item = NSMenuItem(
@@ -451,22 +621,84 @@ final class NotePanel: NSPanel {
             item.state = (sheet == sheetTemplate) ? .on : .off
             styleMenu.addItem(item)
         }
-        styleItem.submenu = styleMenu
-        menu.addItem(styleItem)
+        return styleMenu
+    }
 
-        menu.addItem(.separator())
-        let hide = NSMenuItem(title: "Hide Note", action: #selector(contextHideNote(_:)), keyEquivalent: "")
-        hide.target = self
-        menu.addItem(hide)
-        let close = NSMenuItem(title: "Close Note", action: #selector(contextCloseNote(_:)), keyEquivalent: "")
-        close.target = self
-        menu.addItem(close)
+    private func showStylePicker() {
+        guard let anchor = styleMetadataView else { return }
+        makeStyleMenu().popUp(
+            positioning: nil,
+            at: NSPoint(x: anchor.bounds.minX, y: anchor.bounds.maxY + 4),
+            in: anchor
+        )
+    }
+
+    private func normalizeMenuSeparators(_ menu: NSMenu) {
+        var hasLeadingItem = false
+        var previousWasSeparator = false
+        for item in menu.items {
+            guard item.isSeparatorItem else {
+                hasLeadingItem = true
+                previousWasSeparator = false
+                continue
+            }
+            if !hasLeadingItem || previousWasSeparator {
+                menu.removeItem(item)
+            } else {
+                previousWasSeparator = true
+            }
+        }
+        if let last = menu.items.last, last.isSeparatorItem {
+            menu.removeItem(last)
+        }
+    }
+
+    private func contextItem(
+        _ title: String,
+        symbol: String,
+        action: Selector,
+        state: NSControl.StateValue = .off
+    ) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        item.image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)
+        item.state = state
+        return item
     }
 
     @objc private func contextSelectSheet(_ sender: NSMenuItem) {
         guard let sheet = sender.representedObject as? String else { return }
         applySheet(sheet)
         onSheetChanged?(sheet)
+    }
+
+    @objc private func contextCopyNoteID(_ sender: NSMenuItem) {
+        copyNoteID()
+    }
+
+    @objc private func contextCopyMarkdown(_ sender: NSMenuItem) {
+        guard let markdown = markdownProvider?() else { return }
+        copyToPasteboard(markdown)
+    }
+
+    @objc private func contextCopyFilePath(_ sender: NSMenuItem) {
+        copyToPasteboard(noteFileURL.path)
+    }
+
+    @objc private func contextOpenMarkdownFile(_ sender: NSMenuItem) {
+        NSWorkspace.shared.open(noteFileURL)
+    }
+
+    @objc private func contextRevealInFinder(_ sender: NSMenuItem) {
+        NSWorkspace.shared.activateFileViewerSelecting([noteFileURL])
+    }
+
+    @objc private func contextToggleMode(_ sender: NSMenuItem) {
+        selectMode(currentMode == "edit" ? "read" : "edit")
+    }
+
+    @objc private func contextToggleFocus(_ sender: NSMenuItem) {
+        toggleFocus()
     }
 
     /// Soft hide: tuck the panel away but keep it in the session, so clicking
@@ -937,20 +1169,32 @@ final class NotePanel: NSPanel {
     /// Copy the exact agent-facing id, then return keyboard focus to the editor
     /// so identifying a note never interrupts the writing flow.
     private func copyNoteID() {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(noteID, forType: .string)
+        copyToPasteboard(noteID)
         guard currentMode == "edit" else { return }
         makeKey()
         makeFirstResponder(editor.webView)
         editor.focus()
     }
+
+    private var noteFileURL: URL {
+        BlinkPaths.notes().appendingPathComponent("\(noteID).md", isDirectory: false)
+    }
+
+    private func copyToPasteboard(_ string: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(string, forType: .string)
+    }
 }
 
-/// Observable mode + focus state for the SwiftUI toggle overlay.
+/// Observable state shared by the panel's SwiftUI chrome.
 @MainActor
 final class PanelModeState: ObservableObject {
     @Published var mode: String = "edit"
     @Published var focus: Bool = false
+    @Published var sheet: String = "glass"
+    @Published var style: String?
+    @Published var font: String = "System"
+    @Published var fontSize: Double = 13
 }
 
 /// ✎/◧ mode segments; the active segment is lit. Hover-revealed, top-right.
@@ -985,9 +1229,7 @@ private struct ModeToggle: View {
     }
 }
 
-/// The note/window handle exposed only while editing. It shows the stable slug
-/// agents already use (`blink write <id>`, panel APIs) and copies the full value
-/// even when a narrow panel has to truncate the middle visually.
+/// The stable, copyable note/window identity at bottom-center in edit mode.
 private struct NoteIdentifierBadge: View {
     let noteID: String
     var onCopy: () -> Void
@@ -1020,6 +1262,68 @@ private struct NoteIdentifierBadge: View {
     }
 }
 
+/// A tiny build signature at bottom-left, balancing identity and treatment.
+private struct AppVersionLabel: View {
+    let version: String
+
+    var body: some View {
+        Text("blink v\(version)")
+            .font(.system(size: 8.5, weight: .medium, design: .monospaced))
+            .foregroundStyle(Color.primary.opacity(0.34))
+            .lineLimit(1)
+            .frame(height: 18)
+            .help("Blink \(version)")
+    }
+}
+
+/// Read-mostly treatment metadata at bottom-right. It stays quieter than the
+/// centered identity; clicking jumps straight into the sheet picker.
+private struct StyleMetadataBadge: View {
+    @ObservedObject var state: PanelModeState
+    var onTap: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: onTap) {
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 4) {
+                    styleLabel
+                    Text("·").foregroundStyle(Color.primary.opacity(0.25))
+                    Text("\(state.font) \(formattedFontSize)")
+                        .lineLimit(1)
+                }
+                styleLabel
+            }
+            .font(.system(size: 8.5, weight: .medium, design: .monospaced))
+            .foregroundStyle(Color.primary.opacity(hovering ? 0.70 : 0.42))
+            .padding(.horizontal, 5)
+            .frame(height: 18)
+            .background(Color.primary.opacity(hovering ? 0.07 : 0.025), in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .help("Style: \(state.sheet) — click to change")
+    }
+
+    private var styleLabel: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "paintpalette")
+                .font(.system(size: 8))
+            if let style = state.style {
+                Text("\(style)/\(state.sheet)").lineLimit(1)
+            } else {
+                Text(state.sheet).lineLimit(1)
+            }
+        }
+    }
+
+    private var formattedFontSize: String {
+        state.fontSize.rounded() == state.fontSize
+            ? String(Int(state.fontSize))
+            : String(format: "%.1f", state.fontSize)
+    }
+}
+
 /// The focus ring: a small dashed circle, alone in the bottom-right corner —
 /// deliberately not a peer of the mode segments. Fills in while focus is on.
 private struct FocusGlyph: View {
@@ -1048,10 +1352,51 @@ private struct FocusGlyph: View {
 /// feels exactly like the native one — the cursor keeps its grip point.
 private final class DragHandle: NSView {
     private var isDragging = false
+    private var isHovering = false
+    private var tracking: NSTrackingArea?
     private var grabMouse = NSPoint.zero   // screen point at mouseDown
     private var grabOrigin = NSPoint.zero  // window origin at mouseDown
     private var tracker = DragVelocityTracker()
     private var shake = ShakeDetector()
+
+    override var isOpaque: Bool { false }
+
+    override func updateTrackingAreas() {
+        if let tracking { removeTrackingArea(tracking) }
+        let next = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .cursorUpdate, .activeAlways, .inVisibleRect],
+            owner: self
+        )
+        addTrackingArea(next)
+        tracking = next
+        super.updateTrackingAreas()
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        // A hairline grip keeps the borderless panel discoverably movable
+        // without turning the strip into visible window chrome.
+        let alpha: CGFloat = isDragging ? 0.38 : (isHovering ? 0.24 : 0.08)
+        NSColor.labelColor.withAlphaComponent(alpha).setFill()
+        let grip = NSRect(x: bounds.midX - 12, y: bounds.maxY - 5, width: 24, height: 2)
+        NSBezierPath(roundedRect: grip, xRadius: 1, yRadius: 1).fill()
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHovering = true
+        NSCursor.openHand.set()
+        needsDisplay = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovering = false
+        if !isDragging { needsDisplay = true }
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+        (isDragging ? NSCursor.closedHand : NSCursor.openHand).set()
+    }
 
     override func mouseDown(with event: NSEvent) {
         guard let panel = window as? NotePanel else { return }
@@ -1069,6 +1414,8 @@ private final class DragHandle: NSView {
         tracker.reset()
         shake.reset()
         isDragging = true
+        NSCursor.closedHand.set()
+        needsDisplay = true
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -1095,6 +1442,8 @@ private final class DragHandle: NSView {
     override func mouseUp(with event: NSEvent) {
         guard isDragging, let panel = window as? NotePanel else { return }
         isDragging = false
+        NSCursor.openHand.set()
+        needsDisplay = true
         tracker.add(panel.frame.origin, at: event.timestamp)
         panel.endManualDrag(velocity: tracker.velocity())
     }

--- a/Sources/BlinkApp/NotePanel.swift
+++ b/Sources/BlinkApp/NotePanel.swift
@@ -1,5 +1,6 @@
 import AppKit
 import BlinkCore
+import HudsonObservability
 import SwiftUI
 import WebKit
 
@@ -17,11 +18,25 @@ final class NotePanel: NSPanel {
     /// This note's presentation intent (the `blink:` block, plus any legacy
     /// `sheet:` alias merged in by PanelManager). The single input to
     /// `config.resolved(for:)`, so open-time and hot-reload theming agree.
-    private let notePresentation: NotePresentation
+    /// Mutable: the context menu's style picker updates `sheet` in place.
+    private var notePresentation: NotePresentation
+
+    /// The sheet templates offered in the panel's right-click "Style" menu
+    /// (config.md → `blink.sheet`), in presentation order.
+    static let availableSheets = ["glass", "card", "dotted", "bracket", "marginalia"]
 
     /// Fired for user-initiated mode flips from the native toggle or ⌘⇧P
     /// (JS-side flips arrive via the bridge's modeChanged instead).
     var onUserModeChange: ((String) -> Void)?
+
+    /// The user picked a new sheet from the context menu — PanelManager persists
+    /// it to the note's frontmatter (the panel already applied it live).
+    var onSheetChanged: ((String) -> Void)?
+
+    /// The panel's on-screen presence changed by its own hand (context-menu
+    /// Hide) — lets PanelManager re-evaluate the drape, which depends on how
+    /// many notes are visible.
+    var onVisibilityChanged: (() -> Void)?
 
     let modeState = PanelModeState()
     var currentMode: String { modeState.mode }
@@ -154,7 +169,7 @@ final class NotePanel: NSPanel {
             drag.topAnchor.constraint(equalTo: container.topAnchor),
             drag.leadingAnchor.constraint(equalTo: container.leadingAnchor),
             drag.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            drag.heightAnchor.constraint(equalToConstant: 24),
+            drag.heightAnchor.constraint(equalToConstant: Self.bandHeight),
         ])
 
         // Chrome is earned: controls fade in on hover, floating IN the former
@@ -250,6 +265,7 @@ final class NotePanel: NSPanel {
         editor.load()
         editor.setContent(initialContent)
         editor.setSheet(sheetTemplate)
+        editor.onWillOpenContextMenu = { [weak self] menu in self?.decorateContextMenu(menu) }
         // Focus-on-ready and initial mode are owned by PanelManager (mode-aware).
     }
 
@@ -403,6 +419,68 @@ final class NotePanel: NSPanel {
         editor.setTheme(theme.editorThemeVars)
     }
 
+    /// Change this note's sheet template live from the context menu: re-derive
+    /// both the web sheet and the native surface (glass vs flat, material,
+    /// radius). Persistence to frontmatter is the caller's job via
+    /// `onSheetChanged`; this only touches presentation, never geometry.
+    func applySheet(_ sheet: String) {
+        guard sheet != sheetTemplate else { return }
+        notePresentation.sheet = sheet
+        applyTheme(BlinkConfigStore.shared.config)
+    }
+
+    // MARK: - Context menu
+
+    /// Rewrite WebKit's right-click menu into Blink's: drop the stock "Reload",
+    /// then offer a live style picker, a soft hide (re-show from the menubar
+    /// canvas), and a real close (removes the note from the open session).
+    private func decorateContextMenu(_ menu: NSMenu) {
+        menu.items.removeAll { $0.identifier?.rawValue == "WKMenuItemIdentifierReload" }
+        if !menu.items.isEmpty { menu.addItem(.separator()) }
+
+        let styleItem = NSMenuItem(title: "Style", action: nil, keyEquivalent: "")
+        let styleMenu = NSMenu()
+        for sheet in Self.availableSheets {
+            let item = NSMenuItem(
+                title: sheet.capitalized,
+                action: #selector(contextSelectSheet(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = sheet
+            item.state = (sheet == sheetTemplate) ? .on : .off
+            styleMenu.addItem(item)
+        }
+        styleItem.submenu = styleMenu
+        menu.addItem(styleItem)
+
+        menu.addItem(.separator())
+        let hide = NSMenuItem(title: "Hide Note", action: #selector(contextHideNote(_:)), keyEquivalent: "")
+        hide.target = self
+        menu.addItem(hide)
+        let close = NSMenuItem(title: "Close Note", action: #selector(contextCloseNote(_:)), keyEquivalent: "")
+        close.target = self
+        menu.addItem(close)
+    }
+
+    @objc private func contextSelectSheet(_ sender: NSMenuItem) {
+        guard let sheet = sender.representedObject as? String else { return }
+        applySheet(sheet)
+        onSheetChanged?(sheet)
+    }
+
+    /// Soft hide: tuck the panel away but keep it in the session, so clicking
+    /// the note in the menubar canvas brings it right back (openPanel focuses
+    /// the existing, hidden panel). Distinct from Close, which forgets it.
+    @objc private func contextHideNote(_ sender: NSMenuItem) {
+        orderOut(nil)
+        onVisibilityChanged?()
+    }
+
+    @objc private func contextCloseNote(_ sender: NSMenuItem) {
+        close()
+    }
+
     // MARK: - Arrival: motion signature
 
     /// True when the OS asks for reduced motion — treated as `"none"` (spec).
@@ -430,6 +508,8 @@ final class NotePanel: NSPanel {
     /// `fromOffset` nudges the pre-animation origin (used by the blink's
     /// compass reveal) on top of any per-kind drift.
     func animateEntrance(motion: BlinkConfig.Motion, fromOffset: CGSize = .zero) {
+        // A programmatic move supersedes any in-flight glide.
+        cancelFling()
         // If an exhale left the frame drifted, snap back to the resting home
         // before we read the target — the reveal must land the panel exactly
         // where it lives, never at a drifted position.
@@ -496,6 +576,7 @@ final class NotePanel: NSPanel {
     func animateExhale(
         direction: CGSize, durationMs: Double, then finish: @escaping @MainActor () -> Void
     ) {
+        cancelFling()  // the blink's choreography supersedes any glide
         let home = frame
         blinkHomeFrame = home
         let dur = max(0.05, durationMs / 1000)
@@ -525,6 +606,9 @@ final class NotePanel: NSPanel {
     /// (GridOverlay draws its own placement today; this is here for it to adopt
     /// later — the spec forbids modifying GridOverlay to use it now.)
     func animateLock(to frame: NSRect) {
+        // A programmatic placement supersedes any in-flight glide; the
+        // completion persists the target as usual.
+        cancelFling()
         // Overshoot slightly past the target along the travel direction, then
         // settle back. Direction derives from where we're coming from.
         let current = self.frame
@@ -598,6 +682,243 @@ final class NotePanel: NSPanel {
             layer.transform = CATransform3DMakeScale(scale, scale, 1)
             container.animator().alphaValue = alpha
         }
+    }
+
+    // MARK: - Panel physics (fling + shade)
+
+    /// Height of the grab band — and of the whole panel while shaded: the
+    /// fold collapses the window to exactly its drag strip.
+    static let bandHeight: CGFloat = 24
+
+    /// Speed (pt/s) below which a glide is declared at rest: ~0.5pt per frame
+    /// at 120Hz — invisible. Not configurable; `flingFriction` is the feel knob.
+    private static let flingRestSpeed: Double = 30
+
+    private let physicsLog = HudLogger(category: "blink.panel")
+
+    /// Shake-to-shade is a physics gesture: config-gated, and off under Reduce
+    /// Motion like the fling. (Double-click shading stays available regardless —
+    /// an instant fold involves no motion.)
+    var shakeGesturesEnabled: Bool {
+        BlinkConfigStore.shared.config.physics.shakeEnabled && !Self.reduceMotion
+    }
+
+    /// Session-only shade state. Deliberately NOT persisted: relaunch always
+    /// restores the full panel from the unshaded geometry we keep saving.
+    private(set) var isShaded = false
+    /// The panel's full size while shaded — the restore target grows back down
+    /// from the band, so a shaded drag needs no tracking: the band's current
+    /// top edge plus this size IS the unshaded frame.
+    private var unshadedSize: CGSize?
+    private var preShadeMinSize: NSSize?
+    private var preShadeMaxSize: NSSize?
+
+    private var dragInProgress = false
+    private var fling: FlingIntegrator?
+    private var flingLink: CADisplayLink?
+    private var flingLastTime: CFTimeInterval = 0
+    /// Set while a fling tick or a geometry-persistence swap applies a frame,
+    /// so the setFrame overrides below don't read our own writes as an
+    /// interruption and kill the glide (or re-enable autosave mid-swap).
+    private var applyingPhysicsFrame = false
+
+    private var autosaveName: String { "blink.note.\(noteID)" }
+
+    /// Frame autosave writes on window moves, which would spam the defaults
+    /// during a glide — and, worse, persist the COLLAPSED frame while shaded.
+    /// So autosave is suspended whenever physics owns the frame (drag, fling,
+    /// or shaded session) and geometry is written exactly once, at rest, by
+    /// `persistRestingGeometry`. Never scramble a layout.
+    private func refreshAutosaveSuspension() {
+        let physicsOwnsFrame = dragInProgress || fling != nil || isShaded
+        setFrameAutosaveName(physicsOwnsFrame ? "" : autosaveName)
+    }
+
+    /// Persist the resting geometry — always the UNSHADED frame, so a panel
+    /// that dies shaded still relaunches full-size. Called once per rest.
+    private func persistRestingGeometry() {
+        guard isShaded, let fullSize = unshadedSize else {
+            saveFrame(usingName: autosaveName)
+            return
+        }
+        // Autosave only knows the live (collapsed) frame, so briefly pose the
+        // full panel, save, and fold again — display off, nothing renders.
+        applyingPhysicsFrame = true
+        let band = frame
+        setFrame(unshadedFrame(forBand: band, fullSize: fullSize), display: false)
+        saveFrame(usingName: autosaveName)
+        setFrame(band, display: false)
+        applyingPhysicsFrame = false
+    }
+
+    /// The full panel that a shaded band restores to: same size it had, top
+    /// edge anchored at the band's top (the panel unfolds downward from it).
+    private func unshadedFrame(forBand band: NSRect, fullSize: CGSize) -> NSRect {
+        NSRect(x: band.minX, y: band.maxY - fullSize.height, width: fullSize.width, height: fullSize.height)
+    }
+
+    // MARK: Shade
+
+    /// Fold the panel into its top band, or unfold it back. Triggered by a
+    /// shake mid-drag or a double-click on the band. Instant: the shake is a
+    /// violent gesture and the snap is the feedback (classic windowshade).
+    func toggleShade() {
+        if isShaded { unshade() } else { shade() }
+    }
+
+    private func shade() {
+        guard !isShaded else { return }
+        cancelFling()
+        let full = frame
+        unshadedSize = full.size
+        // Persist the FULL frame before collapsing, then keep autosave off for
+        // the whole shaded session so the band's 24pt height never reaches disk.
+        saveFrame(usingName: autosaveName)
+        isShaded = true
+        refreshAutosaveSuspension()
+        // Pin the height at the band so native edge-resizing can't fight the fold.
+        preShadeMinSize = minSize
+        preShadeMaxSize = maxSize
+        minSize = NSSize(width: preShadeMinSize?.width ?? 260, height: Self.bandHeight)
+        maxSize = NSSize(width: preShadeMaxSize?.width ?? .greatestFiniteMagnitude, height: Self.bandHeight)
+        // Fold up under the grab band: the top edge stays put, the bottom rises.
+        setFrame(
+            NSRect(x: full.minX, y: full.maxY - Self.bandHeight, width: full.width, height: Self.bandHeight),
+            display: true
+        )
+    }
+
+    private func unshade() {
+        guard isShaded, let fullSize = unshadedSize else { return }
+        let full = unshadedFrame(forBand: frame, fullSize: fullSize)
+        isShaded = false
+        unshadedSize = nil
+        minSize = preShadeMinSize ?? NSSize(width: 260, height: 120)
+        maxSize = preShadeMaxSize ?? NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        preShadeMinSize = nil
+        preShadeMaxSize = nil
+        setFrame(full, display: true)
+        refreshAutosaveSuspension()
+        saveFrame(usingName: autosaveName)
+    }
+
+    // MARK: Drag → fling
+
+    /// The drag strip went down: take the frame over from any in-flight glide
+    /// and suspend autosave until the gesture (plus any fling it starts) rests.
+    func beginManualDrag() {
+        cancelFling()
+        dragInProgress = true
+        refreshAutosaveSuspension()
+    }
+
+    /// Released. A fast enough throw becomes a glide; anything slower is just
+    /// a drop — persist the resting frame either way, exactly once.
+    func endManualDrag(velocity: CGPoint) {
+        dragInProgress = false
+        let physics = BlinkConfigStore.shared.config.physics
+        let speed = hypot(velocity.x, velocity.y)
+        guard physics.flingEnabled, !Self.reduceMotion,
+              speed >= physics.flingMinVelocity,
+              let bounds = flingBounds()
+        else {
+            persistRestingGeometry()
+            refreshAutosaveSuspension()
+            return
+        }
+        physicsLog.info("[BLINK] fling", metadata: ["speed": "\(Int(speed))"])
+        fling = FlingIntegrator(
+            origin: frame.origin,
+            velocity: velocity,
+            size: frame.size,
+            bounds: bounds,
+            friction: physics.flingFriction,
+            bounceDamping: physics.bounceDamping,
+            restSpeed: Self.flingRestSpeed
+        )
+        flingLastTime = CACurrentMediaTime()
+        // CADisplayLink (macOS 14) fires on the main runloop at the panel's
+        // native refresh — no C callback, no thread hop.
+        let link = container.displayLink(target: self, selector: #selector(flingTick(_:)))
+        link.add(to: .main, forMode: .common)
+        flingLink = link
+        refreshAutosaveSuspension()
+    }
+
+    /// The visible frame of the screen the panel is MOSTLY on (max intersection
+    /// area) — the arena the glide bounces within.
+    private func flingBounds() -> CGRect? {
+        var best: CGRect?
+        var bestArea: CGFloat = 0
+        for screen in NSScreen.screens {
+            let hit = screen.visibleFrame.intersection(frame)
+            guard !hit.isNull else { continue }
+            let area = hit.width * hit.height
+            if area > bestArea {
+                bestArea = area
+                best = screen.visibleFrame
+            }
+        }
+        return best ?? (screen ?? NSScreen.main)?.visibleFrame
+    }
+
+    @objc private func flingTick(_ link: CADisplayLink) {
+        guard var f = fling else {
+            stopFling()
+            return
+        }
+        let now = CACurrentMediaTime()
+        // Clamp long frames (stalls, breakpoint hits) so one dt never teleports.
+        let dt = min(now - flingLastTime, 1.0 / 20)
+        flingLastTime = now
+        let alive = f.step(dt: dt)
+        fling = f
+        applyingPhysicsFrame = true
+        setFrameOrigin(f.origin)
+        applyingPhysicsFrame = false
+        if !alive { stopFling() }
+    }
+
+    /// End a glide: unhook the display link, persist the resting frame, and
+    /// hand autosave back. Safe to call redundantly — a no-op without a fling.
+    private func stopFling() {
+        flingLink?.invalidate()
+        flingLink = nil
+        let wasGliding = fling != nil
+        fling = nil
+        if wasGliding { persistRestingGeometry() }
+        refreshAutosaveSuspension()
+    }
+
+    /// Any interruption — a new grab, a shade fold, a programmatic placement,
+    /// close — kills the glide and keeps its last position (the interrupter
+    /// owns the frame from here, and its own rest will persist again).
+    private func cancelFling() {
+        guard fling != nil || flingLink != nil else { return }
+        stopFling()
+    }
+
+    /// Any frame change that didn't come from the fling tick or the persistence
+    /// swap itself cancels an in-flight glide — this is what makes programmatic
+    /// animation (animateLock, entrances, grid placement) supersede a fling.
+    /// This override must use Objective-C dynamic dispatch. AppKit's
+    /// `animator()` returns an `_NSAnimProxy` typed as `Self`; a native Swift
+    /// call would run this body with the proxy as `self` and interpret its
+    /// storage as `NotePanel` ivars instead of letting the proxy forward the
+    /// message to the real panel.
+    @objc dynamic override func setFrame(_ frameRect: NSRect, display flag: Bool) {
+        if !applyingPhysicsFrame { cancelFling() }
+        super.setFrame(frameRect, display: flag)
+    }
+
+    @objc dynamic override func setFrame(_ frameRect: NSRect, display flag: Bool, animate flag2: Bool) {
+        if !applyingPhysicsFrame { cancelFling() }
+        super.setFrame(frameRect, display: flag, animate: flag2)
+    }
+
+    override func close() {
+        cancelFling()
+        super.close()
     }
 
     /// User-initiated mode change from native chrome (toggle click or ⌘⇧P).
@@ -719,9 +1040,63 @@ private struct FocusGlyph: View {
 /// Invisible top-edge strip that moves the window — the webview eats clicks
 /// everywhere else, so this is the drag surface (the titlebar's ghost, minus
 /// the band).
+///
+/// The drag is tracked manually (not `performDrag`) so the gesture carries
+/// data the OS drag never exposes: a release velocity (a fast throw becomes a
+/// momentum fling) and a shake signature (folds the panel into the band).
+/// The move math is the classic grab-relative offset, so an ordinary drag
+/// feels exactly like the native one — the cursor keeps its grip point.
 private final class DragHandle: NSView {
+    private var isDragging = false
+    private var grabMouse = NSPoint.zero   // screen point at mouseDown
+    private var grabOrigin = NSPoint.zero  // window origin at mouseDown
+    private var tracker = DragVelocityTracker()
+    private var shake = ShakeDetector()
+
     override func mouseDown(with event: NSEvent) {
-        window?.performDrag(with: event)
+        guard let panel = window as? NotePanel else { return }
+        // Double-click on the band toggles the shade — the classic windowshade
+        // gesture. The click that opened the pair already ran a movement-less
+        // drag begin/end, so nothing here is left in flight; the paired
+        // mouseUp finds isDragging false and is ignored.
+        if event.clickCount == 2 {
+            panel.toggleShade()
+            return
+        }
+        panel.beginManualDrag()
+        grabMouse = NSEvent.mouseLocation
+        grabOrigin = panel.frame.origin
+        tracker.reset()
+        shake.reset()
+        isDragging = true
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard isDragging, let panel = window as? NotePanel else { return }
+        let mouse = NSEvent.mouseLocation
+        let origin = NSPoint(
+            x: grabOrigin.x + mouse.x - grabMouse.x,
+            y: grabOrigin.y + mouse.y - grabMouse.y
+        )
+        panel.setFrameOrigin(origin)
+        tracker.add(origin, at: event.timestamp)
+        // Shake → shade. The fold/grow moves the origin under the cursor, so
+        // re-anchor the grab and restart the gesture's sensors or the panel
+        // would jump on the next dragged event.
+        if panel.shakeGesturesEnabled, shake.add(origin, at: event.timestamp) {
+            panel.toggleShade()
+            grabOrigin = panel.frame.origin
+            grabMouse = mouse
+            tracker.reset()
+            shake.reset()
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard isDragging, let panel = window as? NotePanel else { return }
+        isDragging = false
+        tracker.add(panel.frame.origin, at: event.timestamp)
+        panel.endManualDrag(velocity: tracker.velocity())
     }
 }
 

--- a/Sources/BlinkApp/PanelManager.swift
+++ b/Sources/BlinkApp/PanelManager.swift
@@ -492,11 +492,13 @@ final class PanelManager: NSObject, NSWindowDelegate {
     /// gates as the focus overlay, so the two backdrops never fight.
     private func updateDrape() {
         let drape = BlinkConfigStore.shared.config.drape
-        let noteScreens = panels.values.compactMap { panel -> NSScreen? in
-            guard panel.isVisible, panel.isOnActiveSpace else { return nil }
-            return panel.screen
-        }
+        let visiblePanels = panels.values.filter { $0.isVisible && $0.isOnActiveSpace }
+        let noteScreens = visiblePanels.compactMap { $0.screen }
+        // A lone note stays clean over the desktop; the drape earns its keep only
+        // once the notes form a set (config.drape.soloSuppressed, default on).
+        let soloOK = !drape.soloSuppressed || visiblePanels.count >= 2
         if drape.enabled,
+           soloOK,
            !noteScreens.isEmpty,
            !blinkHidden,
            gridOverlay?.isVisible != true {

--- a/Sources/BlinkApp/PanelManager.swift
+++ b/Sources/BlinkApp/PanelManager.swift
@@ -153,6 +153,15 @@ final class PanelManager: NSObject, NSWindowDelegate {
         guard let panel = panels[id], pendingText[id] == nil else { return }
         guard let note = await store.note(id: id) else { return }
 
+        // Presentation is part of the live note, not launch-only decoration.
+        // Merge the legacy sheet alias exactly as openPanel does, then update
+        // both the rendered treatment and the bottom metadata rail.
+        var presentation = note.presentation
+        if presentation.sheet == nil, let legacy = note.extraFrontmatterValue(for: "sheet") {
+            presentation.sheet = legacy
+        }
+        panel.applyPresentation(presentation)
+
         // Presentation intent must reach an open panel even when the body is
         // unchanged: `blink present --slot N` moves the panel into its grid cell.
         reconcileSlot(id: id, note: note, panel: panel)
@@ -371,6 +380,13 @@ final class PanelManager: NSObject, NSWindowDelegate {
         panels[note.id] = panel
         panelContent[note.id] = note.content
 
+        // The panel's context menu copies the truthful in-memory document,
+        // including edits that have not reached the debounced disk save yet.
+        panel.markdownProvider = { [weak self] in
+            guard let self else { return nil }
+            return self.pendingText[note.id] ?? self.panelContent[note.id] ?? note.content
+        }
+
         // Style picked from the panel's context menu — persist to frontmatter
         // (the panel already applied it live). Flows through the store so the
         // canvas and any other surface see the change.
@@ -418,7 +434,11 @@ final class PanelManager: NSObject, NSWindowDelegate {
             ?? UserDefaults.standard.string(forKey: ConfigKeys.noteMode(note.id))
             ?? BlinkConfigStore.shared.config.behavior.defaultMode
         panel.editor.setMode(mode)
-        panel.editor.setTheme(BlinkConfigStore.shared.config.resolved(for: presentation).editorThemeVars)
+        panel.editor.setTheme(
+            BlinkConfigStore.shared.config
+                .resolved(for: presentation)
+                .editorThemeVars(scheme: AppearanceManager.shared.scheme)
+        )
         panel.reflectMode(mode)
         panel.editor.onReady = { [weak panel] in
             if mode == "edit" { panel?.editor.focus() }

--- a/Sources/BlinkApp/PanelManager.swift
+++ b/Sources/BlinkApp/PanelManager.swift
@@ -371,6 +371,27 @@ final class PanelManager: NSObject, NSWindowDelegate {
         panels[note.id] = panel
         panelContent[note.id] = note.content
 
+        // Style picked from the panel's context menu — persist to frontmatter
+        // (the panel already applied it live). Flows through the store so the
+        // canvas and any other surface see the change.
+        panel.onSheetChanged = { [weak self] sheet in
+            Task { @MainActor in
+                guard let self else { return }
+                do {
+                    try await self.store.updateSheet(id: note.id, sheet: sheet)
+                } catch {
+                    self.log.error(
+                        "[BLINK] failed to persist sheet",
+                        metadata: ["id": note.id, "error": "\(error)"]
+                    )
+                }
+            }
+        }
+
+        // Hiding a note from its context menu changes how many notes are on
+        // screen, which the drape depends on — re-evaluate its backdrops.
+        panel.onVisibilityChanged = { [weak self] in self?.updateFocusOverlay() }
+
         panel.editor.onContentChanged = { [weak self] text in
             // User input is the reveal's hard stop. Web already unmasks its
             // complete doc before posting; native mirrors that cancellation so

--- a/Sources/BlinkApp/WebBridge.swift
+++ b/Sources/BlinkApp/WebBridge.swift
@@ -5,6 +5,18 @@ import HudsonObservability
 import UniformTypeIdentifiers
 import WebKit
 
+/// A WKWebView that lets its host rewrite the right-click menu before it opens.
+/// WebKit's stock note-surface menu is just "Reload"; the panel swaps in
+/// Blink-relevant items (change style, hide, close) via `onWillOpenContextMenu`.
+final class BlinkEditorWebView: WKWebView {
+    var onWillOpenContextMenu: ((NSMenu) -> Void)?
+
+    override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
+        onWillOpenContextMenu?(menu)
+        super.willOpenMenu(menu, with: event)
+    }
+}
+
 /// Hosts the CodeMirror editor bundle in a WKWebView and speaks the bridge
 /// contract (see web/editor/README.md):
 ///   JS → native:  ready · contentChanged(text) · saveRequested
@@ -22,6 +34,13 @@ final class EditorWebView: NSObject, WKScriptMessageHandler, WKNavigationDelegat
     /// A rendered `[[wiki-link]]` was clicked (`blink://open/<id>`): open or focus
     /// that note. Wired by PanelManager to the NoteStore.
     var onOpenNote: ((String) -> Void)?
+
+    /// Rewrite the WKWebView context menu before it opens — the panel drops
+    /// WebKit's stock "Reload" and appends Blink's own items (style, hide, close).
+    var onWillOpenContextMenu: ((NSMenu) -> Void)? {
+        get { (webView as? BlinkEditorWebView)?.onWillOpenContextMenu }
+        set { (webView as? BlinkEditorWebView)?.onWillOpenContextMenu = newValue }
+    }
 
     /// Serves `blink://attachments/…` from the Blink home. Held so its lifetime
     /// matches the webview; the configuration copy retains it too.
@@ -47,7 +66,7 @@ final class EditorWebView: NSObject, WKScriptMessageHandler, WKNavigationDelegat
         // copies it — scheme handlers cannot be added to a live webview.
         let handler = BlinkAssetSchemeHandler()
         configuration.setURLSchemeHandler(handler, forURLScheme: "blink")
-        webView = WKWebView(frame: .zero, configuration: configuration)
+        webView = BlinkEditorWebView(frame: .zero, configuration: configuration)
         assetSchemeHandler = handler
         super.init()
 

--- a/Sources/BlinkApp/WebBridge.swift
+++ b/Sources/BlinkApp/WebBridge.swift
@@ -12,8 +12,11 @@ final class BlinkEditorWebView: WKWebView {
     var onWillOpenContextMenu: ((NSMenu) -> Void)?
 
     override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
-        onWillOpenContextMenu?(menu)
         super.willOpenMenu(menu, with: event)
+        // Let WebKit finish contributing context-dependent entries (including
+        // AutoFill) before Blink curates the final menu. Calling the hook first
+        // left late WebKit additions stranded below Blink's closing actions.
+        onWillOpenContextMenu?(menu)
     }
 }
 

--- a/Sources/BlinkCLI/BlinkCLI.swift
+++ b/Sources/BlinkCLI/BlinkCLI.swift
@@ -16,7 +16,7 @@ struct BlinkCommand: AsyncParsableCommand {
         else ~/Library/Application Support/Blink/Notes. Every command takes \
         --json for structured output.
         """,
-        version: "2.0.2",
+        version: "2.0.3",
         subcommands: [
             Ls.self, Cat.self, New.self, Present.self, Append.self, Type.self, Write.self,
             Search.self, Rm.self, PathCommand.self,

--- a/Sources/BlinkCore/NoteStore.swift
+++ b/Sources/BlinkCore/NoteStore.swift
@@ -95,6 +95,31 @@ public actor NoteStore {
         return note
     }
 
+    /// Set a note's sheet template (the Blink-owned `blink.sheet` presentation
+    /// field) and persist. Like `update(content:)`, foreign frontmatter is
+    /// re-read from disk so a concurrent external edit is never clobbered;
+    /// content stays as last known (an open panel re-flushes its own edits).
+    /// Pass `nil` to clear the override and fall back to the config default.
+    @discardableResult
+    public func updateSheet(id: String, sheet: String?) throws -> Note {
+        guard var note = notes[id] else {
+            throw NoteFileStoreError.noteNotFound(id: id)
+        }
+        if let onDisk = try? fileStore.load(id: id) {
+            note.tags = onDisk.tags
+            note.pinned = onDisk.pinned
+            note.createdAt = onDisk.createdAt
+            note.extraFrontmatter = onDisk.extraFrontmatter
+        }
+        note.presentation.sheet = sheet
+        note.updatedAt = clock()
+        note = normalized(note)
+        try fileStore.save(note)
+        notes[id] = note
+        post(.blinkNoteUpdated, id: id)
+        return note
+    }
+
     /// Delete a note by id. Throws if `id` is unknown.
     public func delete(id: String) throws {
         guard notes[id] != nil else {

--- a/Sources/BlinkCore/PanelPhysics.swift
+++ b/Sources/BlinkCore/PanelPhysics.swift
@@ -1,0 +1,223 @@
+import CoreGraphics
+import Foundation
+
+/// Pure panel-physics primitives — the math behind Blink's "panel physics":
+/// momentum fling (velocity decay, edge reflection, rest detection),
+/// release-velocity estimation, and shake recognition. No AppKit: the window
+/// glue (display link, event tracking, frame autosave) lives in BlinkApp and
+/// drives these value types.
+
+/// A flung panel's momentum integrator: one `step(dt:)` per display frame.
+///
+/// Velocity decays exponentially (`v *= exp(-friction * dt)`), the origin
+/// integrates along it, and hitting an edge of `bounds` reflects that velocity
+/// component scaled by `bounceDamping`. Below `restSpeed` the panel is at rest
+/// and `step` returns false — the caller stops ticking and persists the frame.
+/// Total glide distance is ~`speed / friction`, so friction is the one knob
+/// that reads as "heft".
+public struct FlingIntegrator: Equatable, Sendable {
+    /// Window origin (AppKit bottom-left; the math is axis-symmetric so the
+    /// coordinate handedness doesn't matter as long as `bounds` matches it).
+    public var origin: CGPoint
+    /// pt/s, per axis.
+    public var velocity: CGPoint
+    /// Panel size — fixed for the glide's lifetime.
+    public var size: CGSize
+    /// The rectangle the panel bounces within (a screen's `visibleFrame`).
+    public var bounds: CGRect
+    /// Exponential friction, 1/s. Higher = heavier, stops sooner.
+    public var friction: Double
+    /// Fraction of the normal velocity component kept after an edge bounce (0…1).
+    public var bounceDamping: Double
+    /// Speed (pt/s) below which the panel is declared at rest.
+    public var restSpeed: Double
+
+    public init(
+        origin: CGPoint,
+        velocity: CGPoint,
+        size: CGSize,
+        bounds: CGRect,
+        friction: Double,
+        bounceDamping: Double,
+        restSpeed: Double
+    ) {
+        self.origin = origin
+        self.velocity = velocity
+        self.size = size
+        self.bounds = bounds
+        self.friction = friction
+        self.bounceDamping = bounceDamping
+        self.restSpeed = restSpeed
+    }
+
+    public var speed: Double {
+        hypot(Double(velocity.x), Double(velocity.y))
+    }
+
+    /// Advance the glide by `dt` seconds. Returns false once at rest (velocity
+    /// zeroed); a zero-velocity integrator is immediately at rest.
+    @discardableResult
+    public mutating func step(dt: Double) -> Bool {
+        guard speed >= restSpeed else {
+            velocity = .zero
+            return false
+        }
+        guard dt > 0 else { return true }
+
+        let decay = exp(-friction * dt)
+        velocity = CGPoint(x: velocity.x * decay, y: velocity.y * decay)
+        origin.x += velocity.x * CGFloat(dt)
+        origin.y += velocity.y * CGFloat(dt)
+
+        bounce(axis: \.x, length: \.width)
+        bounce(axis: \.y, length: \.height)
+
+        guard speed >= restSpeed else {
+            velocity = .zero
+            return false
+        }
+        return true
+    }
+
+    /// Reflect one axis at its bound, keeping `bounceDamping` of the speed.
+    /// A panel larger than the bound clamps to the near edge and stops on
+    /// that axis — there is no room to bounce in.
+    private mutating func bounce(axis: WritableKeyPath<CGPoint, CGFloat>, length: KeyPath<CGSize, CGFloat>) {
+        let lo = bounds.origin[keyPath: axis]
+        let hi = lo + bounds.size[keyPath: length] - size[keyPath: length]
+        if hi <= lo {
+            origin[keyPath: axis] = lo
+            velocity[keyPath: axis] = 0
+        } else if origin[keyPath: axis] < lo {
+            origin[keyPath: axis] = lo
+            velocity[keyPath: axis] = abs(velocity[keyPath: axis]) * bounceDamping
+        } else if origin[keyPath: axis] > hi {
+            origin[keyPath: axis] = hi
+            velocity[keyPath: axis] = -abs(velocity[keyPath: axis]) * bounceDamping
+        }
+    }
+}
+
+/// Release-velocity estimate for a drag: a trailing window of recent samples,
+/// so a flick registers fast even if the gesture as a whole started slow.
+/// Feed window positions from `mouseDragged` (+ one final sample at `mouseUp`),
+/// then read `velocity()` at release.
+public struct DragVelocityTracker: Sendable {
+    /// How far back (seconds) samples count toward the estimate.
+    public var window: Double
+    private var samples: [(time: Double, point: CGPoint)] = []
+
+    public init(window: Double = 0.1) {
+        self.window = window
+    }
+
+    public mutating func reset() {
+        samples.removeAll(keepingCapacity: true)
+    }
+
+    public mutating func add(_ point: CGPoint, at time: Double) {
+        samples.append((time, point))
+        let cutoff = time - window
+        while samples.count > 1, samples[0].time < cutoff {
+            samples.removeFirst()
+        }
+    }
+
+    /// pt/s across the retained window; zero with fewer than two usable samples.
+    public func velocity() -> CGPoint {
+        guard let first = samples.first, let last = samples.last, last.time > first.time else {
+            return .zero
+        }
+        let dt = last.time - first.time
+        return CGPoint(
+            x: (last.point.x - first.point.x) / dt,
+            y: (last.point.y - first.point.y) / dt
+        )
+    }
+}
+
+/// Recognizes a horizontal shake during a drag: `requiredReversals` direction
+/// flips within `window` seconds, each spanning at least `minAmplitude` points,
+/// with little net vertical travel. Feed drag samples; it returns true the
+/// moment a shake is recognized, then re-arms so a continued shake can fire
+/// again after another full set of reversals.
+public struct ShakeDetector: Sendable {
+    /// All reversals must land inside this window (seconds).
+    public var window: Double
+    /// Minimum horizontal span (pt) of one back-or-forth leg for it to count.
+    public var minAmplitude: CGFloat
+    /// Direction flips needed to fire.
+    public var requiredReversals: Int
+    /// Net vertical travel tolerated across the window (pt) — a shake is sideways.
+    public var maxVerticalDrift: CGFloat
+
+    public init(
+        window: Double = 0.6,
+        minAmplitude: CGFloat = 40,
+        requiredReversals: Int = 3,
+        maxVerticalDrift: CGFloat = 60
+    ) {
+        self.window = window
+        self.minAmplitude = minAmplitude
+        self.requiredReversals = requiredReversals
+        self.maxVerticalDrift = maxVerticalDrift
+    }
+
+    private var lastPoint: CGPoint?
+    private var lastDirection: Int = 0  // -1 | 0 | +1, the current horizontal run
+    private var runStart: CGPoint = .zero  // where the current run began
+    private var extreme: CGPoint = .zero   // furthest point of the current run
+    private var reversals: [(time: Double, point: CGPoint)] = []
+
+    public mutating func reset() {
+        lastPoint = nil
+        lastDirection = 0
+        runStart = .zero
+        extreme = .zero
+        reversals.removeAll(keepingCapacity: true)
+    }
+
+    public mutating func add(_ point: CGPoint, at time: Double) -> Bool {
+        reversals.removeAll { time - $0.time > window }
+        guard let last = lastPoint else {
+            lastPoint = point
+            runStart = point
+            extreme = point
+            return false
+        }
+        lastPoint = point
+        let dx = point.x - last.x
+        let direction = dx > 0 ? 1 : (dx < 0 ? -1 : 0)
+        guard direction != 0 else { return false }
+
+        if lastDirection == 0 {
+            // First real movement: the run starts where sampling started.
+            lastDirection = direction
+            extreme = point
+            return false
+        }
+        if direction == lastDirection {
+            // Same run — keep the extreme current.
+            if direction > 0, point.x > extreme.x { extreme = point }
+            if direction < 0, point.x < extreme.x { extreme = point }
+            return false
+        }
+
+        // Direction flipped: the completed run is a candidate reversal.
+        lastDirection = direction
+        let amplitude = abs(extreme.x - runStart.x)
+        defer {
+            runStart = extreme
+            extreme = point
+        }
+        guard amplitude >= minAmplitude else { return false }
+        reversals.append((time, extreme))
+        guard reversals.count >= requiredReversals,
+              abs(point.y - reversals[0].point.y) <= maxVerticalDrift
+        else { return false }
+
+        // Recognized — re-arm so a sustained shake toggles again.
+        reversals.removeAll(keepingCapacity: true)
+        return true
+    }
+}

--- a/Tests/BlinkCoreTests/PanelPhysicsTests.swift
+++ b/Tests/BlinkCoreTests/PanelPhysicsTests.swift
@@ -1,0 +1,190 @@
+import CoreGraphics
+import Testing
+@testable import BlinkCore
+
+@Suite("Panel physics")
+struct PanelPhysicsTests {
+    private let bounds = CGRect(x: 0, y: 0, width: 1000, height: 800)
+    private let size = CGSize(width: 200, height: 150)
+
+    private func fling(
+        origin: CGPoint, velocity: CGPoint,
+        friction: Double = 3.2, damping: Double = 0.6, rest: Double = 30,
+        bounds: CGRect? = nil
+    ) -> FlingIntegrator {
+        FlingIntegrator(
+            origin: origin, velocity: velocity, size: size,
+            bounds: bounds ?? self.bounds,
+            friction: friction, bounceDamping: damping, restSpeed: rest
+        )
+    }
+
+    /// Run a glide to rest (or a generous cap), returning the final integrator
+    /// and how many steps it took.
+    private func runToRest(_ f: FlingIntegrator, dt: Double = 1.0 / 240) -> (FlingIntegrator, Int) {
+        var f = f
+        var steps = 0
+        while steps < 240 * 10, f.step(dt: dt) { steps += 1 }
+        return (f, steps)
+    }
+
+    @Test("zero velocity is an immediate no-op")
+    func zeroVelocity() {
+        var f = fling(origin: CGPoint(x: 100, y: 100), velocity: .zero)
+        #expect(f.step(dt: 1.0 / 60) == false)
+        #expect(f.origin == CGPoint(x: 100, y: 100))
+        #expect(f.velocity == .zero)
+    }
+
+    @Test("exponential friction decays a glide to rest")
+    func decaysToRest() {
+        // Roomy bounds so nothing bounces; travel should approach v0/friction.
+        let room = CGRect(x: -10_000, y: -10_000, width: 20_000, height: 20_000)
+        let (f, steps) = runToRest(
+            fling(origin: .zero, velocity: CGPoint(x: 2000, y: 0), bounds: room)
+        )
+        #expect(steps > 0)
+        #expect(f.velocity == .zero)
+        // Integral of 2000·e^(−3.2t) is 625; Euler integration lands within a few %.
+        #expect(abs(Double(f.origin.x) - 625) < 40)
+        // And rest arrives in a human-scale time, not an asymptotic forever.
+        #expect(Double(steps) / 240 < 2.5)
+    }
+
+    @Test("edge bounce reflects and damps the normal velocity")
+    func bounce() {
+        // 100pt from the right edge (maxX = 1000 − 200 = 800), moving right.
+        var f = fling(origin: CGPoint(x: 700, y: 400), velocity: CGPoint(x: 1000, y: 0))
+        var bounced = false
+        var preBounceSpeed = 0.0
+        for _ in 0 ..< 240 {
+            let before = f.velocity.x
+            _ = f.step(dt: 1.0 / 240)
+            if f.velocity.x < 0, before > 0 {
+                bounced = true
+                preBounceSpeed = Double(before)
+                break
+            }
+        }
+        #expect(bounced)
+        #expect(f.origin.x == 800)  // clamped exactly onto the edge
+        // Reflection kept 60% of the speed it carried into the wall.
+        #expect(abs(Double(f.velocity.x)) - 0.6 * preBounceSpeed < 1)
+        #expect(f.velocity.y == 0)
+    }
+
+    @Test("a diagonal fling settles inside the bounds")
+    func settlesInside() {
+        let (f, _) = runToRest(fling(origin: CGPoint(x: 100, y: 100), velocity: CGPoint(x: 3000, y: 2500)))
+        #expect(f.velocity == .zero)
+        #expect(f.origin.x >= 0 && f.origin.x <= 800)
+        #expect(f.origin.y >= 0 && f.origin.y <= 650)
+    }
+
+    @Test("a panel larger than the bounds clamps instead of vibrating")
+    func oversized() {
+        var f = FlingIntegrator(
+            origin: CGPoint(x: 50, y: 50), velocity: CGPoint(x: -500, y: 500),
+            size: CGSize(width: 2000, height: 150),
+            bounds: bounds, friction: 3.2, bounceDamping: 0.6, restSpeed: 30
+        )
+        _ = f.step(dt: 1.0 / 60)
+        #expect(f.origin.x == 0)
+        #expect(f.velocity.x == 0)
+    }
+}
+
+@Suite("Drag velocity tracker")
+struct DragVelocityTrackerTests {
+    @Test("no or one sample reads as zero")
+    func insufficient() {
+        var t = DragVelocityTracker()
+        #expect(t.velocity() == .zero)
+        t.add(CGPoint(x: 5, y: 5), at: 1.0)
+        #expect(t.velocity() == .zero)
+    }
+
+    @Test("constant motion estimates exactly")
+    func constantVelocity() {
+        var t = DragVelocityTracker(window: 0.1)
+        t.add(CGPoint(x: 0, y: 0), at: 0.0)
+        t.add(CGPoint(x: 100, y: -50), at: 0.05)
+        t.add(CGPoint(x: 200, y: -100), at: 0.1)
+        #expect(t.velocity() == CGPoint(x: 2000, y: -1000))
+    }
+
+    @Test("old samples fall out of the trailing window")
+    func pruning() {
+        var t = DragVelocityTracker(window: 0.1)
+        t.add(CGPoint(x: 0, y: 0), at: 0.0)      // stale by the end
+        t.add(CGPoint(x: 10, y: 0), at: 0.09)
+        t.add(CGPoint(x: 210, y: 0), at: 0.14)
+        t.add(CGPoint(x: 410, y: 0), at: 0.19)
+        // Retained window is [0.09, 0.19] — the slow crawl at the start is
+        // gone and the flick (200pt per 0.05s) reads at its true 4000pt/s.
+        #expect(t.velocity() == CGPoint(x: 4000, y: 0))
+    }
+}
+
+@Suite("Shake detector")
+struct ShakeDetectorTests {
+    /// Feed samples of x = amplitude·sin(2π·frequency·t) at 120Hz, returning
+    /// whether the detector ever fired.
+    private func shakeFires(amplitude: Double, frequency: Double, seconds: Double, y: (Double) -> Double = { _ in 0 }) -> Bool {
+        var d = ShakeDetector()
+        var t = 0.0
+        while t <= seconds {
+            if d.add(CGPoint(x: amplitude * sin(2 * .pi * frequency * t), y: y(t)), at: t) { return true }
+            t += 1.0 / 120
+        }
+        return false
+    }
+
+    @Test("a real shake fires")
+    func shakes() {
+        // 100pt swing, 3Hz → 6 reversals/sec: 3 land well inside 0.6s.
+        #expect(shakeFires(amplitude: 100, frequency: 3, seconds: 1.0))
+    }
+
+    @Test("small wiggles never reach the amplitude floor")
+    func tooSmall() {
+        // Amplitude counts per reversal LEG (peak-to-trough), so a ±15pt
+        // wiggle has 30pt legs — under the 40pt floor.
+        #expect(!shakeFires(amplitude: 15, frequency: 3, seconds: 1.5))
+    }
+
+    @Test("slow sways fall outside the time window")
+    func tooSlow() {
+        // 0.8Hz → a reversal every 0.625s: three never fit in 0.6s.
+        #expect(!shakeFires(amplitude: 100, frequency: 0.8, seconds: 3.0))
+    }
+
+    @Test("a steady drag is not a shake")
+    func steadyDrag() {
+        var d = ShakeDetector()
+        var t = 0.0
+        var fired = false
+        while t <= 1.0 {
+            if d.add(CGPoint(x: 500 * t, y: 0), at: t) { fired = true; break }
+            t += 1.0 / 120
+        }
+        #expect(!fired)
+    }
+
+    @Test("vertical shaking does not count")
+    func verticalOnly() {
+        var d = ShakeDetector()
+        var t = 0.0
+        var fired = false
+        while t <= 1.0 {
+            if d.add(CGPoint(x: 0, y: 100 * sin(2 * .pi * 3 * t)), at: t) { fired = true; break }
+            t += 1.0 / 120
+        }
+        #expect(!fired)
+    }
+
+    @Test("climbing while shaking suppresses the gesture")
+    func verticalDrift() {
+        #expect(!shakeFires(amplitude: 100, frequency: 3, seconds: 1.0) { 300 * $0 })
+    }
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -65,6 +65,15 @@ Rules:
     "staggerMs": 40,            // per-panel delay in group reveals (session restore, the blink)
     "enabled": true             // master switch — false = instant show/hide (today's behavior)
   },
+  "physics": {                  // panel physics: how a note behaves under the hand
+    "flingEnabled": true,       // throw a panel by its top band — it glides on and bounces off screen edges
+    "flingFriction": 3.2,       // exponential glide friction (1/s); higher = heavier, stops sooner
+                                // (total glide distance ≈ release speed / flingFriction)
+    "flingMinVelocity": 900,    // release speed (pt/s) that starts a glide; below it the panel just stays
+    "bounceDamping": 0.6,       // 0–1 velocity kept after an edge bounce
+    "shakeEnabled": true        // shake side-to-side during a drag to fold the panel into its band (shade);
+                                // shake again — or double-click the band — to restore
+  },
   "editor": {                   // typography & colors, applied to editor AND reader
     "fontFamily": null,         // null → system font stack; any CSS font-family string
     "monoFamily": null,         // null → ui-monospace stack
@@ -96,6 +105,9 @@ Rules:
 - `motion.*` choreographs every show/hide (see **Motion (Arrival)** below);
   applied live, so the next note you open — or the next Hyper+B — uses the new
   feel. `enabled: false` restores the instant behavior exactly.
+- `physics.*` is read at each gesture, so edits apply to the very next drag —
+  see **Panel physics** below. macOS **Reduce Motion** disables the fling and
+  shake gestures regardless of these values.
 - `editor.*` maps to the web bundle's CSS custom properties
   (`--blink-font-size`, `--blink-text`, …) and is pushed over the bridge via
   `window.blink.setTheme`. The full variable table lives in
@@ -157,6 +169,27 @@ Where the choreography shows up:
 - **Focus mode** recedes the non-key panels a hair (a subtle depth cue), so the
   note you're writing stands proud. Transform-only — window positions never
   move.
+
+## Panel physics
+
+Notes aren't just placed — they can be thrown. `physics.*` governs the two
+gestures on a panel's top band (the invisible 24pt drag strip along its top
+edge):
+
+- **Fling.** Drag a panel and release it with speed: it glides on with
+  momentum, decays exponentially (`flingFriction`), and bounces off the edges
+  of the screen it's mostly on, keeping `bounceDamping` of its speed per hit.
+  Below `flingMinVelocity` a release is just a drop. Any new grab, close, or
+  programmatic placement kills a glide mid-flight.
+- **Shake-to-shade.** Shake the panel side-to-side mid-drag (~3 reversals in
+  0.6s, ≥40pt each, little vertical travel) and it folds up into its top band,
+  windowshade-style. Shake again — or double-click the band — and it unfolds
+  back to its full frame. Resizing is pinned while shaded so nothing fights
+  the fold.
+
+Geometry is persisted only when a panel is at rest — never mid-glide — and
+always as the UNSHADED frame, so a note that was shaded when Blink quit still
+relaunches full-size. The shaded state itself is session-only.
 
 ## What does NOT live here
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,6 +22,8 @@ Rules:
 
 ```jsonc
 {
+  "appearance": "auto",         // app-wide light/dark: "auto" (follow macOS) | "light" | "dark"
+                                // "auto" tracks the system live; menubar → Appearance overrides it
   "behavior": {
     "restoreSession": true,     // reopen last session's panels at launch
     "defaultMode": "read",      // "read" | "edit" — mode for notes with no remembered mode

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arach/blink",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Spatial notes for macOS — native floating panels and an agent-first CLI over local Markdown.",
   "homepage": "https://blink.arach.dev",
   "bugs": {

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -63,6 +63,11 @@ else
   echo "warning: web/editor/dist/editor.html missing — note panels will not load an editor" >&2
 fi
 
+# Keep local bundles truthful: the same package version drives the CLI, npm,
+# releases, and the in-panel build signature.
+package_version="$(bun -p 'require("./packages/npm/package.json").version')"
+marketing_version="${package_version%%-*}"
+
 cat > "$app_path/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -85,9 +90,9 @@ cat > "$app_path/Contents/Info.plist" <<PLIST
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.0.0</string>
+  <string>${marketing_version}</string>
   <key>CFBundleVersion</key>
-  <string>1</string>
+  <string>${marketing_version}</string>
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>
   <key>LSUIElement</key>

--- a/web/editor/README.md
+++ b/web/editor/README.md
@@ -88,7 +88,7 @@ hard-coded values. Native code overrides them at runtime via
 | `--blink-code-bg` | `rgba(255,255,255,0.07)` | Code chip / block background. |
 | `--blink-code-text` | `rgba(255,255,255,0.8)` | Code text (inline + block). |
 | `--blink-caret` | `#ffffff` | Text caret / cursor. |
-| `--blink-selection` | `rgba(255,255,255,0.18)` | Selection highlight (+ selection match). |
+| `--blink-selection` | `rgba(255,255,255,0.18)` | Editor and reader selection highlight (+ selection match); light mode supplies a stronger amber wash. |
 | `--blink-h1-size` | `20px` | H1 size (reader). Editor derives `calc(… - 3px)` → 17px. |
 | `--blink-h2-size` | `17px` | H2 size (reader). Editor derives `calc(… - 3px)` → 14px. |
 | `--blink-h3-size` | `15px` | H3–H6 size (reader). Editor derives `calc(… - 3px)` → 12px. |

--- a/web/editor/build.mjs
+++ b/web/editor/build.mjs
@@ -104,6 +104,13 @@ const PAGE_CSS = `
    * the keyframes well-defined if an entrance ever fires without one. */
   --blink-enter-ms: 260ms;
 }
+
+/* Reader mode uses native DOM selection rather than CodeMirror's painted
+ * selection layer. Give it the same quiet, themeable treatment. */
+::selection {
+  background: var(--blink-selection);
+}
+
 * { box-sizing: border-box; }
 html, body {
   margin: 0;

--- a/web/editor/src/theme.ts
+++ b/web/editor/src/theme.ts
@@ -64,9 +64,12 @@ export const blinkTheme: Extension = EditorView.theme(
     "&.cm-focused .cm-cursor": {
       borderLeftColor: "var(--blink-caret)",
     },
-    // Selection: works for both native and drawSelection layers.
-    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, ::selection": {
-      backgroundColor: "var(--blink-selection)",
+    // `drawSelection()` ships a dark fallback that wins on translucent/light
+    // panels unless we override its painted layer explicitly. Keep native
+    // selection transparent (CodeMirror's base rule does that) and make the
+    // drawn rectangles use Blink's scheme-aware color.
+    "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground": {
+      backgroundColor: "var(--blink-selection) !important",
     },
     ".cm-selectionMatch": {
       backgroundColor: "var(--blink-selection)",


### PR DESCRIPTION
## Summary
- add panel fling physics, curated note actions, and safer animator lifecycle handling
- add the copyable note ID, subtle top drag affordance, and balanced version / ID / style footer
- add app-wide auto/light/dark appearance across notes, popover, drape, focus, and grid surfaces
- polish the capture popover and hot-apply note presentation metadata
- replace the opaque selected-text block with a scheme-aware selection wash
- bump the CLI and npm package to 2.0.3

## Verification
- `swift test` — 88 tests passed
- `swift build --product blink`
- `.build/debug/blink --version` → `2.0.3`
- `(cd web/editor && bun run build)`
- `./tools/release/ship.sh --dry-run`
- live macOS QA: edit/read chrome, copyable ID, direct style picker, and light-mode text selection

## Release
After merge, publish GitHub release `v2.0.3`, then push `npm-v2.0.3` to trigger the canonical provenance-enabled npm workflow.