### PR TITLE
🎨 Add reusable branded note treatments

### DIFF
--- a/Sources/BlinkApp/BlinkConfig.swift
+++ b/Sources/BlinkApp/BlinkConfig.swift
@@ -56,6 +56,13 @@ struct BlinkConfig: Codable, Equatable {
         var shadow: Bool = true
         var defaultWidth: Double = 420
         var defaultHeight: Double = 340
+        /// Optional CSS surface color painted by the web sheet. `nil` keeps
+        /// glass transparent; treatments can supply an opaque brand canvas.
+        var background: String?
+        /// Optional identity mark shown in the panel's top-left chrome. Relative
+        /// paths resolve under `$BLINK_HOME/attachments`; note markdown never
+        /// needs to carry presentation-only brand assets.
+        var mark: String?
 
         init() {}
         init(from decoder: Decoder) throws {
@@ -68,6 +75,8 @@ struct BlinkConfig: Codable, Equatable {
             shadow = try c.decodeIfPresent(Bool.self, forKey: .shadow) ?? true
             defaultWidth = try c.decodeIfPresent(Double.self, forKey: .defaultWidth) ?? 420
             defaultHeight = try c.decodeIfPresent(Double.self, forKey: .defaultHeight) ?? 340
+            background = try c.decodeIfPresent(String.self, forKey: .background)
+            mark = try c.decodeIfPresent(String.self, forKey: .mark)
         }
 
         var visualEffectMaterial: NSVisualEffectView.Material {
@@ -182,6 +191,7 @@ struct BlinkConfig: Codable, Equatable {
     struct Editor: Codable, Equatable {
         var fontFamily: String?
         var monoFamily: String?
+        var titleFamily: String?
         var fontSize: Double = 13
         var lineHeight: Double = 1.75
         var paddingX: Double = 20
@@ -189,8 +199,12 @@ struct BlinkConfig: Codable, Equatable {
         var textColor: String?
         var textStrongColor: String?
         var textMutedColor: String?
+        var dimColor: String?
+        var borderColor: String?
         var accentColor: String?
+        var accentDimColor: String?
         var codeBackground: String?
+        var codeTextColor: String?
         var caretColor: String?
         var selectionColor: String?
         var h1Size: Double?
@@ -202,6 +216,7 @@ struct BlinkConfig: Codable, Equatable {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             fontFamily = try c.decodeIfPresent(String.self, forKey: .fontFamily)
             monoFamily = try c.decodeIfPresent(String.self, forKey: .monoFamily)
+            titleFamily = try c.decodeIfPresent(String.self, forKey: .titleFamily)
             fontSize = try c.decodeIfPresent(Double.self, forKey: .fontSize) ?? 13
             lineHeight = try c.decodeIfPresent(Double.self, forKey: .lineHeight) ?? 1.75
             paddingX = try c.decodeIfPresent(Double.self, forKey: .paddingX) ?? 20
@@ -209,8 +224,12 @@ struct BlinkConfig: Codable, Equatable {
             textColor = try c.decodeIfPresent(String.self, forKey: .textColor)
             textStrongColor = try c.decodeIfPresent(String.self, forKey: .textStrongColor)
             textMutedColor = try c.decodeIfPresent(String.self, forKey: .textMutedColor)
+            dimColor = try c.decodeIfPresent(String.self, forKey: .dimColor)
+            borderColor = try c.decodeIfPresent(String.self, forKey: .borderColor)
             accentColor = try c.decodeIfPresent(String.self, forKey: .accentColor)
+            accentDimColor = try c.decodeIfPresent(String.self, forKey: .accentDimColor)
             codeBackground = try c.decodeIfPresent(String.self, forKey: .codeBackground)
+            codeTextColor = try c.decodeIfPresent(String.self, forKey: .codeTextColor)
             caretColor = try c.decodeIfPresent(String.self, forKey: .caretColor)
             selectionColor = try c.decodeIfPresent(String.self, forKey: .selectionColor)
             h1Size = try c.decodeIfPresent(Double.self, forKey: .h1Size)
@@ -228,26 +247,56 @@ struct BlinkConfig: Codable, Equatable {
     struct Treatment: Codable, Equatable {
         var sheet: String?
         var accent: String?
+        var accentDim: String?
         var font: String?
+        var mono: String?
+        var titleFont: String?
         var fontSize: Double?
         var lineHeight: Double?
+        var background: String?
+        var text: String?
+        var textStrong: String?
+        var textMuted: String?
+        var dim: String?
+        var border: String?
+        var codeBackground: String?
+        var codeText: String?
+        var caret: String?
+        var selection: String?
         var tint: Double?
         var tintRead: Double?
         var tintEdit: Double?
         var radius: Double?
+        /// Relative path under `$BLINK_HOME/attachments` for a restrained
+        /// identity mark in the panel's top-left chrome.
+        var mark: String?
 
         init() {}
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             sheet = try c.decodeIfPresent(String.self, forKey: .sheet)
             accent = try c.decodeIfPresent(String.self, forKey: .accent)
+            accentDim = try c.decodeIfPresent(String.self, forKey: .accentDim)
             font = try c.decodeIfPresent(String.self, forKey: .font)
+            mono = try c.decodeIfPresent(String.self, forKey: .mono)
+            titleFont = try c.decodeIfPresent(String.self, forKey: .titleFont)
             fontSize = try c.decodeIfPresent(Double.self, forKey: .fontSize)
             lineHeight = try c.decodeIfPresent(Double.self, forKey: .lineHeight)
+            background = try c.decodeIfPresent(String.self, forKey: .background)
+            text = try c.decodeIfPresent(String.self, forKey: .text)
+            textStrong = try c.decodeIfPresent(String.self, forKey: .textStrong)
+            textMuted = try c.decodeIfPresent(String.self, forKey: .textMuted)
+            dim = try c.decodeIfPresent(String.self, forKey: .dim)
+            border = try c.decodeIfPresent(String.self, forKey: .border)
+            codeBackground = try c.decodeIfPresent(String.self, forKey: .codeBackground)
+            codeText = try c.decodeIfPresent(String.self, forKey: .codeText)
+            caret = try c.decodeIfPresent(String.self, forKey: .caret)
+            selection = try c.decodeIfPresent(String.self, forKey: .selection)
             tint = try c.decodeIfPresent(Double.self, forKey: .tint)
             tintRead = try c.decodeIfPresent(Double.self, forKey: .tintRead)
             tintEdit = try c.decodeIfPresent(Double.self, forKey: .tintEdit)
             radius = try c.decodeIfPresent(Double.self, forKey: .radius)
+            mark = try c.decodeIfPresent(String.self, forKey: .mark)
         }
     }
 
@@ -302,14 +351,28 @@ struct BlinkConfig: Codable, Equatable {
     mutating func apply(treatment t: Treatment) {
         if let v = t.sheet { panel.sheet = v }
         if let v = t.accent { editor.accentColor = v }
+        if let v = t.accentDim { editor.accentDimColor = v }
         if let v = t.font { editor.fontFamily = v }
+        if let v = t.mono { editor.monoFamily = v }
+        if let v = t.titleFont { editor.titleFamily = v }
         if let v = t.fontSize { editor.fontSize = clamp(v, 6, 48) }
         if let v = t.lineHeight { editor.lineHeight = clamp(v, 0.8, 3.0) }
+        if let v = t.background { panel.background = v }
+        if let v = t.text { editor.textColor = v }
+        if let v = t.textStrong { editor.textStrongColor = v }
+        if let v = t.textMuted { editor.textMutedColor = v }
+        if let v = t.dim { editor.dimColor = v }
+        if let v = t.border { editor.borderColor = v }
+        if let v = t.codeBackground { editor.codeBackground = v }
+        if let v = t.codeText { editor.codeTextColor = v }
+        if let v = t.caret { editor.caretColor = v }
+        if let v = t.selection { editor.selectionColor = v }
         // `tint` is shorthand for both; explicit read/edit win over it.
         if let v = t.tint { let c = clamp(v, 0, 1); panel.tintRead = c; panel.tintEdit = c }
         if let v = t.tintRead { panel.tintRead = clamp(v, 0, 1) }
         if let v = t.tintEdit { panel.tintEdit = clamp(v, 0, 1) }
         if let v = t.radius { panel.cornerRadius = clamp(v, 0, 40) }
+        if let v = t.mark { panel.mark = v }
     }
 
     /// The loose per-note overrides as a treatment (everything but `style`/`slot`).
@@ -336,7 +399,9 @@ struct BlinkConfig: Codable, Equatable {
         var vars: [String: String] = [
             "--blink-font-size": "\(editor.fontSize)px",
             "--blink-line-height": "\(editor.lineHeight)",
-            "--blink-pad-x": "\(editor.paddingX)px",
+            // A top-left identity mark earns a small content gutter so the
+            // chrome never overlaps the first heading or editor source.
+            "--blink-pad-x": "\(panel.mark == nil ? editor.paddingX : max(editor.paddingX, 56))px",
             "--blink-pad-y": "\(editor.paddingY)px",
         ]
         if scheme == .light {
@@ -352,11 +417,24 @@ struct BlinkConfig: Codable, Equatable {
         }
         if let v = editor.fontFamily { vars["--blink-font-family"] = v }
         if let v = editor.monoFamily { vars["--blink-mono-family"] = v }
+        if let v = editor.titleFamily { vars["--blink-title-family"] = v }
+        if let v = panel.background { vars["--blink-sheet-bg"] = v }
         if let v = editor.textColor { vars["--blink-text"] = v }
         if let v = editor.textStrongColor { vars["--blink-text-strong"] = v }
-        if let v = editor.textMutedColor { vars["--blink-text-muted"] = v }
+        if let v = editor.textMutedColor {
+            vars["--blink-text-muted"] = v
+            vars["--blink-quote-text"] = v
+        }
+        if let v = editor.dimColor { vars["--blink-marker"] = v }
+        if let v = editor.borderColor {
+            vars["--blink-quote-border"] = v
+            vars["--blink-rule"] = v
+            vars["--blink-frame"] = v
+        }
         if let v = editor.accentColor { vars["--blink-accent"] = v }
+        if let v = editor.accentDimColor { vars["--blink-accent-dim"] = v }
         if let v = editor.codeBackground { vars["--blink-code-bg"] = v }
+        if let v = editor.codeTextColor { vars["--blink-code-text"] = v }
         if let v = editor.caretColor { vars["--blink-caret"] = v }
         if let v = editor.selectionColor { vars["--blink-selection"] = v }
         if let v = editor.h1Size { vars["--blink-h1-size"] = "\(v)px" }

--- a/Sources/BlinkApp/NotePanel.swift
+++ b/Sources/BlinkApp/NotePanel.swift
@@ -4,6 +4,50 @@ import HudsonObservability
 import SwiftUI
 import WebKit
 
+/// Root panel surface that owns hover tracking across all descendants,
+/// including WKWebView. It also reconciles the current pointer after launch so
+/// a panel opened underneath the cursor does not wait for a synthetic re-entry.
+@MainActor
+private final class PanelHoverView: NSView {
+    var onHoverChanged: ((Bool) -> Void)?
+
+    private var hoverTrackingArea: NSTrackingArea?
+    private var pointerInside = false
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let hoverTrackingArea { removeTrackingArea(hoverTrackingArea) }
+        let next = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self
+        )
+        addTrackingArea(next)
+        hoverTrackingArea = next
+        DispatchQueue.main.async { [weak self] in self?.syncPointerLocation() }
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        DispatchQueue.main.async { [weak self] in self?.syncPointerLocation() }
+    }
+
+    override func mouseEntered(with event: NSEvent) { setPointerInside(true) }
+    override func mouseExited(with event: NSEvent) { setPointerInside(false) }
+
+    private func syncPointerLocation() {
+        guard let window else { return }
+        let windowPoint = window.convertPoint(fromScreen: NSEvent.mouseLocation)
+        setPointerInside(bounds.contains(convert(windowPoint, from: nil)))
+    }
+
+    private func setPointerInside(_ inside: Bool) {
+        guard inside != pointerInside else { return }
+        pointerInside = inside
+        onHoverChanged?(inside)
+    }
+}
+
 /// A floating glass panel that IS a note — Blink's atomic unit.
 /// Glass material + a transparent CodeMirror/reader webview; chrome is minimal.
 /// Geometry persists via frame autosave (full spatial state lands in M3).
@@ -55,11 +99,12 @@ final class NotePanel: NSPanel {
     private let glassView = NSVisualEffectView()
     /// Plain root content view; the glass material is a sibling behind the
     /// content so flat sheets can hide the glass without hiding the webview.
-    private let container = NSView()
+    private let container = PanelHoverView()
     private var readTint: CGFloat
     private var editTint: CGFloat
 
     private var modePillView: NSView?
+    private var themeMarkView: NSView?
     private var noteIDView: NSView?
     private var versionMetadataView: NSView?
     private var styleMetadataView: NSView?
@@ -103,6 +148,7 @@ final class NotePanel: NSPanel {
         isFloatingPanel = true
         level = .floating
         hidesOnDeactivate = false
+        acceptsMouseMovedEvents = true
         isMovableByWindowBackground = true
         // Title never renders (borderless) but names the window for AX/scripts.
         self.title = title
@@ -194,8 +240,10 @@ final class NotePanel: NSPanel {
         pill.alphaValue = 0
         container.addSubview(pill)
         NSLayoutConstraint.activate([
-            pill.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
-            pill.topAnchor.constraint(equalTo: container.topAnchor, constant: 8),
+            pill.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            pill.topAnchor.constraint(equalTo: container.topAnchor, constant: 18),
+            pill.widthAnchor.constraint(equalToConstant: 50),
+            pill.heightAnchor.constraint(equalToConstant: 22),
         ])
         modePillView = pill
 
@@ -229,6 +277,20 @@ final class NotePanel: NSPanel {
         ])
         versionMetadataView = versionHost
 
+        // One stable 24pt cell in the TOP-LEFT CHROME: brand at rest, close on
+        // hover. The content gutter stays fixed, so chrome never shifts text.
+        let markHost = NSHostingView(rootView: ThemeMarkBadge(state: modeState))
+        markHost.translatesAutoresizingMaskIntoConstraints = false
+        markHost.alphaValue = modeState.hasThemeMark ? 0.94 : 0
+        container.addSubview(markHost)
+        NSLayoutConstraint.activate([
+            markHost.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            markHost.topAnchor.constraint(equalTo: container.topAnchor, constant: 17),
+            markHost.widthAnchor.constraint(equalToConstant: 24),
+            markHost.heightAnchor.constraint(equalToConstant: 24),
+        ])
+        themeMarkView = markHost
+
         let noteIDHost = NSHostingView(
             rootView: NoteIdentifierBadge(noteID: noteID) { [weak self] in
                 self?.copyNoteID()
@@ -245,9 +307,7 @@ final class NotePanel: NSPanel {
         ])
         noteIDView = noteIDHost
 
-        // Close glyph (✕) mirrors the mode pill: hover-earned, top-LEFT, in the
-        // title area. This (and ⌘W) is how a note is dismissed — close(), which
-        // still runs the windowWillClose flush path.
+        // Close occupies the exact same fixed cell as the resting brand.
         let closeHost = NSHostingView(
             rootView: CloseGlyph { [weak self] in
                 self?.close()
@@ -257,8 +317,10 @@ final class NotePanel: NSPanel {
         closeHost.alphaValue = 0
         container.addSubview(closeHost)
         NSLayoutConstraint.activate([
-            closeHost.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 8),
-            closeHost.topAnchor.constraint(equalTo: container.topAnchor, constant: 8),
+            closeHost.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            closeHost.topAnchor.constraint(equalTo: container.topAnchor, constant: 17),
+            closeHost.widthAnchor.constraint(equalToConstant: 24),
+            closeHost.heightAnchor.constraint(equalToConstant: 24),
         ])
         closeButtonView = closeHost
 
@@ -276,13 +338,12 @@ final class NotePanel: NSPanel {
         ])
         focusGlyphView = focusHost
 
-        container.addTrackingArea(
-            NSTrackingArea(
-                rect: .zero,
-                options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
-                owner: self
-            )
-        )
+        container.onHoverChanged = { [weak self] _ in
+            // WKWebView can make an ancestor tracking area report a transient
+            // exit while the pointer is still inside the panel. Screen-frame
+            // containment is the authoritative state.
+            self?.syncHoveredFromPointer()
+        }
 
         contentView = container
 
@@ -414,21 +475,35 @@ final class NotePanel: NSPanel {
 
     // MARK: - Hover-earned chrome
 
-    override func mouseEntered(with event: NSEvent) {
-        isHovered = true
-        updateChromeVisibility()
+    override func sendEvent(_ event: NSEvent) {
+        switch event.type {
+        case .mouseMoved, .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
+            syncHoveredFromPointer()
+        default:
+            break
+        }
+        super.sendEvent(event)
     }
 
-    override func mouseExited(with event: NSEvent) {
-        isHovered = false
+    private func syncHoveredFromPointer() {
+        setHovered(frame.contains(NSEvent.mouseLocation))
+    }
+
+    private func setHovered(_ hovered: Bool) {
+        guard hovered != isHovered else { return }
+        isHovered = hovered
         updateChromeVisibility()
     }
 
     private func updateChromeVisibility() {
+        // NSHostingView can fail to animate out of an initial zero alpha; make
+        // the mode control deterministic and reserve animation for the
+        // same-cell brand/close crossfade.
+        modePillView?.alphaValue = isHovered ? 1 : 0
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.15
-            modePillView?.animator().alphaValue = isHovered ? 1 : 0
             closeButtonView?.animator().alphaValue = isHovered ? 1 : 0
+            themeMarkView?.animator().alphaValue = isHovered || !modeState.hasThemeMark ? 0 : 0.94
             noteIDView?.animator().alphaValue = currentMode == "edit"
                 ? (isHovered ? 1 : 0.55)
                 : 0
@@ -513,6 +588,8 @@ final class NotePanel: NSPanel {
         modeState.style = notePresentation.style
         modeState.font = Self.displayFontName(theme.editor.fontFamily)
         modeState.fontSize = theme.editor.fontSize
+        modeState.mark = theme.panel.mark
+        themeMarkView?.alphaValue = isHovered || !modeState.hasThemeMark ? 0 : 0.94
     }
 
     private static func displayFontName(_ cssFamily: String?) -> String {
@@ -1195,6 +1272,11 @@ final class PanelModeState: ObservableObject {
     @Published var style: String?
     @Published var font: String = "System"
     @Published var fontSize: Double = 13
+    @Published var mark: String?
+
+    var hasThemeMark: Bool {
+        mark != nil
+    }
 }
 
 /// ✎/◧ mode segments; the active segment is lit. Hover-revealed, top-right.
@@ -1262,7 +1344,8 @@ private struct NoteIdentifierBadge: View {
     }
 }
 
-/// A tiny build signature at bottom-left, balancing identity and treatment.
+/// A tiny build signature at bottom-left. Theme identity never lives here;
+/// `ThemeMarkBadge` owns the top-left chrome cell above.
 private struct AppVersionLabel: View {
     let version: String
 
@@ -1273,6 +1356,55 @@ private struct AppVersionLabel: View {
             .lineLimit(1)
             .frame(height: 18)
             .help("Blink \(version)")
+    }
+}
+
+/// Theme identity in the panel's top-left chrome.
+private struct ThemeMarkBadge: View {
+    @ObservedObject var state: PanelModeState
+
+    var body: some View {
+        Group {
+            if let image = ThemeMarkLoader.image(named: state.mark) {
+                Image(nsImage: image)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 20, height: 20)
+                    .accessibilityLabel("Theme mark")
+            }
+        }
+        .frame(width: 24, height: 24)
+        .allowsHitTesting(false)
+        .help("Theme identity")
+    }
+}
+
+/// Resolve theme marks from Blink's attachment store, never from note markdown.
+/// Relative-only + symlink containment mirrors the web asset handler's boundary:
+/// a theme typo becomes an absent mark, not an arbitrary file read.
+private enum ThemeMarkLoader {
+    static func image(named raw: String?) -> NSImage? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("/") else { return nil }
+
+        let relative: String
+        if trimmed.hasPrefix("blink://attachments/") {
+            relative = String(trimmed.dropFirst("blink://attachments/".count))
+        } else {
+            relative = trimmed
+        }
+
+        let root = BlinkPaths.attachments().standardizedFileURL.resolvingSymlinksInPath()
+        let candidate = root.appendingPathComponent(relative)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        guard candidate.path.hasPrefix(root.path + "/"),
+              let values = try? candidate.resourceValues(forKeys: [.isRegularFileKey]),
+              values.isRegularFile == true
+        else { return nil }
+        return NSImage(contentsOf: candidate)
     }
 }
 
@@ -1457,12 +1589,13 @@ private struct CloseGlyph: View {
     var body: some View {
         Button(action: onTap) {
             Image(systemName: "xmark")
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(.white.opacity(0.55))
-                .frame(width: 18, height: 18)
+                .frame(width: 20, height: 20)
                 .background(.white.opacity(0.08), in: Circle())
         }
         .buttonStyle(.plain)
+        .frame(width: 24, height: 24)
         .help("Close (⌘W)")
     }
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -50,7 +50,9 @@ Rules:
     "tintEdit": 0.28,           // 0–1 tint in edit mode (focused writing surface)
     "shadow": true,             // window drop shadow
     "defaultWidth": 420,        // size for panels opening for the first time
-    "defaultHeight": 340
+    "defaultHeight": 340,
+    "background": null,         // optional CSS color; null keeps the glass sheet transparent
+    "mark": null                // optional identity mark from $BLINK_HOME/attachments
   },
   "focus": {
     "dim": 0.30                 // 0–1 strength of the focus-mode veil over everything else
@@ -79,6 +81,7 @@ Rules:
   "editor": {                   // typography & colors, applied to editor AND reader
     "fontFamily": null,         // null → system font stack; any CSS font-family string
     "monoFamily": null,         // null → ui-monospace stack
+    "titleFamily": null,        // null → body stack; headings/titles only
     "fontSize": 13,             // px
     "lineHeight": 1.75,
     "paddingX": 20,             // px
@@ -86,8 +89,12 @@ Rules:
     "textColor": null,          // any CSS color; null → rgba(255,255,255,0.85)
     "textStrongColor": null,    // headings/bold; default rgba(255,255,255,0.96)
     "textMutedColor": null,     // markers/list bullets; default rgba(255,255,255,0.45)
+    "dimColor": null,           // Markdown syntax markers
+    "borderColor": null,        // rules, quote borders, sheet frame
     "accentColor": null,        // links; default rgba(158,203,255,0.9)
+    "accentDimColor": null,      // source-mode link targets
     "codeBackground": null,     // default rgba(255,255,255,0.07)
+    "codeTextColor": null,       // inline + block code ink
     "caretColor": null,         // default white
     "selectionColor": null,     // default rgba(255,255,255,0.18)
     "h1Size": null,             // px, reader scale; default 20 (editor derives slightly smaller)
@@ -139,6 +146,50 @@ Maximum-contrast writing mode:
   "focus": { "dim": 0.45 }
 }
 ```
+
+Reusable treatment with a restrained identity mark:
+
+```json
+{
+  "styles": {
+    "scout-control": {
+      "background": "#070908",
+      "text": "#f2f4ef",
+      "textStrong": "#f2f4ef",
+      "textMuted": "#aab1a7",
+      "dim": "#777e75",
+      "border": "rgba(239,244,237,.09)",
+      "accent": "#a6ef87",
+      "accentDim": "rgba(166,239,135,.58)",
+      "font": "\"JetBrains Mono\", ui-monospace, Menlo, monospace",
+      "mono": "\"JetBrains Mono\", ui-monospace, Menlo, monospace",
+      "titleFont": "\"JetBrains Mono\", ui-monospace, Menlo, monospace",
+      "codeBackground": "#111411",
+      "codeText": "#f2f4ef",
+      "caret": "#a6ef87",
+      "selection": "rgba(166,239,135,.1)",
+      "radius": 6,
+      "mark": "theme-marks/openscout-scout-hex.svg"
+    }
+  }
+}
+```
+
+`panel.mark` and `styles.<name>.mark` are relative paths under
+`$BLINK_HOME/attachments` (or the default Blink attachments directory). The
+mark appears at 20px in a 24pt top-left chrome cell and yields that position to
+the close control on hover. Marked themes receive a compact content gutter so
+the identity never overlaps the first heading or editor source. Keeping it in
+the treatment instead of the markdown body preserves the note as portable,
+presentation-free Markdown. Absolute paths and paths escaping the attachments
+directory are ignored.
+
+Treatments are partial overlays. In addition to the original
+`sheet`/`accent`/`font`/`fontSize`/`lineHeight`/`tint*`/`radius` fields, they
+accept `background`, `text`, `textStrong`, `textMuted`, `accentDim`, `mono`,
+`titleFont`, `dim`, `border`, `codeBackground`, `codeText`, `caret`, and
+`selection`. These map to the same editor and sheet variables as their global
+config counterparts, but apply only to notes that reference that named style.
 
 ## Motion (Arrival)
 

--- a/web/editor/README.md
+++ b/web/editor/README.md
@@ -2,10 +2,11 @@
 
 A vanilla [CodeMirror 6](https://codemirror.net/) markdown editor **plus a
 rendered read mode**, built to a single self-contained `dist/editor.html` and
-hosted inside a native macOS NSPanel via `WKWebView`. The page paints no surface
-of its own — the native glass panel behind the web view provides the background,
-blur, and shadow, so html/body and every editor/reader layer are fully
-transparent.
+hosted inside a native macOS NSPanel via `WKWebView`. By default the page paints
+no surface of its own — the native glass panel behind the web view provides the
+background, blur, and shadow. A reusable treatment may opt into an exact sheet
+canvas with `--blink-sheet-bg`; every editor/reader content layer remains
+transparent over it.
 
 Two surfaces flip **in place** on the same glass:
 
@@ -75,10 +76,12 @@ hard-coded values. Native code overrides them at runtime via
 | --- | --- | --- |
 | `--blink-font-family` | `-apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, sans-serif` | Body/UI font (editor + reader). |
 | `--blink-mono-family` | `ui-monospace, "SF Mono", SFMono-Regular, Menlo, Monaco, "Cascadia Code", monospace` | Monospace font (inline + block code). |
+| `--blink-title-family` | `var(--blink-font-family)` | Heading/title font in editor and reader. |
 | `--blink-font-size` | `13px` | Base text size (editor, reader, marker reset, empty placeholder). |
 | `--blink-line-height` | `1.75` | Base line height (editor scroller + reader). |
 | `--blink-pad-x` | `20px` | Horizontal content padding (editor + reader + placeholder). |
 | `--blink-pad-y` | `16px` | Vertical content padding (editor + reader + placeholder). |
+| `--blink-sheet-bg` | `transparent` | Optional exact sheet canvas; transparent preserves native glass. |
 | `--blink-text` | `rgba(255,255,255,0.85)` | Body text; also editor emphasis (`em`). |
 | `--blink-text-strong` | `rgba(255,255,255,0.96)` | Headings, `strong`, table headers. |
 | `--blink-text-muted` | `rgba(255,255,255,0.45)` | List content + markers, `del`/strikethrough, gutter. |

--- a/web/editor/build.mjs
+++ b/web/editor/build.mjs
@@ -43,12 +43,17 @@ const PAGE_CSS = `
   /* Typography */
   --blink-font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --blink-mono-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Monaco, "Cascadia Code", monospace;
+  --blink-title-family: var(--blink-font-family);
   --blink-font-size: 13px;
   --blink-line-height: 1.75;
 
   /* Content padding */
   --blink-pad-x: 20px;
   --blink-pad-y: 16px;
+
+  /* Sheet surface. Transparent preserves the native glass default; reusable
+   * treatments can paint an exact brand canvas without choosing card/serif. */
+  --blink-sheet-bg: transparent;
 
   /* Text colors */
   --blink-text: rgba(255, 255, 255, 0.85);
@@ -117,11 +122,12 @@ html, body {
   padding: 0;
   width: 100%;
   height: 100vh;
-  background: transparent;
   overflow: hidden;
   /* Prevent the WKWebView from painting an opaque backdrop. */
   -webkit-user-select: text;
 }
+html { background: transparent; }
+body { background: var(--blink-sheet-bg); }
 #editor {
   width: 100%;
   height: 100vh;
@@ -168,6 +174,7 @@ html, body {
 .blink-reader h4,
 .blink-reader h5,
 .blink-reader h6 {
+  font-family: var(--blink-title-family);
   font-weight: 600;
   line-height: 1.3;
   margin: 1.4em 0 0.5em;
@@ -707,10 +714,12 @@ async function main() {
   const THEME_VARS = [
     "--blink-font-family",
     "--blink-mono-family",
+    "--blink-title-family",
     "--blink-font-size",
     "--blink-line-height",
     "--blink-pad-x",
     "--blink-pad-y",
+    "--blink-sheet-bg",
     "--blink-text",
     "--blink-text-strong",
     "--blink-text-muted",

--- a/web/editor/src/theme.ts
+++ b/web/editor/src/theme.ts
@@ -128,41 +128,52 @@ export const blinkHighlight: Extension = syntaxHighlighting(
     {
       tag: t.heading1,
       color: "var(--blink-text-strong)",
+      fontFamily: "var(--blink-title-family)",
       fontWeight: "700",
       fontSize: "calc(var(--blink-h1-size) - 3px)",
     },
     {
       tag: t.heading2,
       color: "var(--blink-text-strong)",
+      fontFamily: "var(--blink-title-family)",
       fontWeight: "650",
       fontSize: "calc(var(--blink-h2-size) - 3px)",
     },
     {
       tag: t.heading3,
       color: "var(--blink-text-strong)",
+      fontFamily: "var(--blink-title-family)",
       fontWeight: "600",
       fontSize: "calc(var(--blink-h3-size) - 3px)",
     },
     {
       tag: t.heading4,
       color: "var(--blink-text-strong)",
+      fontFamily: "var(--blink-title-family)",
       fontWeight: "600",
       fontSize: "calc(var(--blink-h3-size) - 3px)",
     },
     {
       tag: t.heading5,
       color: "var(--blink-text-strong)",
+      fontFamily: "var(--blink-title-family)",
       fontWeight: "600",
       fontSize: "calc(var(--blink-h3-size) - 3px)",
     },
     {
       tag: t.heading6,
       color: "var(--blink-text-strong)",
+      fontFamily: "var(--blink-title-family)",
       fontWeight: "600",
       fontSize: "calc(var(--blink-h3-size) - 3px)",
     },
     // Generic heading fallback (Setext bodies not covered above).
-    { tag: t.heading, color: "var(--blink-text-strong)", fontWeight: "600" },
+    {
+      tag: t.heading,
+      color: "var(--blink-text-strong)",
+      fontFamily: "var(--blink-title-family)",
+      fontWeight: "600",
+    },
 
     // Formatting markers (#, *, _, `, >, list bullets, link brackets) — dimmed.
     // Reset weight/size to base so a marker inside a heading stays small & light.


### PR DESCRIPTION
## Summary
- add reusable per-style surface, typography, and color treatment fields
- support a safe optional theme mark in Blink’s top-left chrome with stable hover controls
- expose the matching editor CSS variables and document the Scout treatment pattern

## Verification
- `swift test` (88 tests, 10 suites)
- `bun run build` in `web/editor`
- debug app build/restart and visual inspection of the Scout treatment