### PR TITLE
Ship Blink 2.0.4 workspaces and discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,11 @@ The v1 Tauri app remains at tag `v1-final` — port lessons, not code.
   (local, untracked)
 - Notes CLI (agent-first): `docs/cli.md` — `blink ls/cat/new/search/rm/path`
   over the same files; the app reconciles external writes live.
+- Notes Workspaces (agent-first): `docs/workspaces.md` — `blink workspace`
+  creates a named group of notes and brands it. Definition (title + brand) in
+  `config.json`; membership is one `blink.workspace` frontmatter key, so note
+  markdown stays portable. Brands are generic treatments — never hardcode a
+  specific product's identity into the app.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,11 @@ The v1 Tauri app remains at tag `v1-final` — port lessons, not code.
   (local, untracked)
 - Notes CLI (agent-first): `docs/cli.md` — `blink ls/cat/new/search/rm/path`
   over the same files; the app reconciles external writes live.
+- Notes Workspaces (agent-first): `docs/workspaces.md` — `blink workspace`
+  creates a named group of notes and brands it. Definition (title + brand) in
+  `config.json`; membership is one `blink.workspace` frontmatter key, so note
+  markdown stays portable. Brands are generic treatments — never hardcode a
+  specific product's identity into the app.
 
 ## Commands
 

--- a/Sources/BlinkApp/AppDelegate.swift
+++ b/Sources/BlinkApp/AppDelegate.swift
@@ -13,6 +13,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var panelManager: PanelManager!
     private var model: AppModel!
     private var settingsWindow: NSWindow?
+    private var guideWindow: NSWindow?
+    private var commandPaletteController: BlinkCommandPaletteController?
+    private var activityCatalog: BlinkActivityCatalog?
+    private var commandRequestObserver: NSObjectProtocol?
     private var notesWatcher: DirectoryWatcher?
     private let log = HudLogger(category: "blink.app")
 
@@ -30,6 +34,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         panelManager = PanelManager(store: store)
         model = AppModel(store: store, panelManager: panelManager)
         panelManager.startObservingStore()
+        configureDiscovery()
+        commandRequestObserver = NotificationCenter.default.addObserver(
+            forName: .blinkCommandPaletteRequested,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.toggleCommandPalette(from: nil)
+            }
+        }
 
         // The filesystem is the API: external writers (the blink CLI, agents)
         // touch the Notes directory; reconcile diffs disk against memory and
@@ -96,6 +110,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// responder chain. Without this menu, WKWebView never receives them.
     private func installMainMenu() {
         let mainMenu = NSMenu()
+
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu(title: "Blink")
+        appMenuItem.submenu = appMenu
+        mainMenu.addItem(appMenuItem)
+
+        func appItem(
+            _ title: String,
+            action: Selector,
+            keyEquivalent: String,
+            modifiers: NSEvent.ModifierFlags = .command
+        ) {
+            let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
+            item.target = self
+            item.keyEquivalentModifierMask = modifiers
+            appMenu.addItem(item)
+        }
+
+        appItem("Commands…", action: #selector(menuCommands), keyEquivalent: "k")
+        appItem("Blink Guide", action: #selector(menuGuide), keyEquivalent: "?", modifiers: [.command])
+        appMenu.addItem(.separator())
+        appItem("Settings…", action: #selector(menuSettings), keyEquivalent: ",")
+        appMenu.addItem(.separator())
+        appItem("Quit Blink", action: #selector(menuQuit), keyEquivalent: "q")
+
         let editMenuItem = NSMenuItem()
         let editMenu = NSMenu(title: "Edit")
         editMenuItem.submenu = editMenu
@@ -209,6 +248,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         HotkeyManager.shared.unregisterAll()
+        if let commandRequestObserver {
+            NotificationCenter.default.removeObserver(commandRequestObserver)
+        }
     }
 
     private func newNote() {
@@ -268,6 +310,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 openSettings: { [weak self] in
                     self?.popover?.performClose(nil)
                     self?.openSettings()
+                },
+                openGuide: { [weak self] in
+                    self?.popover?.performClose(nil)
+                    self?.openGuide()
+                },
+                showCommands: { [weak self] in
+                    let invocationWindow = self?.popover?.contentViewController?.view.window
+                    self?.popover?.performClose(nil)
+                    self?.toggleCommandPalette(from: invocationWindow)
                 },
                 toggleBlink: { [weak self] in
                     self?.popover?.performClose(nil)
@@ -394,8 +445,72 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         openSettings()
     }
 
+    @objc private func menuCommands() {
+        toggleCommandPalette(from: NSApp.keyWindow)
+    }
+
+    @objc private func menuGuide() {
+        openGuide()
+    }
+
     @objc private func menuQuit() {
         NSApp.terminate(nil)
+    }
+
+    private func configureDiscovery() {
+        let handlers = BlinkActivityCatalog.Handlers(
+            newNote: { [weak self] in self?.newNote() },
+            toggleBlink: { [weak self] in self?.panelManager.toggleBlink() },
+            showGrid: { [weak self] in self?.panelManager.toggleGridOverlay() },
+            openSettings: { [weak self] in self?.openSettings() },
+            openGuide: { [weak self] in self?.openGuide() },
+            revealNotesFolder: {
+                NSWorkspace.shared.activateFileViewerSelecting([Self.notesDirectory()])
+            },
+            openConfigFile: {
+                NSWorkspace.shared.open(BlinkConfigStore.shared.fileURL)
+            },
+            toggleCurrentNoteMode: { [weak self] in self?.panelManager.toggleCommandNoteMode() },
+            toggleCurrentNoteFocus: { [weak self] in self?.panelManager.toggleCommandNoteFocus() },
+            chooseCurrentNoteStyle: { [weak self] in self?.panelManager.chooseCommandNoteStyle() },
+            hideCurrentNote: { [weak self] in self?.panelManager.hideCommandNote() },
+            closeCurrentNote: { [weak self] in self?.panelManager.closeCommandNote() },
+            copyCurrentNoteID: { [weak self] in self?.panelManager.copyCommandNoteID() },
+            copyCurrentNoteMarkdown: { [weak self] in self?.panelManager.copyCommandNoteMarkdown() },
+            copyCurrentNoteFilePath: { [weak self] in self?.panelManager.copyCommandNoteFilePath() },
+            openCurrentNoteFile: { [weak self] in self?.panelManager.openCommandNoteFile() },
+            revealCurrentNoteInFinder: { [weak self] in self?.panelManager.revealCommandNoteInFinder() },
+            currentNoteAvailable: { [weak self] in self?.panelManager.hasCommandNotePanel ?? false }
+        )
+        let catalog = BlinkActivityCatalog(handlers: handlers)
+        activityCatalog = catalog
+        commandPaletteController = BlinkCommandPaletteController(
+            model: model,
+            activities: { [weak self] in self?.activityCatalog?.paletteActivities ?? [] }
+        )
+    }
+
+    private func toggleCommandPalette(from invocationWindow: NSWindow?) {
+        popover?.performClose(nil)
+        commandPaletteController?.toggle(from: invocationWindow)
+    }
+
+    private func openGuide() {
+        guard let activities = activityCatalog?.activities else { return }
+        if guideWindow == nil {
+            let host = NSHostingController(rootView: BlinkGuideView(activities: activities))
+            let window = NSWindow(contentViewController: host)
+            window.title = "Blink Guide"
+            window.styleMask = [.titled, .closable, .resizable]
+            window.setContentSize(NSSize(width: 780, height: 610))
+            window.contentMinSize = NSSize(width: 720, height: 520)
+            window.isReleasedWhenClosed = false
+            window.setFrameAutosaveName("blink.guide")
+            if window.frame.origin == .zero { window.center() }
+            guideWindow = window
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        guideWindow?.makeKeyAndOrderFront(nil)
     }
 
     private func openSettings() {
@@ -405,7 +520,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             )
             let window = NSWindow(contentViewController: host)
             window.title = "Blink Settings"
-            window.styleMask = [.titled, .closable]
+            window.styleMask = [.titled, .closable, .resizable]
+            window.setContentSize(NSSize(width: 760, height: 640))
+            window.contentMinSize = NSSize(width: 604, height: 540)
             // No explicit appearance — inherit NSApp.appearance, which
             // AppearanceManager pins (light/dark) or clears (auto → the OS).
             window.isReleasedWhenClosed = false
@@ -416,4 +533,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         NSApp.activate(ignoringOtherApps: true)
         settingsWindow?.makeKeyAndOrderFront(nil)
     }
+}
+
+extension Notification.Name {
+    static let blinkCommandPaletteRequested = Notification.Name("blink.commandPaletteRequested")
 }

--- a/Sources/BlinkApp/BlinkActivityCatalog.swift
+++ b/Sources/BlinkApp/BlinkActivityCatalog.swift
@@ -1,0 +1,667 @@
+import Foundation
+
+/// Stable identifiers shared by the command palette, Guide, and contextual
+/// hints. Raw values are persistence-safe: UI copy may change without changing
+/// the identity of an activity.
+enum BlinkActivityID: String, CaseIterable, Identifiable {
+    case newNote = "note.new"
+    case commandPalette = "app.command-palette"
+    case toggleBlink = "visibility.blink"
+    case showGrid = "arrange.grid"
+    case openSettings = "app.settings"
+    case openGuide = "app.guide"
+    case quitBlink = "app.quit"
+
+    case searchNotes = "popover.search"
+    case openSelectedNote = "popover.open-selected-note"
+    case createFromCapture = "popover.create-from-capture"
+    case dictateCapture = "popover.dictate"
+
+    case toggleReadEdit = "note.toggle-read-edit"
+    case toggleFocus = "note.toggle-focus"
+    case saveNote = "note.save"
+    case quietNote = "note.quiet"
+    case editReadingNote = "note.edit-from-reader"
+    case standardEditing = "editor.standard-editing"
+    case openNoteLink = "note.open-link"
+
+    case movePanel = "panel.move"
+    case resizePanel = "panel.resize"
+    case flingPanel = "panel.fling"
+    case shakeToShade = "panel.shake-to-shade"
+    case doubleClickToShade = "panel.double-click-to-shade"
+    case openNoteMenu = "panel.context-menu"
+    case placeOnGrid = "grid.place"
+    case cancelGrid = "grid.cancel"
+
+    case chooseNoteStyle = "note.choose-style"
+    case hideNote = "note.hide"
+    case closeNote = "note.close"
+    case copyNoteID = "note.copy-id"
+    case copyNoteMarkdown = "note.copy-markdown"
+    case copyNoteFilePath = "note.copy-file-path"
+    case openNoteFile = "note.open-file"
+    case revealNoteInFinder = "note.reveal-in-finder"
+    case revealNotesFolder = "files.reveal-notes-folder"
+    case openConfigFile = "files.open-config"
+
+    var id: String { rawValue }
+}
+
+/// Educational grouping used by the Guide. The order of `allCases` is the
+/// intended presentation order.
+enum BlinkActivityGroup: String, CaseIterable, Identifiable {
+    case capture = "Capture"
+    case findAndOpen = "Find & Open"
+    case arrange = "Arrange"
+    case readAndWrite = "Read & Write"
+    case focusAndVisibility = "Focus & Visibility"
+    case styleAndFiles = "Style & Files"
+
+    var id: String { rawValue }
+    var displayTitle: String { rawValue }
+}
+
+/// Where an activity's trigger is active. `global` means a registered system-
+/// wide Carbon hotkey; `application` means Blink must be frontmost.
+enum BlinkActivityScope: String, CaseIterable, Identifiable {
+    case global = "Global"
+    case application = "Blink"
+    case popover = "Popover"
+    case panel = "Panel"
+    case grid = "Grid"
+    case editor = "Editor"
+
+    var id: String { rawValue }
+    var displayTitle: String { rawValue }
+}
+
+/// One discoverable Blink capability. Resolvers intentionally remain closures:
+/// shortcuts and context can change while the Guide or palette is still open.
+@MainActor
+struct BlinkActivity: Identifiable {
+    typealias ShortcutResolver = @MainActor () -> String?
+    typealias Availability = @MainActor () -> Bool
+    typealias Action = @MainActor () -> Void
+
+    let id: BlinkActivityID
+    let title: String
+    let description: String
+    let symbolName: String
+    let group: BlinkActivityGroup
+    let scope: BlinkActivityScope
+    let keywords: [String]
+
+    private let shortcutResolver: ShortcutResolver
+    private let availability: Availability
+    private let execution: Action?
+
+    init(
+        id: BlinkActivityID,
+        title: String,
+        description: String,
+        symbolName: String,
+        group: BlinkActivityGroup,
+        scope: BlinkActivityScope,
+        keywords: [String] = [],
+        shortcut: @escaping ShortcutResolver = { nil },
+        availability: @escaping Availability = { true },
+        execution: Action? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.symbolName = symbolName
+        self.group = group
+        self.scope = scope
+        self.keywords = keywords
+        shortcutResolver = shortcut
+        self.availability = availability
+        self.execution = execution
+    }
+
+    /// Resolved on every read. Configurable bindings therefore hot-apply to
+    /// Settings, Guide, palette rows, and contextual key hints together.
+    var shortcutDisplay: String? { shortcutResolver() }
+
+    /// Dynamic context check (for example, whether a current note exists).
+    var isAvailable: Bool { availability() }
+
+    /// Help-only gestures have no execution closure and are excluded from the
+    /// command palette without needing a second metadata model.
+    var isExecutable: Bool { execution != nil }
+
+    /// Execute only when the activity is still available at invocation time.
+    func perform() {
+        guard isAvailable else { return }
+        execution?()
+    }
+
+    /// Multi-token, case-insensitive matching over user-facing and synonym
+    /// metadata. Every token must match, so "copy path" behaves predictably.
+    func matches(_ query: String) -> Bool {
+        let tokens = query.lowercased().split(whereSeparator: \Character.isWhitespace)
+        guard !tokens.isEmpty else { return true }
+        let haystack = ([title, description, group.displayTitle, scope.displayTitle] + keywords)
+            .joined(separator: " ")
+            .lowercased()
+        return tokens.allSatisfy { haystack.contains($0) }
+    }
+}
+
+/// The single metadata source for Blink's Guide, command palette, shortcut
+/// reference, and contextual hints. It knows no AppDelegate or panel-manager
+/// details; integration supplies those capabilities as closures.
+@MainActor
+struct BlinkActivityCatalog {
+    typealias Action = BlinkActivity.Action
+    typealias Predicate = BlinkActivity.Availability
+
+    struct Handlers {
+        var newNote: Action?
+        var toggleBlink: Action?
+        var showGrid: Action?
+        var openSettings: Action?
+        var openGuide: Action?
+        var revealNotesFolder: Action?
+        var openConfigFile: Action?
+
+        var toggleCurrentNoteMode: Action?
+        var toggleCurrentNoteFocus: Action?
+        var chooseCurrentNoteStyle: Action?
+        var hideCurrentNote: Action?
+        var closeCurrentNote: Action?
+        var copyCurrentNoteID: Action?
+        var copyCurrentNoteMarkdown: Action?
+        var copyCurrentNoteFilePath: Action?
+        var openCurrentNoteFile: Action?
+        var revealCurrentNoteInFinder: Action?
+
+        /// Evaluated immediately before rendering or executing a panel action.
+        var currentNoteAvailable: Predicate
+
+        init(
+            newNote: Action? = nil,
+            toggleBlink: Action? = nil,
+            showGrid: Action? = nil,
+            openSettings: Action? = nil,
+            openGuide: Action? = nil,
+            revealNotesFolder: Action? = nil,
+            openConfigFile: Action? = nil,
+            toggleCurrentNoteMode: Action? = nil,
+            toggleCurrentNoteFocus: Action? = nil,
+            chooseCurrentNoteStyle: Action? = nil,
+            hideCurrentNote: Action? = nil,
+            closeCurrentNote: Action? = nil,
+            copyCurrentNoteID: Action? = nil,
+            copyCurrentNoteMarkdown: Action? = nil,
+            copyCurrentNoteFilePath: Action? = nil,
+            openCurrentNoteFile: Action? = nil,
+            revealCurrentNoteInFinder: Action? = nil,
+            currentNoteAvailable: @escaping Predicate = { false }
+        ) {
+            self.newNote = newNote
+            self.toggleBlink = toggleBlink
+            self.showGrid = showGrid
+            self.openSettings = openSettings
+            self.openGuide = openGuide
+            self.revealNotesFolder = revealNotesFolder
+            self.openConfigFile = openConfigFile
+            self.toggleCurrentNoteMode = toggleCurrentNoteMode
+            self.toggleCurrentNoteFocus = toggleCurrentNoteFocus
+            self.chooseCurrentNoteStyle = chooseCurrentNoteStyle
+            self.hideCurrentNote = hideCurrentNote
+            self.closeCurrentNote = closeCurrentNote
+            self.copyCurrentNoteID = copyCurrentNoteID
+            self.copyCurrentNoteMarkdown = copyCurrentNoteMarkdown
+            self.copyCurrentNoteFilePath = copyCurrentNoteFilePath
+            self.openCurrentNoteFile = openCurrentNoteFile
+            self.revealCurrentNoteInFinder = revealCurrentNoteInFinder
+            self.currentNoteAvailable = currentNoteAvailable
+        }
+    }
+
+    let activities: [BlinkActivity]
+
+    init(handlers: Handlers = .init()) {
+        activities = Self.makeActivities(handlers: handlers)
+    }
+
+    /// Executable entries, including unavailable entries a palette may choose
+    /// to show disabled in order to teach their contextual nature.
+    var paletteActivities: [BlinkActivity] {
+        activities.filter(\.isExecutable)
+    }
+
+    var availablePaletteActivities: [BlinkActivity] {
+        paletteActivities.filter(\.isAvailable)
+    }
+
+    func activities(in group: BlinkActivityGroup) -> [BlinkActivity] {
+        activities.filter { $0.group == group }
+    }
+}
+
+// MARK: - Catalog contents
+
+private extension BlinkActivityCatalog {
+    static func makeActivities(handlers h: Handlers) -> [BlinkActivity] {
+        let currentNoteAvailability: BlinkActivity.Availability = {
+            h.currentNoteAvailable()
+        }
+
+        func configured(_ keyPath: KeyPath<BlinkConfig.Hotkeys, String>)
+            -> BlinkActivity.ShortcutResolver
+        {
+            {
+                let raw = BlinkConfigStore.shared.config.hotkeys[keyPath: keyPath]
+                return KeyChord.parse(raw)?.display ?? raw
+            }
+        }
+
+        func fixed(_ display: String) -> BlinkActivity.ShortcutResolver {
+            { display }
+        }
+
+        func actionAvailability(_ action: Action?) -> BlinkActivity.Availability {
+            { action != nil }
+        }
+
+        func currentActionAvailability(_ action: Action?) -> BlinkActivity.Availability {
+            { action != nil && currentNoteAvailability() }
+        }
+
+        return [
+            BlinkActivity(
+                id: .newNote,
+                title: "New Note",
+                description: "Capture a new note from anywhere.",
+                symbolName: "square.and.pencil",
+                group: .capture,
+                scope: .global,
+                keywords: ["create", "capture", "write"],
+                shortcut: configured(\.newNote),
+                availability: actionAvailability(h.newNote),
+                execution: h.newNote
+            ),
+            BlinkActivity(
+                id: .dictateCapture,
+                title: "Dictate a Capture",
+                description: "Use macOS Dictation in the popover capture field.",
+                symbolName: "mic.fill",
+                group: .capture,
+                scope: .popover,
+                keywords: ["voice", "speech", "microphone"],
+                shortcut: fixed("Mic button")
+            ),
+            BlinkActivity(
+                id: .createFromCapture,
+                title: "Create from Capture",
+                description: "Turn the current capture text into a new note.",
+                symbolName: "plus.rectangle.on.rectangle",
+                group: .capture,
+                scope: .popover,
+                keywords: ["new", "query", "text"],
+                shortcut: fixed("⌘↩")
+            ),
+
+            BlinkActivity(
+                id: .commandPalette,
+                title: "Command Palette",
+                description: "Find any note or available Blink action.",
+                symbolName: "command",
+                group: .findAndOpen,
+                scope: .application,
+                keywords: ["commands", "actions", "search"],
+                shortcut: fixed("⌘K")
+            ),
+            BlinkActivity(
+                id: .searchNotes,
+                title: "Search Notes",
+                description: "Search titles, contents, and tags from the popover or command palette.",
+                symbolName: "magnifyingglass",
+                group: .findAndOpen,
+                scope: .popover,
+                keywords: ["find", "filter", "tags"],
+                shortcut: fixed("Type to search")
+            ),
+            BlinkActivity(
+                id: .openSelectedNote,
+                title: "Open Selected Note",
+                description: "Open or focus the selected note's one panel.",
+                symbolName: "arrow.turn.down.right",
+                group: .findAndOpen,
+                scope: .popover,
+                keywords: ["return", "focus", "panel"],
+                shortcut: fixed("↩")
+            ),
+            BlinkActivity(
+                id: .openNoteLink,
+                title: "Open a Note Link",
+                description: "Follow a rendered wiki link to open or focus its note.",
+                symbolName: "link",
+                group: .findAndOpen,
+                scope: .panel,
+                keywords: ["wiki", "backlink", "click"],
+                shortcut: fixed("Click [[link]]")
+            ),
+            BlinkActivity(
+                id: .openSettings,
+                title: "Settings",
+                description: "Open Blink settings.",
+                symbolName: "gearshape",
+                group: .findAndOpen,
+                scope: .application,
+                keywords: ["preferences", "configure"],
+                shortcut: fixed("⌘,"),
+                availability: actionAvailability(h.openSettings),
+                execution: h.openSettings
+            ),
+            BlinkActivity(
+                id: .openGuide,
+                title: "Blink Guide",
+                description: "See every activity, gesture, and keyboard action.",
+                symbolName: "questionmark.circle",
+                group: .findAndOpen,
+                scope: .application,
+                keywords: ["help", "hints", "shortcuts", "learn"],
+                shortcut: fixed("?"),
+                availability: actionAvailability(h.openGuide),
+                execution: h.openGuide
+            ),
+            BlinkActivity(
+                id: .quitBlink,
+                title: "Quit Blink",
+                description: "Flush pending saves and quit Blink.",
+                symbolName: "power",
+                group: .findAndOpen,
+                scope: .application,
+                keywords: ["exit", "close app"],
+                shortcut: fixed("⌘Q")
+            ),
+
+            BlinkActivity(
+                id: .showGrid,
+                title: "Spatial Grid",
+                description: "Show the nine keyboard-addressable placement slots.",
+                symbolName: "square.grid.3x3",
+                group: .arrange,
+                scope: .global,
+                keywords: ["constellation", "deploy", "place", "snap"],
+                shortcut: configured(\.grid),
+                availability: actionAvailability(h.showGrid),
+                execution: h.showGrid
+            ),
+            BlinkActivity(
+                id: .placeOnGrid,
+                title: "Place on the Grid",
+                description: "Move the active or most recently active note into a 3×3 slot.",
+                symbolName: "rectangle.grid.3x2",
+                group: .arrange,
+                scope: .grid,
+                keywords: ["qwe", "asd", "zxc", "slot", "deploy"],
+                shortcut: fixed("Q W E · A S D · Z X C")
+            ),
+            BlinkActivity(
+                id: .cancelGrid,
+                title: "Leave the Grid",
+                description: "Dismiss the spatial grid without moving a note.",
+                symbolName: "xmark.circle",
+                group: .arrange,
+                scope: .grid,
+                keywords: ["escape", "cancel", "dismiss"],
+                shortcut: fixed("⎋")
+            ),
+            BlinkActivity(
+                id: .movePanel,
+                title: "Move a Panel",
+                description: "Drag the top band to place a note anywhere on the desktop.",
+                symbolName: "arrow.up.and.down.and.arrow.left.and.right",
+                group: .arrange,
+                scope: .panel,
+                keywords: ["drag", "position", "geometry"],
+                shortcut: fixed("Drag top band")
+            ),
+            BlinkActivity(
+                id: .resizePanel,
+                title: "Resize a Panel",
+                description: "Resize a note from any window edge; its geometry is remembered.",
+                symbolName: "arrow.up.left.and.arrow.down.right",
+                group: .arrange,
+                scope: .panel,
+                keywords: ["size", "geometry", "edge"],
+                shortcut: fixed("Drag an edge")
+            ),
+            BlinkActivity(
+                id: .flingPanel,
+                title: "Fling a Panel",
+                description: "Release a fast drag to glide the note and bounce it off screen edges.",
+                symbolName: "cursorarrow.motionlines",
+                group: .arrange,
+                scope: .panel,
+                keywords: ["momentum", "physics", "throw", "bounce"],
+                shortcut: fixed("Fast drag + release")
+            ),
+
+            BlinkActivity(
+                id: .toggleReadEdit,
+                title: "Flip Read / Edit",
+                description: "Switch the same panel between rendered reading and markdown editing.",
+                symbolName: "book.pages",
+                group: .readAndWrite,
+                scope: .panel,
+                keywords: ["preview", "markdown", "mode", "write"],
+                shortcut: configured(\.toggleMode),
+                availability: currentActionAvailability(h.toggleCurrentNoteMode),
+                execution: h.toggleCurrentNoteMode
+            ),
+            BlinkActivity(
+                id: .editReadingNote,
+                title: "Edit a Reading Note",
+                description: "Flip a rendered note into edit mode in place.",
+                symbolName: "pencil",
+                group: .readAndWrite,
+                scope: .panel,
+                keywords: ["preview", "reader", "write"],
+                shortcut: fixed("Double-click note")
+            ),
+            BlinkActivity(
+                id: .saveNote,
+                title: "Save Now",
+                description: "Flush the current edit immediately; Blink also saves automatically.",
+                symbolName: "square.and.arrow.down",
+                group: .readAndWrite,
+                scope: .editor,
+                keywords: ["flush", "write", "disk"],
+                shortcut: fixed("⌘S")
+            ),
+            BlinkActivity(
+                id: .standardEditing,
+                title: "Standard Editing",
+                description: "Undo, redo, cut, copy, paste, and select all use standard macOS keys.",
+                symbolName: "text.cursor",
+                group: .readAndWrite,
+                scope: .editor,
+                keywords: ["undo", "redo", "cut", "copy", "paste", "select all"],
+                shortcut: fixed("⌘Z · ⇧⌘Z · ⌘X · ⌘C · ⌘V · ⌘A")
+            ),
+
+            BlinkActivity(
+                id: .toggleBlink,
+                title: "Blink All Notes / None",
+                description: "Hide every note, or restore the whole arrangement.",
+                symbolName: "eye",
+                group: .focusAndVisibility,
+                scope: .global,
+                keywords: ["show", "hide", "visibility", "all"],
+                shortcut: configured(\.blink),
+                availability: actionAvailability(h.toggleBlink),
+                execution: h.toggleBlink
+            ),
+            BlinkActivity(
+                id: .toggleFocus,
+                title: "Focus Mode",
+                description: "Quiet the desktop and recede the other notes around the current panel.",
+                symbolName: "circle.dashed",
+                group: .focusAndVisibility,
+                scope: .panel,
+                keywords: ["dim", "distraction", "quiet"],
+                shortcut: configured(\.focus),
+                availability: currentActionAvailability(h.toggleCurrentNoteFocus),
+                execution: h.toggleCurrentNoteFocus
+            ),
+            BlinkActivity(
+                id: .quietNote,
+                title: "Step Down",
+                description: "Leave edit mode first, then leave focus mode on the next press.",
+                symbolName: "escape",
+                group: .focusAndVisibility,
+                scope: .panel,
+                keywords: ["escape", "cancel", "read", "focus"],
+                shortcut: fixed("⎋")
+            ),
+            BlinkActivity(
+                id: .shakeToShade,
+                title: "Shake to Shade",
+                description: "Shake a panel side to side while dragging to fold or unfold it.",
+                symbolName: "waveform.path",
+                group: .focusAndVisibility,
+                scope: .panel,
+                keywords: ["windowshade", "fold", "collapse", "gesture"],
+                shortcut: fixed("Shake while dragging")
+            ),
+            BlinkActivity(
+                id: .doubleClickToShade,
+                title: "Shade from the Top Band",
+                description: "Fold or unfold a panel without disturbing its remembered full size.",
+                symbolName: "rectangle.compress.vertical",
+                group: .focusAndVisibility,
+                scope: .panel,
+                keywords: ["windowshade", "fold", "collapse", "gesture"],
+                shortcut: fixed("Double-click top band")
+            ),
+            BlinkActivity(
+                id: .hideNote,
+                title: "Hide Current Note",
+                description: "Remove the note from the desktop without closing its panel.",
+                symbolName: "eye.slash",
+                group: .focusAndVisibility,
+                scope: .panel,
+                keywords: ["visibility", "order out"],
+                availability: currentActionAvailability(h.hideCurrentNote),
+                execution: h.hideCurrentNote
+            ),
+            BlinkActivity(
+                id: .closeNote,
+                title: "Close Current Note",
+                description: "Flush pending edits, then close the panel.",
+                symbolName: "xmark",
+                group: .focusAndVisibility,
+                scope: .panel,
+                keywords: ["window", "dismiss", "flush"],
+                shortcut: fixed("⌘W"),
+                availability: currentActionAvailability(h.closeCurrentNote),
+                execution: h.closeCurrentNote
+            ),
+
+            BlinkActivity(
+                id: .openNoteMenu,
+                title: "Note Action Menu",
+                description: "See file, copy, style, visibility, and close actions for a note.",
+                symbolName: "cursorarrow.click.2",
+                group: .styleAndFiles,
+                scope: .panel,
+                keywords: ["context", "right click", "actions"],
+                shortcut: fixed("Right-click note")
+            ),
+            BlinkActivity(
+                id: .chooseNoteStyle,
+                title: "Choose Note Style",
+                description: "Apply a sheet treatment to the current note.",
+                symbolName: "paintpalette",
+                group: .styleAndFiles,
+                scope: .panel,
+                keywords: ["theme", "sheet", "appearance", "treatment"],
+                availability: currentActionAvailability(h.chooseCurrentNoteStyle),
+                execution: h.chooseCurrentNoteStyle
+            ),
+            BlinkActivity(
+                id: .copyNoteID,
+                title: "Copy Note ID",
+                description: "Copy the stable agent-facing identifier for the current note.",
+                symbolName: "number",
+                group: .styleAndFiles,
+                scope: .panel,
+                keywords: ["identifier", "agent", "clipboard"],
+                availability: currentActionAvailability(h.copyCurrentNoteID),
+                execution: h.copyCurrentNoteID
+            ),
+            BlinkActivity(
+                id: .copyNoteMarkdown,
+                title: "Copy Entire Note as Markdown",
+                description: "Copy the current note's complete markdown source.",
+                symbolName: "doc.on.doc",
+                group: .styleAndFiles,
+                scope: .panel,
+                keywords: ["source", "clipboard", "content"],
+                availability: currentActionAvailability(h.copyCurrentNoteMarkdown),
+                execution: h.copyCurrentNoteMarkdown
+            ),
+            BlinkActivity(
+                id: .copyNoteFilePath,
+                title: "Copy Note File Path",
+                description: "Copy the current note's markdown path.",
+                symbolName: "link",
+                group: .styleAndFiles,
+                scope: .panel,
+                keywords: ["file", "clipboard", "location"],
+                availability: currentActionAvailability(h.copyCurrentNoteFilePath),
+                execution: h.copyCurrentNoteFilePath
+            ),
+            BlinkActivity(
+                id: .openNoteFile,
+                title: "Open Markdown File",
+                description: "Open the current note's backing file in its default app.",
+                symbolName: "doc.text",
+                group: .styleAndFiles,
+                scope: .panel,
+                keywords: ["external", "source", "disk"],
+                availability: currentActionAvailability(h.openCurrentNoteFile),
+                execution: h.openCurrentNoteFile
+            ),
+            BlinkActivity(
+                id: .revealNoteInFinder,
+                title: "Reveal Note in Finder",
+                description: "Show the current note's backing markdown file in Finder.",
+                symbolName: "folder",
+                group: .styleAndFiles,
+                scope: .panel,
+                keywords: ["file", "location", "disk"],
+                availability: currentActionAvailability(h.revealCurrentNoteInFinder),
+                execution: h.revealCurrentNoteInFinder
+            ),
+            BlinkActivity(
+                id: .revealNotesFolder,
+                title: "Reveal Notes Folder",
+                description: "Open Blink's notes directory in Finder.",
+                symbolName: "folder",
+                group: .styleAndFiles,
+                scope: .application,
+                keywords: ["files", "markdown", "directory", "finder"],
+                availability: actionAvailability(h.revealNotesFolder),
+                execution: h.revealNotesFolder
+            ),
+            BlinkActivity(
+                id: .openConfigFile,
+                title: "Open Config File",
+                description: "Open Blink's agent-editable configuration file.",
+                symbolName: "doc.badge.gearshape",
+                group: .styleAndFiles,
+                scope: .application,
+                keywords: ["json", "settings", "theme", "hotkeys"],
+                availability: actionAvailability(h.openConfigFile),
+                execution: h.openConfigFile
+            ),
+        ]
+    }
+}

--- a/Sources/BlinkApp/BlinkCommandPalette.swift
+++ b/Sources/BlinkApp/BlinkCommandPalette.swift
@@ -1,0 +1,605 @@
+// THESIS: Command-K is Blink's fastest path from intent to a note or action.
+// OWN-WORLD: A compact terminal-like graphite/paper panel with one warm signal color.
+// STORY: Type freely, scan Notes and Actions, then run the highlighted result with Return.
+// FIRST VIEWPORT: Live-state strip, decisive search field, grouped results, terse key legend.
+// FORM: A dedicated centered key panel, native to Blink's menubar and floating-panel architecture.
+
+import AppKit
+import BlinkCore
+import SwiftUI
+import HudsonShell
+import HudsonUI
+
+/// Owns Blink's Command-K interstitial. AppDelegate supplies AppModel and the
+/// catalog provider, keeping this surface independent of private panel-manager
+/// and app-controller state.
+@MainActor
+final class BlinkCommandPaletteController: NSObject, NSWindowDelegate {
+    typealias ActivityProvider = @MainActor () -> [BlinkActivity]
+
+    private let model: AppModel
+    private let activities: ActivityProvider
+    private var panel: BlinkCommandPanel?
+    private var hostingController: NSHostingController<BlinkCommandPaletteView>?
+    private var isDismissing = false
+
+    init(model: AppModel, activities: @escaping ActivityProvider) {
+        self.model = model
+        self.activities = activities
+        super.init()
+    }
+
+    var isVisible: Bool { panel?.isVisible == true }
+
+    /// Present on the display that invoked Command-K. Capture the screen before
+    /// activating Blink because the palette itself becomes the key window.
+    func show(from invocationWindow: NSWindow? = nil) {
+        if let panel, panel.isVisible {
+            NSApp.activate(ignoringOtherApps: true)
+            panel.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        let screen = invocationScreen(for: invocationWindow)
+        let rootView = BlinkCommandPaletteView(
+            model: model,
+            activities: activities(),
+            dismiss: { [weak self] in self?.dismiss() }
+        )
+        let host = NSHostingController(rootView: rootView)
+        host.sizingOptions = .preferredContentSize
+
+        let contentSize = BlinkCommandPaletteView.contentSize
+        let panel = BlinkCommandPanel(
+            contentRect: NSRect(origin: .zero, size: contentSize),
+            // Unlike note panels, the interstitial must activate Blink so its
+            // search field owns typing even when invoked from a nonactivating
+            // note panel over another app.
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        panel.identifier = NSUserInterfaceItemIdentifier(BlinkCommandPanel.identifier)
+        panel.delegate = self
+        panel.contentViewController = host
+        panel.setContentSize(contentSize)
+        panel.title = "Blink Commands"
+        panel.titleVisibility = .hidden
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = false
+        panel.level = .floating
+        panel.isFloatingPanel = true
+        panel.becomesKeyOnlyIfNeeded = false
+        panel.hidesOnDeactivate = true
+        panel.isReleasedWhenClosed = false
+        panel.isMovableByWindowBackground = true
+        panel.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
+        panel.animationBehavior = .none
+
+        center(panel, on: screen)
+        self.panel = panel
+        hostingController = host
+
+        NSApp.activate(ignoringOtherApps: true)
+        panel.makeKeyAndOrderFront(nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak panel] in
+            guard let panel else { return }
+            NSApp.activate(ignoringOtherApps: true)
+            panel.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    func toggle(from invocationWindow: NSWindow? = nil) {
+        if isVisible {
+            dismiss()
+        } else {
+            show(from: invocationWindow)
+        }
+    }
+
+    func dismiss() {
+        guard !isDismissing else { return }
+        isDismissing = true
+        panel?.orderOut(nil)
+        panel?.delegate = nil
+        panel?.contentViewController = nil
+        panel = nil
+        hostingController = nil
+        isDismissing = false
+    }
+
+    private func invocationScreen(for window: NSWindow?) -> NSScreen {
+        if let screen = window?.screen ?? NSApp.keyWindow?.screen {
+            return screen
+        }
+        let mouse = NSEvent.mouseLocation
+        return NSScreen.screens.first(where: { $0.frame.contains(mouse) })
+            ?? NSScreen.main
+            ?? NSScreen.screens[0]
+    }
+
+    private func center(_ window: NSWindow, on screen: NSScreen) {
+        let visible = screen.visibleFrame
+        let size = window.frame.size
+        window.setFrameOrigin(NSPoint(
+            x: visible.midX - size.width / 2,
+            y: visible.midY - size.height / 2
+        ))
+    }
+}
+
+private final class BlinkCommandPanel: NSPanel {
+    static let identifier = "blink.command-palette"
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
+@MainActor
+private struct BlinkCommandPaletteView: View {
+    static let contentSize = NSSize(width: 620, height: 500)
+
+    @ObservedObject var model: AppModel
+    let activities: [BlinkActivity]
+    let dismiss: () -> Void
+
+    @ObservedObject private var appearance = AppearanceManager.shared
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var query = ""
+    @State private var selectedIndex = 0
+    @State private var keyMonitor: Any?
+    @State private var appeared = false
+    @State private var hoveredID: String?
+    @FocusState private var searchFocused: Bool
+
+    private var palette: BlinkDiscoveryPalette {
+        .forScheme(appearance.scheme)
+    }
+
+    private var trimmedQuery: String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var results: [PaletteResult] {
+        noteResults + activityResults
+    }
+
+    private var noteResults: [PaletteResult] {
+        let ordered = model.notes.sorted { $0.updatedAt > $1.updatedAt }
+        if trimmedQuery.isEmpty {
+            return ordered.prefix(8).map(PaletteResult.note)
+        }
+        let tokens = searchTokens
+        return ordered
+            .filter { note in
+                let searchable = ([note.title, note.content] + note.tags)
+                    .joined(separator: " ")
+                    .lowercased()
+                return tokens.allSatisfy { searchable.contains($0) }
+            }
+            .prefix(14)
+            .map(PaletteResult.note)
+    }
+
+    private var activityResults: [PaletteResult] {
+        activities
+            .filter { $0.isExecutable && $0.isAvailable }
+            .filter { $0.matches(trimmedQuery) }
+            .map(PaletteResult.activity)
+    }
+
+    private var searchTokens: [String] {
+        trimmedQuery.lowercased().split(whereSeparator: \Character.isWhitespace).map(String.init)
+    }
+
+    private var resultSections: [PaletteSection] {
+        let notes = results.filter { $0.kind == .note }
+        let actions = results.filter { $0.kind == .activity }
+        return [
+            PaletteSection(title: "Notes", results: notes),
+            PaletteSection(title: "Actions", results: actions),
+        ].filter { !$0.results.isEmpty }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            liveStrip
+            HudDivider(color: palette.rule)
+            searchField
+            HudDivider(color: palette.rule)
+            resultBody
+            HudDivider(color: palette.rule)
+            footer
+        }
+        .frame(width: Self.contentSize.width, height: Self.contentSize.height)
+        .background(BlinkDiscoveryBackdrop(palette: palette))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(palette.rule, lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.34), radius: 30, x: 0, y: 16)
+        .scaleEffect(reduceMotion ? 1 : (appeared ? 1 : 0.985))
+        .opacity(appeared ? 1 : 0)
+        .preferredColorScheme(appearance.scheme == .dark ? .dark : .light)
+        .onAppear {
+            query = ""
+            selectedIndex = 0
+            installKeyMonitor()
+            if reduceMotion {
+                appeared = true
+            } else {
+                withAnimation(HudMotion.chromeResize) { appeared = true }
+            }
+            DispatchQueue.main.async { searchFocused = true }
+        }
+        .onDisappear {
+            removeKeyMonitor()
+            appeared = false
+        }
+        .onChange(of: query) { _, _ in selectedIndex = 0 }
+        .onChange(of: results.map(\.id)) { _, ids in
+            if ids.isEmpty {
+                selectedIndex = 0
+            } else {
+                selectedIndex = min(selectedIndex, ids.count - 1)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Blink commands")
+    }
+
+    private var liveStrip: some View {
+        HStack(spacing: HudSpacing.md) {
+            Circle()
+                .fill(palette.live)
+                .frame(width: 6, height: 6)
+                .shadow(color: palette.live.opacity(0.7), radius: 4)
+                .accessibilityHidden(true)
+
+            Text("BLINK · COMMANDS")
+                .font(HudFont.mono(HudTextSize.micro, weight: .semibold))
+                .tracking(HudTracking.widest)
+                .foregroundStyle(palette.accent)
+
+            Spacer()
+
+            BlinkKeyChip("⌘K", palette: palette)
+        }
+        .padding(.horizontal, HudSpacing.xxl)
+        .frame(height: 30)
+        .background(palette.accentSoft)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Blink command palette")
+    }
+
+    private var searchField: some View {
+        HStack(spacing: HudSpacing.xl) {
+            Image(systemName: "magnifyingglass")
+                .font(HudFont.ui(HudTextSize.lg, weight: .medium))
+                .foregroundStyle(palette.muted)
+                .accessibilityHidden(true)
+
+            TextField(
+                "",
+                text: $query,
+                prompt: Text("Find a note or run an action…")
+                    .foregroundStyle(palette.dim)
+            )
+            .textFieldStyle(.plain)
+            .font(HudFont.ui(HudTextSize.lg))
+            .foregroundStyle(palette.ink)
+            .tint(palette.accent)
+            .focused($searchFocused)
+            .accessibilityLabel("Search notes and commands")
+
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(HudFont.ui(HudTextSize.base))
+                        .foregroundStyle(palette.dim)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, HudSpacing.xxxl)
+        .frame(height: 62)
+        .background(palette.raised.opacity(0.9))
+    }
+
+    @ViewBuilder
+    private var resultBody: some View {
+        if results.isEmpty {
+            emptyState
+        } else {
+            resultList
+        }
+    }
+
+    private var resultList: some View {
+        let visibleResults = results
+        return ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0, pinnedViews: [.sectionHeaders]) {
+                    ForEach(resultSections) { section in
+                        Section {
+                            ForEach(section.results, id: \.id) { result in
+                                if let index = visibleResults.firstIndex(where: { $0.id == result.id }) {
+                                    resultRow(result, index: index)
+                                        .id(result.id)
+                                }
+                            }
+                        } header: {
+                            HStack {
+                                HudSectionLabel(section.title, tint: palette.dim)
+                                Spacer()
+                                Text("\(section.results.count)")
+                                    .font(HudFont.mono(HudTextSize.micro, weight: .medium))
+                                    .foregroundStyle(palette.dim)
+                            }
+                            .padding(.horizontal, HudSpacing.xxxl)
+                            .padding(.top, HudSpacing.lg)
+                            .padding(.bottom, HudSpacing.sm)
+                            .background(palette.bg.opacity(0.98))
+                        }
+                    }
+                }
+                .padding(.bottom, HudSpacing.md)
+            }
+            .scrollIndicators(.automatic)
+            .onChange(of: selectedIndex) { _, newIndex in
+                guard let id = visibleResults[safe: newIndex]?.id else { return }
+                if reduceMotion {
+                    proxy.scrollTo(id, anchor: nil)
+                } else {
+                    withAnimation(HudMotion.quickScroll) {
+                        proxy.scrollTo(id, anchor: nil)
+                    }
+                }
+            }
+        }
+    }
+
+    private func resultRow(_ result: PaletteResult, index: Int) -> some View {
+        let selected = selectedIndex == index
+        let hovering = hoveredID == result.id
+        return Button {
+            selectedIndex = index
+            performSelection()
+        } label: {
+            HStack(spacing: HudSpacing.xl) {
+                Image(systemName: result.symbolName)
+                    .font(HudFont.ui(HudTextSize.base, weight: .medium))
+                    .foregroundStyle(selected ? palette.accent : palette.muted)
+                    .frame(width: 24, height: 24)
+                    .background(selected ? palette.accentSoft : palette.rule.opacity(0.28))
+                    .clipShape(RoundedRectangle(cornerRadius: HudRadius.standard))
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: HudSpacing.xxs) {
+                    HStack(spacing: HudSpacing.sm) {
+                        Text(result.title)
+                            .font(HudFont.ui(HudTextSize.base, weight: selected ? .semibold : .medium))
+                            .foregroundStyle(palette.ink)
+                            .lineLimit(1)
+
+                        if let context = result.contextLabel {
+                            Text(context.uppercased())
+                                .font(HudFont.mono(HudTextSize.micro, weight: .medium))
+                                .tracking(HudTracking.wide)
+                                .foregroundStyle(palette.dim)
+                        }
+                    }
+
+                    if let subtitle = result.subtitle {
+                        Text(subtitle)
+                            .font(HudFont.ui(HudTextSize.xs))
+                            .foregroundStyle(palette.muted)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer(minLength: HudSpacing.xl)
+
+                if let shortcut = result.shortcutDisplay {
+                    BlinkKeyChip(shortcut, palette: palette)
+                } else if selected {
+                    Image(systemName: "return")
+                        .font(HudFont.ui(HudTextSize.xs, weight: .semibold))
+                        .foregroundStyle(palette.dim)
+                        .accessibilityHidden(true)
+                }
+            }
+            .padding(.horizontal, HudSpacing.xxxl)
+            .frame(height: 48)
+            .background(selected ? palette.selection : (hovering ? palette.rule.opacity(0.25) : .clear))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering in
+            hoveredID = isHovering ? result.id : (hoveredID == result.id ? nil : hoveredID)
+            if isHovering { selectedIndex = index }
+        }
+        .accessibilityLabel(result.accessibilityLabel)
+        .accessibilityValue(selected ? "Selected" : "")
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: HudSpacing.lg) {
+            Image(systemName: "magnifyingglass")
+                .font(HudFont.ui(HudTextSize.xxxl, weight: .light))
+                .foregroundStyle(palette.dim)
+            Text("No notes or actions match “\(trimmedQuery)”")
+                .font(HudFont.ui(HudTextSize.base, weight: .medium))
+                .foregroundStyle(palette.muted)
+            Text("Try a title, tag, or verb like “focus” or “reveal”.")
+                .font(HudFont.ui(HudTextSize.xs))
+                .foregroundStyle(palette.dim)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var footer: some View {
+        HStack(spacing: HudSpacing.xxxl) {
+            footerHint(keys: "↑↓", label: "navigate")
+            footerHint(keys: "↩", label: "open or run")
+            footerHint(keys: "Esc", label: "dismiss")
+            Spacer()
+            Text("\(results.count) READY")
+                .font(HudFont.mono(HudTextSize.micro, weight: .medium))
+                .tracking(HudTracking.wide)
+                .foregroundStyle(palette.dim)
+        }
+        .padding(.horizontal, HudSpacing.xxl)
+        .frame(height: 42)
+        .background(palette.chrome.opacity(0.96))
+    }
+
+    private func footerHint(keys: String, label: String) -> some View {
+        HStack(spacing: HudSpacing.sm) {
+            BlinkKeyChip(keys, palette: palette)
+            Text(label)
+                .font(HudFont.ui(HudTextSize.xs))
+                .foregroundStyle(palette.dim)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func installKeyMonitor() {
+        removeKeyMonitor()
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard NSApp.keyWindow?.identifier?.rawValue == BlinkCommandPanel.identifier else {
+                return event
+            }
+            switch event.keyCode {
+            case 53: // Escape
+                dismiss()
+                return nil
+            case 125: // Down
+                moveSelection(1)
+                return nil
+            case 126: // Up
+                moveSelection(-1)
+                return nil
+            case 36, 76: // Return / keypad Enter — no alternate Command-Return behavior.
+                performSelection()
+                return nil
+            default:
+                return event
+            }
+        }
+    }
+
+    private func removeKeyMonitor() {
+        if let keyMonitor {
+            NSEvent.removeMonitor(keyMonitor)
+            self.keyMonitor = nil
+        }
+    }
+
+    private func moveSelection(_ delta: Int) {
+        guard !results.isEmpty else { return }
+        selectedIndex = (selectedIndex + delta + results.count) % results.count
+    }
+
+    private func performSelection() {
+        guard let result = results[safe: selectedIndex] else { return }
+        dismiss()
+        switch result {
+        case .note(let note):
+            Task { @MainActor in await model.openNote(id: note.id) }
+        case .activity(let activity):
+            DispatchQueue.main.async { activity.perform() }
+        }
+    }
+}
+
+private enum PaletteResultKind {
+    case note
+    case activity
+}
+
+@MainActor
+private enum PaletteResult {
+    case note(Note)
+    case activity(BlinkActivity)
+
+    var id: String {
+        switch self {
+        case .note(let note): "note-\(note.id)"
+        case .activity(let activity): "activity-\(activity.id.rawValue)"
+        }
+    }
+
+    var kind: PaletteResultKind {
+        switch self {
+        case .note: .note
+        case .activity: .activity
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .note(let note): note.title
+        case .activity(let activity): activity.title
+        }
+    }
+
+    var subtitle: String? {
+        switch self {
+        case .note(let note):
+            let collapsed = note.content
+                .replacingOccurrences(of: "\n", with: " ")
+                .split(whereSeparator: \Character.isWhitespace)
+                .joined(separator: " ")
+            guard collapsed != note.title, !collapsed.isEmpty else {
+                return note.tags.isEmpty ? "Markdown note" : note.tags.map { "#\($0)" }.joined(separator: "  ")
+            }
+            return String(collapsed.prefix(110))
+        case .activity(let activity):
+            return activity.description
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .note: "note.text"
+        case .activity(let activity): activity.symbolName
+        }
+    }
+
+    var contextLabel: String? {
+        switch self {
+        case .note: nil
+        case .activity(let activity): activity.scope.displayTitle
+        }
+    }
+
+    var shortcutDisplay: String? {
+        switch self {
+        case .note: nil
+        case .activity(let activity): activity.shortcutDisplay
+        }
+    }
+
+    var accessibilityLabel: String {
+        [title, subtitle, shortcutDisplay].compactMap { $0 }.joined(separator: ", ")
+    }
+}
+
+private struct PaletteSection: Identifiable {
+    let title: String
+    let results: [PaletteResult]
+    var id: String { title }
+}
+
+private extension Collection {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/BlinkApp/BlinkConfig.swift
+++ b/Sources/BlinkApp/BlinkConfig.swift
@@ -240,65 +240,18 @@ struct BlinkConfig: Codable, Equatable {
 
     /// A named, reusable presentation preset — a *partial* overlay onto the
     /// panel/editor defaults, every field optional. A note references one by name
-    /// via its `blink.style`; the studio's treatments live here. Typed (not
-    /// passed-through) so it survives a config re-encode.
-    /// Field → surface mapping is in `apply(treatment:)`; see
+    /// via its `blink.style`, and a workspace brands every one of its notes with
+    /// one (see `BlinkCore.Workspace`).
+    ///
+    /// The type itself lives in BlinkCore so the app, the `blink` CLI, and tests
+    /// share one brand vocabulary. Field → surface mapping is in
+    /// `apply(treatment:)`; see `docs/workspaces.md` and
     /// `docs/notes-representation.md` Appendix A.
-    struct Treatment: Codable, Equatable {
-        var sheet: String?
-        var accent: String?
-        var accentDim: String?
-        var font: String?
-        var mono: String?
-        var titleFont: String?
-        var fontSize: Double?
-        var lineHeight: Double?
-        var background: String?
-        var text: String?
-        var textStrong: String?
-        var textMuted: String?
-        var dim: String?
-        var border: String?
-        var codeBackground: String?
-        var codeText: String?
-        var caret: String?
-        var selection: String?
-        var tint: Double?
-        var tintRead: Double?
-        var tintEdit: Double?
-        var radius: Double?
-        /// Relative path under `$BLINK_HOME/attachments` for a restrained
-        /// identity mark in the panel's top-left chrome.
-        var mark: String?
+    typealias Treatment = BlinkCore.Treatment
 
-        init() {}
-        init(from decoder: Decoder) throws {
-            let c = try decoder.container(keyedBy: CodingKeys.self)
-            sheet = try c.decodeIfPresent(String.self, forKey: .sheet)
-            accent = try c.decodeIfPresent(String.self, forKey: .accent)
-            accentDim = try c.decodeIfPresent(String.self, forKey: .accentDim)
-            font = try c.decodeIfPresent(String.self, forKey: .font)
-            mono = try c.decodeIfPresent(String.self, forKey: .mono)
-            titleFont = try c.decodeIfPresent(String.self, forKey: .titleFont)
-            fontSize = try c.decodeIfPresent(Double.self, forKey: .fontSize)
-            lineHeight = try c.decodeIfPresent(Double.self, forKey: .lineHeight)
-            background = try c.decodeIfPresent(String.self, forKey: .background)
-            text = try c.decodeIfPresent(String.self, forKey: .text)
-            textStrong = try c.decodeIfPresent(String.self, forKey: .textStrong)
-            textMuted = try c.decodeIfPresent(String.self, forKey: .textMuted)
-            dim = try c.decodeIfPresent(String.self, forKey: .dim)
-            border = try c.decodeIfPresent(String.self, forKey: .border)
-            codeBackground = try c.decodeIfPresent(String.self, forKey: .codeBackground)
-            codeText = try c.decodeIfPresent(String.self, forKey: .codeText)
-            caret = try c.decodeIfPresent(String.self, forKey: .caret)
-            selection = try c.decodeIfPresent(String.self, forKey: .selection)
-            tint = try c.decodeIfPresent(Double.self, forKey: .tint)
-            tintRead = try c.decodeIfPresent(Double.self, forKey: .tintRead)
-            tintEdit = try c.decodeIfPresent(Double.self, forKey: .tintEdit)
-            radius = try c.decodeIfPresent(Double.self, forKey: .radius)
-            mark = try c.decodeIfPresent(String.self, forKey: .mark)
-        }
-    }
+    /// A named group of notes plus the brand they render under. Defined here;
+    /// *membership* lives in each note's `blink.workspace` frontmatter key.
+    typealias Workspace = BlinkCore.Workspace
 
     /// App-wide light/dark axis: "auto" (follow macOS) | "light" | "dark".
     /// Resolved to an effective `AppScheme` by `AppearanceManager`; every
@@ -312,8 +265,12 @@ struct BlinkConfig: Codable, Equatable {
     var motion = Motion()
     var physics = Physics()
     var editor = Editor()
-    /// Named presentation presets, referenced by a note's `blink.style`.
+    /// Named presentation presets, referenced by a note's `blink.style` and
+    /// reusable as a workspace's brand base.
     var styles: [String: Treatment]?
+    /// Named workspaces, referenced by a note's `blink.workspace`. Absent by
+    /// default — an unbranded Blink is the baseline, not a special case.
+    var workspaces: [String: Workspace]?
 
     init() {}
     init(from decoder: Decoder) throws {
@@ -328,21 +285,29 @@ struct BlinkConfig: Codable, Equatable {
         physics = try c.decodeIfPresent(Physics.self, forKey: .physics) ?? Physics()
         editor = try c.decodeIfPresent(Editor.self, forKey: .editor) ?? Editor()
         styles = try c.decodeIfPresent([String: Treatment].self, forKey: .styles)
+        workspaces = try c.decodeIfPresent([String: Workspace].self, forKey: .workspaces)
     }
 
     // MARK: - Per-note presentation resolution
 
     /// Resolve a note's `blink:` presentation onto this config, producing the
     /// effective config *for that note*:
-    /// `configDefaults ← styles[name] ← loose overrides` (Appendix A).
-    /// A missing/unknown style name is ignored (defaults stand); loose overrides
-    /// always win. Never throws — a bad value is clamped, never fatal.
+    /// `configDefaults ← workspaces[ws].brand ← styles[name] ← loose overrides`
+    /// (Appendix A, extended by `docs/workspaces.md`).
+    ///
+    /// The workspace brand sits between the global defaults and the note's own
+    /// style so a note inherits its workspace's identity for free, while keeping
+    /// every existing escape hatch: a per-note `style` still overrides the brand,
+    /// and loose `blink:` keys still beat both. A missing or unknown workspace
+    /// or style name is ignored and the defaults stand — never throws, and a bad
+    /// value is clamped rather than fatal.
     func resolved(for presentation: NotePresentation) -> BlinkConfig {
         var c = self
-        if let name = presentation.style, let treatment = styles?[name] {
+        for treatment in PresentationResolver.chain(
+            for: presentation, styles: styles, workspaces: workspaces
+        ) {
             c.apply(treatment: treatment)
         }
-        c.apply(treatment: BlinkConfig.treatment(from: presentation))
         return c
     }
 
@@ -373,21 +338,6 @@ struct BlinkConfig: Codable, Equatable {
         if let v = t.tintEdit { panel.tintEdit = clamp(v, 0, 1) }
         if let v = t.radius { panel.cornerRadius = clamp(v, 0, 40) }
         if let v = t.mark { panel.mark = v }
-    }
-
-    /// The loose per-note overrides as a treatment (everything but `style`/`slot`).
-    private static func treatment(from p: NotePresentation) -> Treatment {
-        var t = Treatment()
-        t.sheet = p.sheet
-        t.accent = p.accent
-        t.font = p.font
-        t.fontSize = p.fontSize
-        t.lineHeight = p.lineHeight
-        t.tint = p.tint
-        t.tintRead = p.tintRead
-        t.tintEdit = p.tintEdit
-        t.radius = p.radius
-        return t
     }
 
     /// Map editor settings onto the web bundle's CSS variable contract

--- a/Sources/BlinkApp/BlinkGuideView.swift
+++ b/Sources/BlinkApp/BlinkGuideView.swift
@@ -1,0 +1,530 @@
+// THESIS: Blink's Guide is a field manual for a spatial tool, not a settings appendix.
+// OWN-WORLD: A quiet graphite/paper surface, fine spatial grid, warm signal-orange, mono labels.
+// STORY: Learn the things Blink can do, then scan every key by the place where it works.
+// FIRST VIEWPORT: A narrow navigator anchors two dense, legible reference pages.
+// FORM: An established-world extension of Blink's terminal canvas and Hudson's native tokens.
+
+import SwiftUI
+import HudsonUI
+
+/// Blink's educational surface. The catalog supplies live names, shortcuts, and
+/// scopes; the small interaction field manual supplies gestures that are not
+/// executable commands and therefore do not belong in the palette.
+@MainActor
+struct BlinkGuideView: View {
+    enum Page: String, CaseIterable, Identifiable {
+        case activities
+        case shortcuts
+
+        var id: Self { self }
+        var title: String {
+            switch self {
+            case .activities: "Activities"
+            case .shortcuts: "All Shortcuts"
+            }
+        }
+        var subtitle: String {
+            switch self {
+            case .activities: "What Blink can do"
+            case .shortcuts: "Keys grouped by scope"
+            }
+        }
+        var symbolName: String {
+            switch self {
+            case .activities: "sparkles"
+            case .shortcuts: "command"
+            }
+        }
+    }
+
+    let activities: [BlinkActivity]
+
+    @State private var page: Page = .activities
+    @ObservedObject private var appearance = AppearanceManager.shared
+
+    private var palette: BlinkDiscoveryPalette {
+        .forScheme(appearance.scheme)
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            navigator
+                .frame(width: 190)
+            HudDivider(color: palette.rule, axis: .vertical)
+            detail
+        }
+        .frame(minWidth: 720, idealWidth: 780, minHeight: 520, idealHeight: 610)
+        .background(BlinkDiscoveryBackdrop(palette: palette))
+        .preferredColorScheme(appearance.scheme == .dark ? .dark : .light)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Blink Guide")
+    }
+
+    private var navigator: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: HudSpacing.xs) {
+                HStack(spacing: HudSpacing.md) {
+                    Image(systemName: "questionmark")
+                        .font(HudFont.mono(HudTextSize.sm, weight: .bold))
+                        .foregroundStyle(palette.accent)
+                        .frame(width: 24, height: 24)
+                        .background(palette.accentSoft)
+                        .clipShape(RoundedRectangle(cornerRadius: HudRadius.standard))
+
+                    Text("BLINK GUIDE")
+                        .font(HudFont.mono(HudTextSize.xs, weight: .semibold))
+                        .tracking(HudTracking.wider)
+                        .foregroundStyle(palette.ink)
+                }
+
+                Text("A field manual for your note desk.")
+                    .font(HudFont.ui(HudTextSize.xs))
+                    .foregroundStyle(palette.muted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, HudSpacing.xxl)
+            .padding(.top, HudSpacing.xxxl)
+            .padding(.bottom, HudSpacing.xxl)
+
+            VStack(spacing: HudSpacing.xs) {
+                ForEach(Page.allCases) { item in
+                    Button {
+                        page = item
+                    } label: {
+                        HStack(spacing: HudSpacing.lg) {
+                            Image(systemName: item.symbolName)
+                                .font(HudFont.ui(HudTextSize.sm, weight: .medium))
+                                .frame(width: 16)
+
+                            VStack(alignment: .leading, spacing: HudSpacing.xxs) {
+                                Text(item.title)
+                                    .font(HudFont.ui(HudTextSize.sm, weight: page == item ? .semibold : .regular))
+                                Text(item.subtitle)
+                                    .font(HudFont.ui(HudTextSize.xxs))
+                                    .foregroundStyle(page == item ? palette.ink.opacity(0.72) : palette.dim)
+                            }
+
+                            Spacer(minLength: 0)
+                        }
+                        .foregroundStyle(page == item ? palette.ink : palette.muted)
+                        .padding(.horizontal, HudSpacing.lg)
+                        .frame(height: 48)
+                        .background(page == item ? palette.selection : .clear)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .clipShape(RoundedRectangle(cornerRadius: HudRadius.standard))
+                    .accessibilityValue(page == item ? "Selected" : "")
+                }
+            }
+            .padding(.horizontal, HudSpacing.md)
+
+            Spacer()
+
+            HStack(spacing: HudSpacing.sm) {
+                Circle()
+                    .fill(palette.live)
+                    .frame(width: 6, height: 6)
+                Text("SHORTCUTS FOLLOW CONFIG")
+                    .font(HudFont.mono(HudTextSize.micro, weight: .medium))
+                    .tracking(HudTracking.wide)
+                    .foregroundStyle(palette.dim)
+            }
+            .padding(HudSpacing.xxl)
+            .accessibilityLabel("Shortcuts update with Blink configuration")
+        }
+        .background(palette.chrome.opacity(0.96))
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        switch page {
+        case .activities:
+            activitiesPage
+        case .shortcuts:
+            shortcutsPage
+        }
+    }
+
+    private var activitiesPage: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: HudSpacing.huge) {
+                pageHeader(
+                    title: "Activities",
+                    subtitle: "Everything Blink lets you capture, find, arrange, and shape."
+                )
+
+                ForEach(BlinkActivityGroup.allCases) { group in
+                    let entries = activities.filter { $0.group == group }
+                    if !entries.isEmpty {
+                        activitySection(group: group, entries: entries)
+                    }
+                }
+
+            }
+            .padding(.horizontal, HudSpacing.huge)
+            .padding(.vertical, HudSpacing.xxxl)
+            .frame(maxWidth: 720, alignment: .leading)
+        }
+        .scrollIndicators(.automatic)
+    }
+
+    private func activitySection(group: BlinkActivityGroup, entries: [BlinkActivity]) -> some View {
+        VStack(alignment: .leading, spacing: HudSpacing.md) {
+            HudSectionLabel(group.displayTitle, tint: palette.dim)
+
+            VStack(spacing: 0) {
+                ForEach(entries) { activity in
+                    activityRow(activity)
+                    if activity.id != entries.last?.id {
+                        HudDivider(color: palette.rule.opacity(0.72))
+                            .padding(.leading, 42)
+                    }
+                }
+            }
+            .background(palette.raised)
+            .clipShape(RoundedRectangle(cornerRadius: HudRadius.card))
+            .overlay(
+                RoundedRectangle(cornerRadius: HudRadius.card)
+                    .stroke(palette.rule, lineWidth: 1)
+            )
+        }
+    }
+
+    private func activityRow(_ activity: BlinkActivity) -> some View {
+        HStack(alignment: .top, spacing: HudSpacing.xl) {
+            Image(systemName: activity.symbolName)
+                .font(HudFont.ui(HudTextSize.base, weight: .medium))
+                .foregroundStyle(palette.accent)
+                .frame(width: 24, height: 24)
+                .background(palette.accentSoft)
+                .clipShape(RoundedRectangle(cornerRadius: HudRadius.standard))
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: HudSpacing.xs) {
+                HStack(alignment: .firstTextBaseline, spacing: HudSpacing.md) {
+                    Text(activity.title)
+                        .font(HudFont.ui(HudTextSize.base, weight: .semibold))
+                        .foregroundStyle(palette.ink)
+                    scopeLabel(activity.scope)
+                    Spacer(minLength: 0)
+                    if let shortcut = activity.shortcutDisplay {
+                        BlinkKeyChip(shortcut, palette: palette)
+                    }
+                }
+
+                Text(activity.description)
+                    .font(HudFont.ui(HudTextSize.sm))
+                    .foregroundStyle(palette.muted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(HudSpacing.xl)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var shortcutsPage: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: HudSpacing.huge) {
+                pageHeader(
+                    title: "All Shortcuts",
+                    subtitle: "Keys are grouped by where Blink listens for them."
+                )
+
+                ForEach(BlinkActivityScope.allCases) { scope in
+                    let rows = shortcutRows(for: scope)
+                    if !rows.isEmpty {
+                        shortcutSection(scope: scope, rows: rows)
+                    }
+                }
+            }
+            .padding(.horizontal, HudSpacing.huge)
+            .padding(.vertical, HudSpacing.xxxl)
+            .frame(maxWidth: 720, alignment: .leading)
+        }
+        .scrollIndicators(.automatic)
+    }
+
+    private func shortcutSection(scope: BlinkActivityScope, rows: [GuideShortcut]) -> some View {
+        VStack(alignment: .leading, spacing: HudSpacing.md) {
+            HStack {
+                HudSectionLabel(scope.displayTitle, tint: palette.dim)
+                Spacer()
+                Text("\(rows.count)")
+                    .font(HudFont.mono(HudTextSize.micro, weight: .medium))
+                    .foregroundStyle(palette.dim)
+            }
+
+            VStack(spacing: 0) {
+                ForEach(rows) { row in
+                    HStack(alignment: .firstTextBaseline, spacing: HudSpacing.xl) {
+                        VStack(alignment: .leading, spacing: HudSpacing.xxs) {
+                            Text(row.title)
+                                .font(HudFont.ui(HudTextSize.sm, weight: .medium))
+                                .foregroundStyle(palette.ink)
+                            if let detail = row.detail {
+                                Text(detail)
+                                    .font(HudFont.ui(HudTextSize.xs))
+                                    .foregroundStyle(palette.muted)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                        Spacer(minLength: HudSpacing.xl)
+                        BlinkKeyChip(row.keys, palette: palette)
+                    }
+                    .padding(.horizontal, HudSpacing.xl)
+                    .padding(.vertical, HudSpacing.lg)
+                    .accessibilityElement(children: .combine)
+
+                    if row.id != rows.last?.id {
+                        HudDivider(color: palette.rule.opacity(0.72))
+                    }
+                }
+            }
+            .background(palette.raised)
+            .clipShape(RoundedRectangle(cornerRadius: HudRadius.card))
+            .overlay(RoundedRectangle(cornerRadius: HudRadius.card).stroke(palette.rule, lineWidth: 1))
+        }
+    }
+
+    private func pageHeader(title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: HudSpacing.sm) {
+            Text(title)
+                .font(HudFont.ui(HudTextSize.xxl, weight: .semibold))
+                .foregroundStyle(palette.ink)
+            Text(subtitle)
+                .font(HudFont.ui(HudTextSize.base))
+                .foregroundStyle(palette.muted)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func scopeLabel(_ scope: BlinkActivityScope) -> some View {
+        Text(scope.displayTitle.uppercased())
+            .font(HudFont.mono(HudTextSize.micro, weight: .medium))
+            .tracking(HudTracking.wide)
+            .foregroundStyle(palette.dim)
+    }
+
+    private func shortcutRows(for scope: BlinkActivityScope) -> [GuideShortcut] {
+        var rows = activities
+            .filter { $0.scope == scope }
+            .compactMap { activity -> GuideShortcut? in
+                guard let shortcut = activity.shortcutDisplay else { return nil }
+                return GuideShortcut(
+                    id: "activity-\(String(describing: activity.id))",
+                    scope: activity.scope,
+                    keys: shortcut,
+                    title: activity.title,
+                    detail: activity.description
+                )
+            }
+
+        for supplement in GuideShortcut.supplements where supplement.scope == scope {
+            let normalized = supplement.title.lowercased()
+            let alreadyCovered = rows.contains {
+                $0.title.lowercased() == normalized
+                    || (!supplement.deduplicationHint.isEmpty
+                        && $0.title.lowercased().contains(supplement.deduplicationHint))
+            }
+            if !alreadyCovered {
+                rows.append(supplement)
+            }
+        }
+        return rows
+    }
+}
+
+private struct GuideShortcut: Identifiable {
+    let id: String
+    let scope: BlinkActivityScope
+    let keys: String
+    let title: String
+    let detail: String?
+    let deduplicationHint: String
+
+    init(
+        id: String,
+        scope: BlinkActivityScope = .application,
+        keys: String,
+        title: String,
+        detail: String? = nil,
+        deduplicationHint: String = ""
+    ) {
+        self.id = id
+        self.scope = scope
+        self.keys = keys
+        self.title = title
+        self.detail = detail
+        self.deduplicationHint = deduplicationHint
+    }
+
+    static let supplements: [GuideShortcut] = [
+        .init(
+            id: "panel-mode",
+            scope: .panel,
+            keys: "⌘⇧P",
+            title: "Switch read / edit",
+            detail: "Flip the current note between reading and writing.",
+            deduplicationHint: "read"
+        ),
+        .init(
+            id: "panel-focus",
+            scope: .panel,
+            keys: "⌘.",
+            title: "Focus current note",
+            detail: "Recede the surrounding desk and keep this note present.",
+            deduplicationHint: "focus"
+        ),
+        .init(
+            id: "panel-close",
+            scope: .panel,
+            keys: "⌘W",
+            title: "Close current note",
+            detail: "Pending edits are saved before its panel closes.",
+            deduplicationHint: "close"
+        ),
+        .init(
+            id: "panel-escape",
+            scope: .panel,
+            keys: "Esc",
+            title: "Step back",
+            detail: "Escape moves from edit → read → leave focus, one step at a time.",
+            deduplicationHint: "step"
+        ),
+        .init(
+            id: "popover-return",
+            scope: .popover,
+            keys: "↩",
+            title: "Open the result",
+            detail: "Open the selected or first match; create only when nothing matches.",
+            deduplicationHint: "open"
+        ),
+        .init(
+            id: "popover-command-return",
+            scope: .popover,
+            keys: "⌘↩",
+            title: "Create from the search field",
+            detail: "Always create a new note using the current capture text.",
+            deduplicationHint: "create"
+        ),
+        .init(
+            id: "grid-cells",
+            scope: .grid,
+            keys: "Q W E  /  A S D  /  Z X C",
+            title: "Place in the 3 × 3 grid",
+            detail: "Each letter maps to the matching screen cell.",
+            deduplicationHint: "place"
+        ),
+        .init(
+            id: "grid-dismiss",
+            scope: .grid,
+            keys: "Esc",
+            title: "Leave the grid",
+            deduplicationHint: "leave"
+        ),
+        .init(
+            id: "editor-save",
+            scope: .editor,
+            keys: "⌘S",
+            title: "Save now",
+            detail: "Flush the current edit immediately; Blink also saves as you type."
+        ),
+    ]
+}
+
+/// Shared discovery-surface colors. Hudson owns spacing, type, motion, and
+/// component geometry; Blink supplies the app-specific graphite/orange world.
+struct BlinkDiscoveryPalette {
+    let bg: Color
+    let chrome: Color
+    let raised: Color
+    let ink: Color
+    let muted: Color
+    let dim: Color
+    let rule: Color
+    let accent: Color
+    let live: Color
+    let selection: Color
+
+    var accentSoft: Color { accent.opacity(0.13) }
+
+    static func forScheme(_ scheme: AppScheme) -> Self {
+        if scheme == .dark {
+            return .init(
+                bg: Color(red: 0.035, green: 0.039, blue: 0.043),
+                chrome: Color(red: 0.025, green: 0.027, blue: 0.030),
+                raised: Color(red: 0.057, green: 0.061, blue: 0.066),
+                ink: Color(red: 0.918, green: 0.922, blue: 0.910),
+                muted: Color(red: 0.650, green: 0.665, blue: 0.665),
+                dim: Color(red: 0.455, green: 0.475, blue: 0.480),
+                rule: Color.white.opacity(0.10),
+                accent: Color(red: 1.0, green: 0.345, blue: 0.133),
+                live: Color(red: 0.353, green: 0.820, blue: 0.608),
+                selection: Color(red: 1.0, green: 0.345, blue: 0.133).opacity(0.13)
+            )
+        }
+        return .init(
+            bg: Color(red: 0.949, green: 0.941, blue: 0.925),
+            chrome: Color(red: 0.925, green: 0.914, blue: 0.894),
+            raised: Color(red: 0.985, green: 0.980, blue: 0.968),
+            ink: Color(red: 0.125, green: 0.110, blue: 0.095),
+            muted: Color(red: 0.360, green: 0.335, blue: 0.310),
+            dim: Color(red: 0.485, green: 0.455, blue: 0.420),
+            rule: Color.black.opacity(0.12),
+            accent: Color(red: 0.820, green: 0.235, blue: 0.060),
+            live: Color(red: 0.106, green: 0.580, blue: 0.404),
+            selection: Color(red: 0.820, green: 0.235, blue: 0.060).opacity(0.11)
+        )
+    }
+}
+
+struct BlinkDiscoveryBackdrop: View {
+    let palette: BlinkDiscoveryPalette
+
+    var body: some View {
+        ZStack {
+            palette.bg
+            Canvas { context, size in
+                let step: CGFloat = 36
+                var path = Path()
+                stride(from: CGFloat.zero, through: size.width, by: step).forEach { x in
+                    path.move(to: CGPoint(x: x, y: 0))
+                    path.addLine(to: CGPoint(x: x, y: size.height))
+                }
+                stride(from: CGFloat.zero, through: size.height, by: step).forEach { y in
+                    path.move(to: CGPoint(x: 0, y: y))
+                    path.addLine(to: CGPoint(x: size.width, y: y))
+                }
+                context.stroke(path, with: .color(palette.rule.opacity(0.18)), lineWidth: 0.5)
+            }
+            .accessibilityHidden(true)
+        }
+    }
+}
+
+struct BlinkKeyChip: View {
+    let text: String
+    let palette: BlinkDiscoveryPalette
+
+    init(_ text: String, palette: BlinkDiscoveryPalette) {
+        self.text = text
+        self.palette = palette
+    }
+
+    var body: some View {
+        Text(text)
+            .font(HudFont.mono(HudTextSize.xxs, weight: .semibold))
+            .foregroundStyle(palette.muted)
+            .lineLimit(1)
+            .padding(.horizontal, HudSpacing.sm)
+            .padding(.vertical, HudSpacing.xs)
+            .background(palette.rule.opacity(0.38))
+            .clipShape(RoundedRectangle(cornerRadius: HudRadius.tight))
+            .overlay(
+                RoundedRectangle(cornerRadius: HudRadius.tight)
+                    .stroke(palette.rule, lineWidth: 1)
+            )
+            .accessibilityLabel("Shortcut \(text)")
+    }
+}

--- a/Sources/BlinkApp/CapturePopoverView.swift
+++ b/Sources/BlinkApp/CapturePopoverView.swift
@@ -12,11 +12,14 @@ struct CapturePopoverView: View {
     @ObservedObject var model: AppModel
     var dismiss: () -> Void
     var openSettings: () -> Void
+    var openGuide: () -> Void
+    var showCommands: () -> Void
     var toggleBlink: () -> Void
     var showGrid: () -> Void
     var beginDictation: () -> Void
 
     @ObservedObject private var appearance = AppearanceManager.shared
+    @ObservedObject private var configStore = BlinkConfigStore.shared
 
     @State private var query = ""
     @State private var selectedNoteID: String?
@@ -31,6 +34,10 @@ struct CapturePopoverView: View {
     private var amber: Color { pal.accent }
     private var amberBright: Color { pal.accentBright }
     private var live: Color { pal.live }
+    private var blinkShortcut: String {
+        KeyChord.parse(configStore.config.hotkeys.blink)?.display
+            ?? configStore.config.hotkeys.blink
+    }
 
     /// The design is set in IBM Plex Mono weight 200. SF Mono at a light weight
     /// is the closest native match (bundling IBM Plex Mono would be exact).
@@ -138,7 +145,12 @@ struct CapturePopoverView: View {
             }
             .padding(.trailing, 4)
 
-            KeyBadge(text: "⌘K")
+            Button(action: showCommands) {
+                KeyBadge(text: "⌘K")
+            }
+            .buttonStyle(.plain)
+            .help("Commands and notes")
+            .accessibilityLabel("Open commands")
 
             Button(action: startSystemDictation) {
                 Image(systemName: "mic.fill")
@@ -343,7 +355,7 @@ struct CapturePopoverView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "eye")
                         .font(.system(size: 12, weight: .light))
-                    Text("⌥Space")
+                    Text(blinkShortcut)
                         .font(mono(10))
                         .padding(.horizontal, 5).padding(.vertical, 1)
                         .overlay(Rectangle().stroke(pal.strokeBase.opacity(0.1), lineWidth: 1))
@@ -351,10 +363,72 @@ struct CapturePopoverView: View {
                 .foregroundStyle(pal.inkMid)  // #a6acae
             }
             .buttonStyle(.plain)
-            .help("Blink notes (⌥Space)")
+            .help("Show or hide all notes (\(blinkShortcut))")
+            .accessibilityLabel("Show or hide all notes")
+
+            footerIconButton(
+                icon: "square.grid.3x3",
+                label: "Grid",
+                help: "Show the spatial grid",
+                action: showGrid
+            )
+
+            Button(action: showCommands) {
+                HStack(spacing: 5) {
+                    Image(systemName: "command")
+                    Text("K")
+                        .font(mono(10))
+                        .padding(.horizontal, 5).padding(.vertical, 1)
+                        .overlay(Rectangle().stroke(pal.strokeBase.opacity(0.1), lineWidth: 1))
+                }
+                .font(.system(size: 12, weight: .light))
+                .foregroundStyle(pal.inkMid)
+            }
+            .buttonStyle(.plain)
+            .help("Open commands and notes (⌘K)")
+            .accessibilityLabel("Open commands and notes")
+
+            footerIconButton(
+                icon: "questionmark.circle",
+                label: nil,
+                help: "Blink Guide — activities and shortcuts",
+                action: openGuide
+            )
+
+            footerIconButton(
+                icon: "gearshape",
+                label: nil,
+                help: "Settings (⌘,)",
+                action: openSettings
+            )
         }
         .padding(.horizontal, 18)
         .frame(height: 38)
+    }
+
+    private func footerIconButton(
+        icon: String,
+        label: String?,
+        help: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                Image(systemName: icon)
+                    .font(.system(size: 12, weight: .light))
+                if let label {
+                    Text(label.uppercased())
+                        .font(mono(9.5))
+                        .tracking(0.7)
+                }
+            }
+            .foregroundStyle(pal.inkMid)
+            .frame(minWidth: 24, minHeight: 24)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(help)
+        .accessibilityLabel(help)
     }
 
     private var hairline: some View {

--- a/Sources/BlinkApp/NotePanel.swift
+++ b/Sources/BlinkApp/NotePanel.swift
@@ -444,6 +444,10 @@ final class NotePanel: NSPanel {
             return true
         }
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if flags == [.command], event.charactersIgnoringModifiers?.lowercased() == "k" {
+            NotificationCenter.default.post(name: .blinkCommandPaletteRequested, object: self)
+            return true
+        }
         if flags == [.command], event.charactersIgnoringModifiers?.lowercased() == "w" {
             close()  // borderless: performClose would beep (no close button)
             return true
@@ -708,6 +712,21 @@ final class NotePanel: NSPanel {
             at: NSPoint(x: anchor.bounds.minX, y: anchor.bounds.maxY + 4),
             in: anchor
         )
+    }
+
+    /// App-level command-palette counterparts to the note context menu. These
+    /// deliberately reuse the same truthful providers and file URLs instead of
+    /// reimplementing note actions in the palette layer.
+    func showCommandStylePicker() { showStylePicker() }
+    func copyCommandNoteID() { copyNoteID() }
+    func copyCommandMarkdown() {
+        guard let markdown = markdownProvider?() else { return }
+        copyToPasteboard(markdown)
+    }
+    func copyCommandFilePath() { copyToPasteboard(noteFileURL.path) }
+    func openCommandMarkdownFile() { NSWorkspace.shared.open(noteFileURL) }
+    func revealCommandNoteInFinder() {
+        NSWorkspace.shared.activateFileViewerSelecting([noteFileURL])
     }
 
     private func normalizeMenuSeparators(_ menu: NSMenu) {
@@ -1282,12 +1301,18 @@ final class PanelModeState: ObservableObject {
 /// ✎/◧ mode segments; the active segment is lit. Hover-revealed, top-right.
 private struct ModeToggle: View {
     @ObservedObject var state: PanelModeState
+    @ObservedObject private var configStore = BlinkConfigStore.shared
     var onSelect: (String) -> Void
+
+    private var shortcut: String {
+        KeyChord.parse(configStore.config.hotkeys.toggleMode)?.display
+            ?? configStore.config.hotkeys.toggleMode
+    }
 
     var body: some View {
         HStack(spacing: 2) {
-            segment(icon: "pencil", mode: "edit", help: "Edit (⌘⇧P)")
-            segment(icon: "book", mode: "read", help: "Read (⌘⇧P)")
+            segment(icon: "pencil", mode: "edit", help: "Edit (\(shortcut))")
+            segment(icon: "book", mode: "read", help: "Read (\(shortcut))")
         }
         .padding(2)
         .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
@@ -1381,30 +1406,13 @@ private struct ThemeMarkBadge: View {
 }
 
 /// Resolve theme marks from Blink's attachment store, never from note markdown.
-/// Relative-only + symlink containment mirrors the web asset handler's boundary:
-/// a theme typo becomes an absent mark, not an arbitrary file read.
+/// The relative-only + symlink containment rule lives in
+/// `BlinkPaths.attachment(named:)` so the app and the `blink` CLI enforce one
+/// boundary: a theme typo becomes an absent mark, not an arbitrary file read.
 private enum ThemeMarkLoader {
     static func image(named raw: String?) -> NSImage? {
-        guard let raw else { return nil }
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, !trimmed.hasPrefix("/") else { return nil }
-
-        let relative: String
-        if trimmed.hasPrefix("blink://attachments/") {
-            relative = String(trimmed.dropFirst("blink://attachments/".count))
-        } else {
-            relative = trimmed
-        }
-
-        let root = BlinkPaths.attachments().standardizedFileURL.resolvingSymlinksInPath()
-        let candidate = root.appendingPathComponent(relative)
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-        guard candidate.path.hasPrefix(root.path + "/"),
-              let values = try? candidate.resourceValues(forKeys: [.isRegularFileKey]),
-              values.isRegularFile == true
-        else { return nil }
-        return NSImage(contentsOf: candidate)
+        guard let url = BlinkPaths.attachment(named: raw) else { return nil }
+        return NSImage(contentsOf: url)
     }
 }
 
@@ -1460,7 +1468,13 @@ private struct StyleMetadataBadge: View {
 /// deliberately not a peer of the mode segments. Fills in while focus is on.
 private struct FocusGlyph: View {
     @ObservedObject var state: PanelModeState
+    @ObservedObject private var configStore = BlinkConfigStore.shared
     var onTap: () -> Void
+
+    private var shortcut: String {
+        KeyChord.parse(configStore.config.hotkeys.focus)?.display
+            ?? configStore.config.hotkeys.focus
+    }
 
     var body: some View {
         Button(action: onTap) {
@@ -1469,7 +1483,7 @@ private struct FocusGlyph: View {
                 .foregroundStyle(state.focus ? .white : .white.opacity(0.5))
         }
         .buttonStyle(.plain)
-        .help("Focus — quiet everything else (⌘.)")
+        .help("Focus — quiet everything else (\(shortcut))")
     }
 }
 

--- a/Sources/BlinkApp/PanelManager.swift
+++ b/Sources/BlinkApp/PanelManager.swift
@@ -571,6 +571,48 @@ final class PanelManager: NSObject, NSWindowDelegate {
     /// The panel that currently has key focus, if any.
     var keyNotePanel: NotePanel? { panels.values.first { $0.isKeyWindow } }
 
+    /// The note panel an app-level command should act on. Opening an interstitial
+    /// palette makes that palette key, so commands must fall back to the most
+    /// recently focused note instead of losing their target during presentation.
+    var commandNotePanel: NotePanel? {
+        keyNotePanel
+            ?? mostRecentKeyPanelID.flatMap { panels[$0] }
+            ?? NSApp.orderedWindows.compactMap { $0 as? NotePanel }.first { panel in
+                panels[panel.noteID] === panel
+            }
+    }
+
+    var hasCommandNotePanel: Bool { commandNotePanel != nil }
+
+    func toggleCommandNoteMode() {
+        guard let panel = commandNotePanel else { return }
+        panel.selectMode(panel.currentMode == "edit" ? "read" : "edit")
+    }
+
+    func toggleCommandNoteFocus() {
+        commandNotePanel?.toggleFocus()
+    }
+
+    func hideCommandNote() {
+        guard let panel = commandNotePanel else { return }
+        panel.orderOut(nil)
+        panel.onVisibilityChanged?()
+    }
+
+    /// Uses the panel's normal close path. `windowWillClose` still owns the
+    /// mandatory pending-save flush, so invoking Close from the palette cannot
+    /// bypass Blink's data-safety invariant.
+    func closeCommandNote() {
+        commandNotePanel?.close()
+    }
+
+    func chooseCommandNoteStyle() { commandNotePanel?.showCommandStylePicker() }
+    func copyCommandNoteID() { commandNotePanel?.copyCommandNoteID() }
+    func copyCommandNoteMarkdown() { commandNotePanel?.copyCommandMarkdown() }
+    func copyCommandNoteFilePath() { commandNotePanel?.copyCommandFilePath() }
+    func openCommandNoteFile() { commandNotePanel?.openCommandMarkdownFile() }
+    func revealCommandNoteInFinder() { commandNotePanel?.revealCommandNoteInFinder() }
+
     /// Turn the desk into one drawn page. The overlay owns its scoped key
     /// registrations; this manager supplies the live panel set and remembers
     /// which panel should move after Blink (or another app) takes key focus.
@@ -595,11 +637,7 @@ final class PanelManager: NSObject, NSWindowDelegate {
     }
 
     private var placementPanel: NotePanel? {
-        keyNotePanel
-            ?? mostRecentKeyPanelID.flatMap { panels[$0] }
-            ?? NSApp.orderedWindows.compactMap { $0 as? NotePanel }.first { panel in
-                panels[panel.noteID] === panel
-            }
+        commandNotePanel
     }
 
     /// Hot-apply a config change to every live surface.

--- a/Sources/BlinkApp/SettingsView.swift
+++ b/Sources/BlinkApp/SettingsView.swift
@@ -2,12 +2,23 @@ import AppKit
 import HudsonUI
 import SwiftUI
 
-/// Blink's whole settings surface: three sections, one screen — built from
-/// HudsonKit's settings primitives. The UI is a *view* over the agent-first
-/// config file; everything here round-trips through config.json.
+/// Blink's settings are a view over the agent-first config file. Every mutable
+/// control round-trips through `BlinkConfigStore.update`; external edits remain
+/// authoritative and repaint this surface through the observed store.
 struct SettingsView: View {
     @ObservedObject var store: BlinkConfigStore
     let notesDirectory: URL
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var selection: SettingsSection = .general
+
+    private var settingsTheme: HudTheme {
+        switch store.config.appearance.lowercased() {
+        case "light": return .lightDraft
+        case "dark": return .default
+        default: return colorScheme == .light ? .lightDraft : .default
+        }
+    }
 
     private var tildePath: String {
         notesDirectory.path.replacingOccurrences(of: NSHomeDirectory(), with: "~")
@@ -34,138 +45,723 @@ struct SettingsView: View {
         )
     }
 
-    /// Pretty form of a config chord string ("hyper+n" → "⌃⌥⇧⌘N").
+    private var defaultSheet: Binding<String> {
+        Binding(
+            get: { store.config.panel.sheet },
+            set: { value in store.update { $0.panel.sheet = value } }
+        )
+    }
+
+    private var panelShadow: Binding<Bool> {
+        Binding(
+            get: { store.config.panel.shadow },
+            set: { value in store.update { $0.panel.shadow = value } }
+        )
+    }
+
+    private var panelSize: Binding<PanelSizePreset> {
+        Binding(
+            get: {
+                PanelSizePreset.matching(
+                    width: store.config.panel.defaultWidth,
+                    height: store.config.panel.defaultHeight
+                )
+            },
+            set: { preset in
+                guard let size = preset.size else { return }
+                store.update {
+                    $0.panel.defaultWidth = size.width
+                    $0.panel.defaultHeight = size.height
+                }
+            }
+        )
+    }
+
+    private var appearance: Binding<String> {
+        Binding(
+            get: {
+                let value = store.config.appearance.lowercased()
+                return ["auto", "light", "dark"].contains(value) ? value : "auto"
+            },
+            set: { value in store.update { $0.appearance = value } }
+        )
+    }
+
+    private var backgroundLevel: Binding<BackgroundLevel> {
+        Binding(
+            get: {
+                guard store.config.drape.enabled else { return .off }
+                return store.config.drape.opacity <= 0.7 ? .light : .full
+            },
+            set: { level in
+                store.update {
+                    switch level {
+                    case .off:
+                        $0.drape.enabled = false
+                    case .light:
+                        $0.drape.enabled = true
+                        $0.drape.opacity = 0.4
+                    case .full:
+                        $0.drape.enabled = true
+                        $0.drape.opacity = 1
+                    }
+                }
+            }
+        )
+    }
+
+    private var suppressSoloDrape: Binding<Bool> {
+        Binding(
+            get: { store.config.drape.soloSuppressed },
+            set: { value in store.update { $0.drape.soloSuppressed = value } }
+        )
+    }
+
+    private var focusDim: Binding<Double> {
+        Binding(
+            get: { store.config.focus.dim },
+            set: { value in store.update { $0.focus.dim = value } }
+        )
+    }
+
+    private var motionEnabled: Binding<Bool> {
+        Binding(
+            get: { store.config.motion.enabled },
+            set: { value in store.update { $0.motion.enabled = value } }
+        )
+    }
+
+    private var entrance: Binding<String> {
+        Binding(
+            get: { store.config.motion.entrance },
+            set: { value in store.update { $0.motion.entrance = value } }
+        )
+    }
+
+    private var flingEnabled: Binding<Bool> {
+        Binding(
+            get: { store.config.physics.flingEnabled },
+            set: { value in store.update { $0.physics.flingEnabled = value } }
+        )
+    }
+
+    private var shakeEnabled: Binding<Bool> {
+        Binding(
+            get: { store.config.physics.shakeEnabled },
+            set: { value in store.update { $0.physics.shakeEnabled = value } }
+        )
+    }
+
+    /// Pretty form of a config chord string ("hyper+n" -> "⌃⌥⇧⌘N").
     private func chord(_ raw: String) -> String {
         KeyChord.parse(raw)?.display ?? raw
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: HudSpacing.xl) {
-                HudSettingsSection("General") {
-                    HudSettingsRow(
-                        icon: "folder",
-                        title: "Notes folder",
-                        subtitle: tildePath,
-                        badge: {
-                            Button("Reveal") {
-                                NSWorkspace.shared.activateFileViewerSelecting([notesDirectory])
-                            }
-                            .controlSize(.small)
-                        }
-                    )
-                    HudSettingsRow(
-                        icon: "curlybraces",
-                        title: "Config file",
-                        subtitle: store.displayPath + " — theme, behavior; agents edit this too",
-                        badge: {
-                            Button("Open") {
-                                NSWorkspace.shared.open(store.fileURL)
-                            }
-                            .controlSize(.small)
-                        }
-                    )
-                    HudSettingsControlRow(
-                        title: "Restore panels at launch",
-                        subtitle: "Reopen last session's notes where you left them",
-                        icon: "macwindow.on.rectangle"
-                    ) {
-                        Toggle("", isOn: restoreSession)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .controlSize(.small)
-                    }
-                    HudSettingsControlRow(
-                        title: "Launch at login",
-                        subtitle: "Start Blink when you sign in",
-                        icon: "power"
-                    ) {
-                        Toggle("", isOn: launchAtLogin)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .controlSize(.small)
-                    }
-                }
+        HStack(spacing: 0) {
+            sidebar
 
-                HudSettingsSection("Editor") {
-                    HudSettingsControlRow(
-                        title: "Open notes in",
-                        subtitle: "New notes always open in edit",
-                        icon: "book"
-                    ) {
-                        Picker("", selection: defaultMode) {
-                            Text("Read").tag("read")
-                            Text("Edit").tag("edit")
-                        }
-                        .pickerStyle(.segmented)
-                        .labelsHidden()
-                        .frame(width: 130)
-                    }
-                    HudSettingsRow(
-                        icon: "paintpalette",
-                        title: "Theme",
-                        subtitle: "Fonts, colors, glass, shadows — edit theme values in the config file"
-                    )
-                }
+            Rectangle()
+                .fill(settingsTheme.hairline.standard)
+                .frame(width: HudStrokeWidth.thin)
+                .accessibilityHidden(true)
 
-                HudSettingsSection("Shortcuts") {
-                    HudSettingsRow(
-                        icon: "plus.square",
-                        title: "New note",
-                        subtitle: "Rebind any of these in the config file's hotkeys section",
-                        badge: { KeyCap(chord(store.config.hotkeys.newNote)) }
-                    )
-                    HudSettingsRow(
-                        icon: "eye",
-                        title: "Blink — all notes / none",
-                        badge: { KeyCap(chord(store.config.hotkeys.blink)) }
-                    )
-                    HudSettingsRow(
-                        icon: "book.closed",
-                        title: "Flip read / edit",
-                        badge: { KeyCap(chord(store.config.hotkeys.toggleMode)) }
-                    )
-                    HudSettingsRow(
-                        icon: "circle.dashed",
-                        title: "Focus",
-                        badge: { KeyCap(chord(store.config.hotkeys.focus)) }
-                    )
-                    HudSettingsRow(
-                        icon: "grid",
-                        title: "Grid overlay",
-                        badge: { KeyCap(chord(store.config.hotkeys.grid)) }
-                    )
-                    HudSettingsRow(
-                        icon: "xmark.square",
-                        title: "Close panel",
-                        subtitle: "⎋ steps down: leaves edit, then drops focus",
-                        badge: { KeyCap("⌘W") }
-                    )
-                    HudSettingsRow(
-                        icon: "command",
-                        title: "Command palette",
-                        subtitle: "soon",
-                        badge: { KeyCap("⌘K") }
-                    )
+            content
+        }
+        .frame(
+            minWidth: HudLayout.dialogWidth + HudLayout.rowHeightRegular,
+            idealWidth: HudLayout.readableWidth + HudSpacing.xxxl,
+            minHeight: HudLayout.dialogWidth - HudSpacing.xxxl,
+            idealHeight: HudLayout.readableWidth - HudSpacing.huge
+        )
+        .background(settingsTheme.palette.bg)
+        .hudTheme(settingsTheme)
+    }
+
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.xl) {
+            Text("Settings")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(settingsTheme.palette.ink)
+                .padding(.horizontal, HudSpacing.xxl)
+                .padding(.top, HudSpacing.xxxl)
+
+            VStack(spacing: HudSpacing.xs) {
+                ForEach(SettingsSection.allCases) { section in
+                    Button {
+                        selection = section
+                    } label: {
+                        HStack(spacing: HudSpacing.lg) {
+                            Image(systemName: section.icon)
+                                .font(.system(size: 13, weight: .medium))
+                                .frame(width: HudIconSize.small, height: HudIconSize.small)
+
+                            Text(section.title)
+                                .font(.system(size: 13, weight: .medium))
+
+                            Spacer(minLength: 0)
+                        }
+                        .foregroundStyle(
+                            selection == section
+                                ? settingsTheme.palette.ink
+                                : settingsTheme.palette.muted
+                        )
+                        .padding(.horizontal, HudSpacing.xl)
+                        .frame(height: HudLayout.rowHeightCompact)
+                        .background(
+                            RoundedRectangle(cornerRadius: settingsTheme.radius.standard)
+                                .fill(
+                                    selection == section
+                                        ? settingsTheme.palette.accentSoft
+                                        : Color.clear
+                                )
+                        )
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(section.title) settings")
+                    .accessibilityAddTraits(selection == section ? .isSelected : [])
                 }
             }
-            .padding(HudSpacing.xl)
+            .padding(.horizontal, HudSpacing.md)
+
+            Spacer(minLength: HudSpacing.xxxl)
+
+            HStack(alignment: .top, spacing: HudSpacing.sm) {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.system(size: 10, weight: .medium))
+                    .padding(.top, HudSpacing.xxs)
+
+                Text("Changes sync with config.json")
+                    .font(.system(size: 11))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .foregroundStyle(settingsTheme.palette.dim)
+            .padding(.horizontal, HudSpacing.xxl)
+            .padding(.bottom, HudSpacing.xxl)
         }
-        .frame(width: 460, height: 640)
+        .frame(width: HudLayout.popoverWidthCompact / 2)
+        .background(settingsTheme.palette.chrome)
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: HudSpacing.xs) {
+                Text(selection.title)
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(settingsTheme.palette.ink)
+
+                Text(selection.subtitle)
+                    .font(.system(size: 12))
+                    .foregroundStyle(settingsTheme.palette.muted)
+            }
+            .padding(.horizontal, HudSpacing.huge)
+            .padding(.top, HudSpacing.xxxl)
+            .padding(.bottom, HudSpacing.xxl)
+
+            ScrollView {
+                selectedPage
+                    .frame(maxWidth: HudLayout.readableWidth, alignment: .leading)
+                    .padding(.horizontal, HudSpacing.huge)
+                    .padding(.bottom, HudSpacing.huge)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private var selectedPage: some View {
+        switch selection {
+        case .general: generalPage
+        case .notes: notesPage
+        case .desktop: desktopPage
+        case .shortcuts: shortcutsPage
+        }
+    }
+
+    private var generalPage: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.xl) {
+            HudSettingsSection("Files", labelTint: settingsTheme.palette.muted) {
+                HudSettingsRow(
+                    icon: "folder",
+                    title: "Notes folder",
+                    subtitle: tildePath,
+                    badge: {
+                        Button("Reveal") {
+                            NSWorkspace.shared.activateFileViewerSelecting([notesDirectory])
+                        }
+                        .controlSize(.small)
+                        .accessibilityHint("Shows the Blink notes folder in Finder")
+                    }
+                )
+                SettingsDivider()
+                HudSettingsRow(
+                    icon: "curlybraces",
+                    title: "Config file",
+                    subtitle: store.displayPath,
+                    badge: {
+                        Button("Open") { openConfig() }
+                            .controlSize(.small)
+                            .accessibilityHint("Opens Blink's JSON configuration file")
+                    }
+                )
+            }
+
+            HudSettingsSection("Startup", labelTint: settingsTheme.palette.muted) {
+                HudSettingsControlRow(
+                    title: "Restore panels at launch",
+                    subtitle: "Reopen notes where you left them",
+                    icon: "macwindow.on.rectangle"
+                ) {
+                    Toggle("Restore panels at launch", isOn: restoreSession)
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .controlSize(.small)
+                        .accessibilityLabel("Restore panels at launch")
+                }
+                SettingsDivider()
+                HudSettingsControlRow(
+                    title: "Launch at login",
+                    subtitle: "Start Blink when you sign in",
+                    icon: "power"
+                ) {
+                    Toggle("Launch at login", isOn: launchAtLogin)
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .controlSize(.small)
+                        .accessibilityLabel("Launch Blink at login")
+                }
+            }
+        }
+    }
+
+    private var notesPage: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.xl) {
+            HudSettingsSection("Defaults", labelTint: settingsTheme.palette.muted) {
+                HudSettingsControlRow(
+                    title: "Open notes in",
+                    subtitle: "New notes can open ready to read or write",
+                    icon: "book"
+                ) {
+                    Picker("Open notes in", selection: defaultMode) {
+                        Text("Read").tag("read")
+                        Text("Edit").tag("edit")
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .frame(width: HudLayout.popoverWidthCompact / 2.6)
+                    .accessibilityLabel("Default note mode")
+                }
+                SettingsDivider()
+                HudSettingsPickerRow(
+                    title: "Default sheet",
+                    subtitle: "The starting look for notes without an override",
+                    icon: "rectangle.on.rectangle",
+                    selection: defaultSheet
+                ) {
+                    Text("Glass").tag("glass")
+                    Text("Card").tag("card")
+                    Text("Dotted").tag("dotted")
+                    Text("Bracket").tag("bracket")
+                    Text("Marginalia").tag("marginalia")
+                }
+                SettingsDivider()
+                HudSettingsControlRow(
+                    title: "Default panel size",
+                    subtitle: panelSize.wrappedValue.description,
+                    icon: "arrow.up.left.and.arrow.down.right"
+                ) {
+                    Picker("Default panel size", selection: panelSize) {
+                        Text("Compact").tag(PanelSizePreset.compact)
+                        Text("Standard").tag(PanelSizePreset.standard)
+                        Text("Large").tag(PanelSizePreset.large)
+                        if panelSize.wrappedValue == .custom {
+                            Text("Custom").tag(PanelSizePreset.custom)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: HudLayout.popoverWidthCompact / 2)
+                    .accessibilityLabel("Default panel size")
+                }
+                SettingsDivider()
+                HudSettingsControlRow(
+                    title: "Panel shadow",
+                    subtitle: "Add depth to glass and card sheets",
+                    icon: "square.3.layers.3d.down.right"
+                ) {
+                    Toggle("Panel shadow", isOn: panelShadow)
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .controlSize(.small)
+                        .accessibilityLabel("Show panel shadows")
+                }
+            }
+
+            HudSettingsSection("Advanced", labelTint: settingsTheme.palette.muted) {
+                HudSettingsRow(
+                    icon: "paintpalette",
+                    title: "Appearance, typography, styles & workspaces",
+                    subtitle: "Tune fonts, colors, glass, spacing and named styles in config.json",
+                    onTap: openConfig
+                )
+                .accessibilityHint("Opens Blink's JSON configuration file")
+            }
+        }
+    }
+
+    private var desktopPage: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.xl) {
+            HudSettingsSection("Appearance", labelTint: settingsTheme.palette.muted) {
+                HudSettingsControlRow(
+                    title: "Appearance",
+                    subtitle: "Auto follows macOS",
+                    icon: "circle.lefthalf.filled"
+                ) {
+                    Picker("Appearance", selection: appearance) {
+                        Text("Auto").tag("auto")
+                        Text("Light").tag("light")
+                        Text("Dark").tag("dark")
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .frame(width: HudLayout.popoverWidthCompact / 2)
+                    .accessibilityLabel("Blink appearance")
+                }
+                SettingsDivider()
+                HudSettingsControlRow(
+                    title: "Desktop background",
+                    subtitle: "A calm stage behind a set of notes",
+                    icon: "rectangle.inset.filled"
+                ) {
+                    Picker("Desktop background", selection: backgroundLevel) {
+                        ForEach(BackgroundLevel.allCases) { level in
+                            Text(level.title).tag(level)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .frame(width: HudLayout.popoverWidthCompact / 2)
+                    .accessibilityLabel("Desktop background strength")
+                }
+                SettingsDivider()
+                HudSettingsControlRow(
+                    title: "Keep one note clear",
+                    subtitle: "Show the background only when notes form a set",
+                    icon: "rectangle.on.rectangle.slash"
+                ) {
+                    Toggle("Keep one note clear", isOn: suppressSoloDrape)
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .controlSize(.small)
+                        .disabled(!store.config.drape.enabled)
+                        .accessibilityLabel("Keep the desktop clear behind a single note")
+                }
+                SettingsDivider()
+                HudSettingsControlRow(
+                    title: "Focus dimming",
+                    subtitle: "Quiet the desktop around the focused note",
+                    value: "\(Int(store.config.focus.dim * 100))%",
+                    icon: "circle.dashed"
+                ) {
+                    Slider(value: focusDim, in: 0...0.8, step: 0.05)
+                        .frame(width: HudLayout.popoverWidthCompact / 2)
+                        .accessibilityLabel("Focus dimming")
+                        .accessibilityValue("\(Int(store.config.focus.dim * 100)) percent")
+                }
+            }
+
+            HudSettingsSection("Motion & Gestures", labelTint: settingsTheme.palette.muted) {
+                HudSettingsControlRow(
+                    title: "Panel motion",
+                    subtitle: "Animate notes as they appear and recede",
+                    icon: "sparkles"
+                ) {
+                    Toggle("Panel motion", isOn: motionEnabled)
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .controlSize(.small)
+                        .accessibilityLabel("Animate panels")
+                }
+                SettingsDivider()
+                HudSettingsPickerRow(
+                    title: "Entrance effect",
+                    subtitle: "Reduce Motion in macOS always takes precedence",
+                    icon: "wand.and.stars",
+                    selection: entrance
+                ) {
+                    Text("Shimmer").tag("shimmer")
+                    Text("Drop").tag("drop")
+                    Text("Draw").tag("draw")
+                    Text("None").tag("none")
+                }
+                .disabled(!store.config.motion.enabled)
+                SettingsDivider()
+                HudSettingsControlRow(
+                    title: "Fling panels",
+                    subtitle: "Release a quick drag to glide and bounce",
+                    icon: "hand.draw"
+                ) {
+                    Toggle("Fling panels", isOn: flingEnabled)
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .controlSize(.small)
+                        .accessibilityLabel("Fling panels after a quick drag")
+                }
+                SettingsDivider()
+                HudSettingsControlRow(
+                    title: "Shake to shade",
+                    subtitle: "Shake a panel sideways to fold its content",
+                    icon: "arrow.left.and.right"
+                ) {
+                    Toggle("Shake to shade", isOn: shakeEnabled)
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .controlSize(.small)
+                        .accessibilityLabel("Shake panels to shade them")
+                }
+            }
+        }
+    }
+
+    private var shortcutsPage: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.xl) {
+            HudSettingsSection(
+                "Global — configurable in config.json",
+                labelTint: settingsTheme.palette.muted
+            ) {
+                ShortcutRow(
+                    icon: "plus.square",
+                    title: "New note",
+                    subtitle: "Works from any app",
+                    keys: chord(store.config.hotkeys.newNote)
+                )
+                SettingsDivider()
+                ShortcutRow(
+                    icon: "eye",
+                    title: "Blink all notes / none",
+                    subtitle: "Works from any app",
+                    keys: chord(store.config.hotkeys.blink)
+                )
+                SettingsDivider()
+                ShortcutRow(
+                    icon: "square.grid.3x3",
+                    title: "Grid overlay",
+                    subtitle: "Works from any app",
+                    keys: chord(store.config.hotkeys.grid)
+                )
+            }
+
+            HudSettingsSection(
+                "Panel — configurable in config.json",
+                labelTint: settingsTheme.palette.muted
+            ) {
+                ShortcutRow(
+                    icon: "book.closed",
+                    title: "Flip read / edit",
+                    keys: chord(store.config.hotkeys.toggleMode)
+                )
+                SettingsDivider()
+                ShortcutRow(
+                    icon: "circle.dashed",
+                    title: "Focus",
+                    keys: chord(store.config.hotkeys.focus)
+                )
+            }
+
+            HudSettingsSection("Panel — fixed", labelTint: settingsTheme.palette.muted) {
+                ShortcutRow(icon: "square.and.arrow.down", title: "Save note", keys: "⌘S")
+                SettingsDivider()
+                ShortcutRow(icon: "xmark.square", title: "Close panel", keys: "⌘W")
+                SettingsDivider()
+                ShortcutRow(
+                    icon: "escape",
+                    title: "Step back",
+                    subtitle: "Leave edit, then leave focus",
+                    keys: "⎋"
+                )
+            }
+
+            HudSettingsSection(
+                "Blink & Capture — fixed",
+                labelTint: settingsTheme.palette.muted
+            ) {
+                ShortcutRow(icon: "command", title: "Command palette", keys: "⌘K")
+                SettingsDivider()
+                ShortcutRow(icon: "gearshape", title: "Settings", keys: "⌘,")
+                SettingsDivider()
+                ShortcutRow(
+                    icon: "arrow.turn.down.left",
+                    title: "Open selected note",
+                    subtitle: "In the capture popover",
+                    keys: "↩"
+                )
+                SettingsDivider()
+                ShortcutRow(
+                    icon: "plus",
+                    title: "Create from typed text",
+                    subtitle: "In the capture popover",
+                    keys: "⌘↩"
+                )
+            }
+
+            HudSettingsSection("Grid — fixed", labelTint: settingsTheme.palette.muted) {
+                ShortcutRow(
+                    icon: "square.grid.3x3",
+                    title: "Place selected note",
+                    subtitle: "Nine positions follow the keyboard grid",
+                    keys: "Q–C"
+                )
+                SettingsDivider()
+                ShortcutRow(icon: "escape", title: "Cancel grid", keys: "⎋")
+            }
+
+            HudSettingsRow(
+                icon: "curlybraces",
+                title: "Rebind configurable shortcuts",
+                subtitle: "Edit the hotkeys section in config.json; Blink applies changes live",
+                onTap: openConfig
+            )
+            .accessibilityHint("Opens Blink's JSON configuration file")
+        }
+    }
+
+    private func openConfig() {
+        NSWorkspace.shared.open(store.fileURL)
+    }
+}
+
+private enum SettingsSection: String, CaseIterable, Identifiable {
+    case general
+    case notes
+    case desktop
+    case shortcuts
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .general: "General"
+        case .notes: "Notes"
+        case .desktop: "Desktop"
+        case .shortcuts: "Shortcuts"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .general: "Files, startup and session behavior"
+        case .notes: "How new notes look and open"
+        case .desktop: "Appearance, focus, movement and gestures"
+        case .shortcuts: "Keyboard actions grouped by where they work"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .general: "gearshape"
+        case .notes: "note.text"
+        case .desktop: "display"
+        case .shortcuts: "keyboard"
+        }
+    }
+}
+
+private enum BackgroundLevel: String, CaseIterable, Identifiable {
+    case off
+    case light
+    case full
+
+    var id: String { rawValue }
+    var title: String { rawValue.capitalized }
+}
+
+private enum PanelSizePreset: String, Hashable {
+    case compact
+    case standard
+    case large
+    case custom
+
+    var size: (width: Double, height: Double)? {
+        switch self {
+        case .compact: (360, 280)
+        case .standard: (420, 340)
+        case .large: (520, 420)
+        case .custom: nil
+        }
+    }
+
+    var description: String {
+        guard let size else { return "Custom size from config.json" }
+        return "\(Int(size.width)) × \(Int(size.height)) points"
+    }
+
+    static func matching(width: Double, height: Double) -> PanelSizePreset {
+        for preset in [PanelSizePreset.compact, .standard, .large] {
+            guard let size = preset.size else { continue }
+            if abs(width - size.width) < 0.5, abs(height - size.height) < 0.5 {
+                return preset
+            }
+        }
+        return .custom
+    }
+}
+
+private struct SettingsDivider: View {
+    @Environment(\.hudTheme) private var theme
+
+    var body: some View {
+        Rectangle()
+            .fill(theme.hairline.subtle)
+            .frame(height: HudStrokeWidth.thin)
+            .padding(.leading, HudIconSize.medium + HudSpacing.xl + HudSpacing.md)
+            .accessibilityHidden(true)
+    }
+}
+
+private struct ShortcutRow: View {
+    let icon: String
+    let title: String
+    var subtitle: String?
+    let keys: String
+
+    init(icon: String, title: String, subtitle: String? = nil, keys: String) {
+        self.icon = icon
+        self.title = title
+        self.subtitle = subtitle
+        self.keys = keys
+    }
+
+    var body: some View {
+        HudSettingsRow(
+            icon: icon,
+            title: title,
+            subtitle: subtitle,
+            badge: { KeyCap(keys) }
+        )
     }
 }
 
 /// Small keycap chip for shortcut rows.
 private struct KeyCap: View {
     let keys: String
+    @Environment(\.hudTheme) private var theme
+
     init(_ keys: String) { self.keys = keys }
 
     var body: some View {
         Text(keys)
-            .font(.system(size: 11, design: .monospaced))
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 4))
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .foregroundStyle(theme.palette.muted)
+            .padding(.horizontal, HudSpacing.sm)
+            .padding(.vertical, HudSpacing.xxs)
+            .background(
+                RoundedRectangle(cornerRadius: theme.radius.tight)
+                    .fill(theme.palette.chrome)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: theme.radius.tight)
+                    .stroke(theme.hairline.standard, lineWidth: HudStrokeWidth.thin)
+            )
+            .accessibilityLabel("Keyboard shortcut \(keys)")
     }
 }

--- a/Sources/BlinkCLI/BlinkCLI.swift
+++ b/Sources/BlinkCLI/BlinkCLI.swift
@@ -16,10 +16,10 @@ struct BlinkCommand: AsyncParsableCommand {
         else ~/Library/Application Support/Blink/Notes. Every command takes \
         --json for structured output.
         """,
-        version: "2.0.3",
+        version: "2.0.4",
         subcommands: [
             Ls.self, Cat.self, New.self, Present.self, Append.self, Type.self, Write.self,
-            Search.self, Rm.self, PathCommand.self,
+            Search.self, Rm.self, PathCommand.self, WorkspaceCommand.self,
         ]
     )
 }
@@ -66,6 +66,8 @@ struct New: AsyncParsableCommand {
         discussion: "The first line becomes the title; the id is a unique slug derived from it."
     )
 
+    @Option(help: "Create the note inside this workspace (blink.workspace).")
+    var workspace: String?
     @Argument(parsing: .remaining, help: "Note content (omit to read stdin).")
     var content: [String] = []
     @Flag(help: "Structured output.") var json = false
@@ -77,7 +79,13 @@ struct New: AsyncParsableCommand {
                 decoding: FileHandle.standardInput.readDataToEndOfFile(), as: UTF8.self
             )
         }
-        let note = try await loadedStore().create(content: text)
+        var note = try await loadedStore().create(content: text)
+        // Membership is a second write rather than a create parameter: the store
+        // owns slug assignment, and this keeps `create` a single-purpose verb.
+        if let workspace {
+            note.presentation.workspace = try WorkspaceStore.normalize(workspace)
+            try fileStore().save(note)
+        }
         if json {
             try printJSON(NoteJSON(note, full: false))
         } else {
@@ -102,6 +110,7 @@ struct Present: AsyncParsableCommand {
     @Argument(parsing: .allUnrecognized, help: "Markdown content (omit to keep existing / read stdin).")
     var content: [String] = []
 
+    @Option(help: "Workspace to file this note under (blink.workspace).") var workspace: String?
     @Option(help: "Named style preset from config (blink.style).") var style: String?
     @Option(help: "Sheet template (blink.sheet).") var sheet: String?
     @Option(help: "Accent color, e.g. #9ece6a (blink.accent).") var accent: String?
@@ -140,6 +149,7 @@ struct Present: AsyncParsableCommand {
 
         // Overlay only the presentation fields provided — never erase the rest.
         var p = note.presentation
+        if let workspace { p.workspace = try WorkspaceStore.normalize(workspace) }
         if let style { p.style = style }
         if let sheet { p.sheet = sheet }
         if let accent { p.accent = accent }
@@ -284,11 +294,11 @@ struct PathCommand: ParsableCommand {
 
 // MARK: - Shared plumbing
 
-private func fileStore() -> NoteFileStore {
+func fileStore() -> NoteFileStore {
     NoteFileStore(directory: BlinkPaths.notes())
 }
 
-private func loadedStore() async throws -> NoteStore {
+func loadedStore() async throws -> NoteStore {
     let store = NoteStore(fileStore: fileStore())
     try await store.load()
     return store
@@ -324,7 +334,7 @@ struct NoteNotFound: Error, CustomStringConvertible {
     var description: String { "no note with id '\(id)' in \(BlinkPaths.notes().path)" }
 }
 
-private func existingNote(id: String) throws -> Note {
+func existingNote(id: String) throws -> Note {
     do {
         return try fileStore().load(id: id)
     } catch {
@@ -357,7 +367,7 @@ struct NoteJSON: Encodable {
     }
 }
 
-private func output(_ notes: [Note], json: Bool) throws {
+func output(_ notes: [Note], json: Bool) throws {
     if json {
         try printJSON(notes.map { NoteJSON($0, full: false) })
     } else if notes.isEmpty {
@@ -373,7 +383,7 @@ private func output(_ notes: [Note], json: Bool) throws {
     }
 }
 
-private func printJSON(_ value: some Encodable) throws {
+func printJSON(_ value: some Encodable) throws {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
     encoder.dateEncodingStrategy = .custom { date, encoder in

--- a/Sources/BlinkCLI/WorkspaceCommands.swift
+++ b/Sources/BlinkCLI/WorkspaceCommands.swift
@@ -1,0 +1,545 @@
+import ArgumentParser
+import BlinkCore
+import Foundation
+
+/// `blink workspace …` — the agent-facing face of Notes Workspaces.
+///
+/// A workspace is two things kept deliberately apart:
+/// - a **definition** in `config.json` → `workspaces.<name>` (title + brand),
+/// - **membership**, one `blink.workspace:` key in each note's frontmatter.
+///
+/// So the brand is edited in one place and the markdown stays portable: a note
+/// carries a workspace *name*, never a color, font, or asset path. Forgetting a
+/// workspace costs a look, never a note. See `docs/workspaces.md`.
+struct WorkspaceCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "workspace",
+        abstract: "Create and brand a named workspace of notes.",
+        discussion: """
+        A workspace groups notes and gives them one identity. The definition \
+        (title + brand) lives in config.json; membership lives in each note's \
+        `blink.workspace` frontmatter key, so note markdown stays portable and \
+        free of presentation-only branding. Notes with no workspace, and \
+        workspaces with no brand, render exactly as they do today.
+        """,
+        subcommands: [
+            WorkspaceInit.self, WorkspaceList.self, WorkspaceShow.self, WorkspaceBrand.self,
+            WorkspaceAdd.self, WorkspaceRemove.self, WorkspaceNotes.self, WorkspaceForget.self,
+        ],
+        defaultSubcommand: WorkspaceList.self
+    )
+}
+
+// MARK: - Brand flags
+
+/// The brand vocabulary, shared by `init` and `brand` so one treatment surface
+/// is described in exactly one place. Every flag is optional: only what you pass
+/// changes, and an unset field inherits — which is what keeps unbranded the
+/// default and makes brands composable.
+struct BrandOptions: ParsableArguments {
+    // Surface
+    @Option(help: "Sheet template: glass | card | dotted | bracket | marginalia.")
+    var sheet: String?
+    @Option(help: "Opaque surface color, e.g. '#070908'. Unset keeps glass transparent.")
+    var background: String?
+    @Option(help: "Corner radius in px — the corner treatment.")
+    var radius: Double?
+    @Option(help: "Glass tint 0–1 (shorthand for both modes).")
+    var tint: Double?
+    @Option(name: .customLong("tint-read"), help: "Read-mode glass tint 0–1.")
+    var tintRead: Double?
+    @Option(name: .customLong("tint-edit"), help: "Edit-mode glass tint 0–1.")
+    var tintEdit: Double?
+
+    // Typography
+    @Option(help: "Body font family (CSS font-family string).")
+    var font: String?
+    @Option(help: "Monospace font family.")
+    var mono: String?
+    @Option(name: .customLong("title-font"), help: "Heading/title font family.")
+    var titleFont: String?
+    @Option(name: .customLong("font-size"), help: "Base font size in px.")
+    var fontSize: Double?
+    @Option(name: .customLong("line-height"), help: "Line height multiplier.")
+    var lineHeight: Double?
+
+    // Palette
+    @Option(help: "Body text color.") var text: String?
+    @Option(name: .customLong("text-strong"), help: "Headings/bold color.") var textStrong: String?
+    @Option(name: .customLong("text-muted"), help: "Muted text color.") var textMuted: String?
+    @Option(help: "Markdown syntax marker color.") var dim: String?
+    @Option(help: "Rules, quote borders, sheet frame color.") var border: String?
+    @Option(help: "Accent color (links, caret).") var accent: String?
+    @Option(name: .customLong("accent-dim"), help: "Secondary accent color.") var accentDim: String?
+    @Option(name: .customLong("code-background"), help: "Code block background.") var codeBackground: String?
+    @Option(name: .customLong("code-text"), help: "Code ink color.") var codeText: String?
+    @Option(help: "Caret color.") var caret: String?
+    @Option(help: "Selection color.") var selection: String?
+
+    // Identity
+    @Option(help: "Reference an already-installed mark, relative to the attachments directory.")
+    var mark: String?
+    @Option(
+        name: .customLong("install-mark"),
+        help: "Copy an image into the attachments store and use it as the mark (the safe path)."
+    )
+    var installMark: String?
+
+    // Bulk + clearing
+    @Option(name: .customLong("brand-from"), help: "Read the whole brand from a JSON file.")
+    var brandFrom: String?
+    @Option(help: "Base style name from config.json → styles, overlaid by this brand.")
+    var style: String?
+    @Option(
+        name: .customLong("clear"),
+        help: "Unset a brand field so it inherits again (repeatable), e.g. --clear mark."
+    )
+    var clear: [String] = []
+
+    /// Fold these flags into a workspace, in place.
+    func apply(to workspace: inout Workspace, store: WorkspaceStore, name: String) throws {
+        var brand = workspace.brand ?? Treatment()
+
+        if let path = brandFrom {
+            let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+            guard let data = try? Data(contentsOf: url) else {
+                throw ValidationError("cannot read brand file at \(url.path)")
+            }
+            let loaded: Treatment
+            do {
+                loaded = try JSONDecoder().decode(Treatment.self, from: data)
+            } catch {
+                throw ValidationError("\(url.lastPathComponent) is not a valid brand: \(error)")
+            }
+            brand = brand.merging(loaded)
+        }
+
+        if let style { workspace.style = style }
+
+        if let sheet { brand.sheet = sheet }
+        if let background { brand.background = background }
+        if let radius { brand.radius = radius }
+        if let tint { brand.tint = tint }
+        if let tintRead { brand.tintRead = tintRead }
+        if let tintEdit { brand.tintEdit = tintEdit }
+        if let font { brand.font = font }
+        if let mono { brand.mono = mono }
+        if let titleFont { brand.titleFont = titleFont }
+        if let fontSize { brand.fontSize = fontSize }
+        if let lineHeight { brand.lineHeight = lineHeight }
+        if let text { brand.text = text }
+        if let textStrong { brand.textStrong = textStrong }
+        if let textMuted { brand.textMuted = textMuted }
+        if let dim { brand.dim = dim }
+        if let border { brand.border = border }
+        if let accent { brand.accent = accent }
+        if let accentDim { brand.accentDim = accentDim }
+        if let codeBackground { brand.codeBackground = codeBackground }
+        if let codeText { brand.codeText = codeText }
+        if let caret { brand.caret = caret }
+        if let selection { brand.selection = selection }
+
+        // Reference an existing asset, or install one. Installing is the safe
+        // path: the app only renders marks from inside the attachments store.
+        if let mark {
+            guard BlinkPaths.attachment(named: mark) != nil else {
+                throw ValidationError(
+                    """
+                    '\(mark)' does not resolve to a file inside \(BlinkPaths.attachments().path).
+                    Use --install-mark <file> to copy an asset in, or pass a path relative to that directory.
+                    """
+                )
+            }
+            brand.mark = mark
+        }
+        if let installMark {
+            let source = URL(fileURLWithPath: (installMark as NSString).expandingTildeInPath)
+            brand.mark = try store.installMark(from: source, for: name)
+        }
+
+        for field in clear {
+            try Self.clear(field, in: &brand, workspace: &workspace)
+        }
+
+        workspace.brand = brand.isEmpty ? nil : brand
+    }
+
+    /// Unset one field by its brand key. Accepts camelCase or kebab-case so
+    /// `--clear textMuted` and `--clear text-muted` both work.
+    private static func clear(
+        _ field: String,
+        in brand: inout Treatment,
+        workspace: inout Workspace
+    ) throws {
+        switch field.lowercased().replacingOccurrences(of: "-", with: "") {
+        case "sheet": brand.sheet = nil
+        case "background": brand.background = nil
+        case "radius": brand.radius = nil
+        case "tint": brand.tint = nil
+        case "tintread": brand.tintRead = nil
+        case "tintedit": brand.tintEdit = nil
+        case "font": brand.font = nil
+        case "mono": brand.mono = nil
+        case "titlefont": brand.titleFont = nil
+        case "fontsize": brand.fontSize = nil
+        case "lineheight": brand.lineHeight = nil
+        case "text": brand.text = nil
+        case "textstrong": brand.textStrong = nil
+        case "textmuted": brand.textMuted = nil
+        case "dim": brand.dim = nil
+        case "border": brand.border = nil
+        case "accent": brand.accent = nil
+        case "accentdim": brand.accentDim = nil
+        case "codebackground": brand.codeBackground = nil
+        case "codetext": brand.codeText = nil
+        case "caret": brand.caret = nil
+        case "selection": brand.selection = nil
+        case "mark": brand.mark = nil
+        case "style": workspace.style = nil
+        case "brand": brand = Treatment()
+        default: throw ValidationError("'\(field)' is not a brand field")
+        }
+    }
+}
+
+// MARK: - Commands
+
+struct WorkspaceInit: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "init",
+        abstract: "Create a workspace (idempotent); optionally brand it in the same call.",
+        discussion: """
+        Safe to re-run: an existing workspace is updated, never replaced. With no \
+        brand flags the workspace is created unbranded, and its notes render with \
+        Blink's defaults until you brand it.
+        """
+    )
+
+    @Argument(help: "Workspace name; normalized to a slug.") var name: String
+    @Option(help: "Human-facing label (defaults to the name).") var title: String?
+    @OptionGroup var brand: BrandOptions
+    @Flag(help: "Structured output.") var json = false
+
+    func run() throws {
+        let store = WorkspaceStore()
+        let key = try WorkspaceStore.normalize(name)
+        var workspace = try store.workspace(named: key) ?? Workspace()
+        if let title { workspace.title = title }
+        try brand.apply(to: &workspace, store: store, name: key)
+        try store.save(workspace, named: key)
+        try emit(name: key, workspace: workspace, store: store, json: json)
+    }
+}
+
+struct WorkspaceList: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "ls",
+        abstract: "List defined workspaces and how many notes are in each."
+    )
+
+    @Flag(help: "Structured output.") var json = false
+
+    func run() async throws {
+        let store = WorkspaceStore()
+        let workspaces = try store.all()
+        let counts = noteCounts()
+
+        let styles = try? store.styles()
+        if json {
+            let rows = workspaces.keys.sorted().map { key in
+                WorkspaceJSON(
+                    name: key,
+                    workspace: workspaces[key] ?? Workspace(),
+                    noteCount: counts[key] ?? 0,
+                    styles: styles
+                )
+            }
+            try printJSON(rows)
+            return
+        }
+
+        guard !workspaces.isEmpty else {
+            FileHandle.standardError.write(Data("no workspaces — create one with `blink workspace init <name>`\n".utf8))
+            return
+        }
+        let width = workspaces.keys.map(\.count).max() ?? 0
+        for key in workspaces.keys.sorted() {
+            let ws = workspaces[key] ?? Workspace()
+            let padded = key.padding(toLength: width, withPad: " ", startingAt: 0)
+            let brand = ws.resolvedBrand(styles: styles)
+            let badge = brand.isEmpty ? "unbranded" : (brand.mark == nil ? "branded" : "branded + mark")
+            let count = counts[key] ?? 0
+            print("\(padded)  \(count) \(count == 1 ? "note " : "notes")  \(badge)  \(ws.title ?? "")")
+        }
+    }
+}
+
+struct WorkspaceShow: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "show",
+        abstract: "Show a workspace's definition, effective brand, and notes."
+    )
+
+    @Argument(help: "Workspace name.") var name: String
+    @Flag(help: "Structured output.") var json = false
+
+    func run() async throws {
+        let store = WorkspaceStore()
+        let key = try WorkspaceStore.normalize(name)
+        guard let workspace = try store.workspace(named: key) else {
+            throw WorkspaceStoreError.unknownWorkspace(name: key)
+        }
+        try emit(name: key, workspace: workspace, store: store, json: json)
+    }
+}
+
+struct WorkspaceBrand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "brand",
+        abstract: "Set or adjust a workspace's brand — mark, palette, typography, corners.",
+        discussion: """
+        A partial overlay: only the fields you pass change, so you can adjust one \
+        color without restating the brand. `--clear <field>` unsets a field so it \
+        inherits again. Config keys this command does not own are preserved \
+        byte-for-byte, so branding never disturbs the rest of config.json.
+        """
+    )
+
+    @Argument(help: "Workspace name.") var name: String
+    @Option(help: "Human-facing label.") var title: String?
+    @OptionGroup var brand: BrandOptions
+    @Flag(help: "Create the workspace if it does not exist.") var create = false
+    @Flag(help: "Structured output.") var json = false
+
+    func run() throws {
+        let store = WorkspaceStore()
+        let key = try WorkspaceStore.normalize(name)
+        let workspace = try store.update(named: key, createIfMissing: create) { ws in
+            if let title { ws.title = title }
+            try brand.apply(to: &ws, store: store, name: key)
+        }
+        try emit(name: key, workspace: workspace, store: store, json: json)
+    }
+}
+
+struct WorkspaceAdd: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "add",
+        abstract: "Put notes in a workspace (writes blink.workspace to each note).",
+        discussion: "Notes are created if they do not exist, so an agent can lay out a workspace in one call."
+    )
+
+    @Argument(help: "Workspace name.") var name: String
+    @Argument(help: "Note ids.") var ids: [String]
+    @Flag(help: "Structured output.") var json = false
+
+    func run() throws {
+        let store = WorkspaceStore()
+        let key = try WorkspaceStore.normalize(name)
+        guard try store.workspace(named: key) != nil else {
+            throw WorkspaceStoreError.unknownWorkspace(name: key)
+        }
+        let moved = try setWorkspace(key, on: ids)
+        try report(moved, json: json, verb: "added to \(key)")
+    }
+}
+
+struct WorkspaceRemove: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "remove",
+        abstract: "Take notes out of a workspace (clears blink.workspace).",
+        discussion: "The notes and their content are untouched — only membership is cleared."
+    )
+
+    @Argument(help: "Note ids.") var ids: [String]
+    @Flag(help: "Structured output.") var json = false
+
+    func run() throws {
+        let moved = try setWorkspace(nil, on: ids)
+        try report(moved, json: json, verb: "removed from its workspace")
+    }
+}
+
+struct WorkspaceNotes: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "notes",
+        abstract: "List the notes in a workspace, most recently updated first.",
+        discussion: "How an agent reopens its workspace: list the ids, then `blink cat` or open them in the app."
+    )
+
+    @Argument(help: "Workspace name.") var name: String
+    @Flag(help: "Structured output.") var json = false
+
+    func run() async throws {
+        let key = try WorkspaceStore.normalize(name)
+        let notes = try await loadedStore().all().filter { $0.presentation.workspace == key }
+        try output(notes, json: json)
+    }
+}
+
+struct WorkspaceForget: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "rm",
+        abstract: "Forget a workspace definition. Notes are never deleted.",
+        discussion: """
+        Removes only the config entry; member notes keep their `blink.workspace` \
+        key and render unbranded until the workspace is defined again. Pass \
+        --detach to also clear membership from every member note.
+        """
+    )
+
+    @Argument(help: "Workspace name.") var name: String
+    @Flag(help: "Also clear blink.workspace from every member note.") var detach = false
+    @Flag(help: "Structured output.") var json = false
+
+    func run() async throws {
+        let store = WorkspaceStore()
+        let key = try WorkspaceStore.normalize(name)
+        var detached: [String] = []
+        if detach {
+            let members = try await loadedStore().all()
+                .filter { $0.presentation.workspace == key }
+                .map(\.id)
+            detached = try setWorkspace(nil, on: members)
+        }
+        let removed = try store.remove(named: key)
+        guard removed else { throw WorkspaceStoreError.unknownWorkspace(name: key) }
+        if json {
+            try printJSON(ForgotJSON(forgot: key, detached: detached))
+        } else {
+            print("forgot \(key)\(detached.isEmpty ? "" : " (detached \(detached.count) notes)")")
+        }
+    }
+}
+
+// MARK: - Shared
+
+/// Write `blink.workspace` on each note, preserving all other presentation and
+/// foreign frontmatter. Creates a note that does not exist yet so an agent can
+/// scaffold a workspace in one call. Returns the ids actually written.
+private func setWorkspace(_ name: String?, on ids: [String]) throws -> [String] {
+    let store = fileStore()
+    var written: [String] = []
+    for raw in ids {
+        let id = Slug.generate(from: raw)
+        let now = Date()
+        var note: Note
+        if let existing = try? store.load(id: id) {
+            note = existing
+            guard note.presentation.workspace != name else { continue }
+            note.updatedAt = now
+        } else {
+            // Removing membership from a note that does not exist is a no-op,
+            // never a reason to create an empty note.
+            guard name != nil else { continue }
+            note = Note(id: id, content: "", createdAt: now, updatedAt: now)
+        }
+        note.presentation.workspace = name
+        try store.save(note)
+        written.append(id)
+    }
+    return written
+}
+
+private func report(_ ids: [String], json: Bool, verb: String) throws {
+    if json {
+        try printJSON(["notes": ids])
+    } else if ids.isEmpty {
+        print("nothing to do")
+    } else {
+        print("\(ids.count) \(ids.count == 1 ? "note" : "notes") \(verb): \(ids.joined(separator: ", "))")
+    }
+}
+
+private struct ForgotJSON: Encodable {
+    let forgot: String
+    let detached: [String]
+}
+
+private func noteCounts() -> [String: Int] {
+    var counts: [String: Int] = [:]
+    for note in fileStore().loadAllLenient() {
+        guard let ws = note.presentation.workspace else { continue }
+        counts[ws, default: 0] += 1
+    }
+    return counts
+}
+
+private func emit(name: String, workspace: Workspace, store: WorkspaceStore, json: Bool) throws {
+    let styles = try? store.styles()
+    if json {
+        try printJSON(
+            WorkspaceJSON(
+                name: name,
+                workspace: workspace,
+                noteCount: noteCounts()[name] ?? 0,
+                styles: styles
+            )
+        )
+        return
+    }
+
+    let brand = workspace.resolvedBrand(styles: styles)
+    print("\(name)\(workspace.title.map { "  (\($0))" } ?? "")")
+    if let style = workspace.style { print("  style      \(style)") }
+    print("  notes      \(noteCounts()[name] ?? 0)")
+    if brand.isEmpty {
+        print("  brand      unbranded — Blink defaults")
+        return
+    }
+    if let v = brand.mark {
+        let resolved = BlinkPaths.attachment(named: v)
+        print("  mark       \(v)\(resolved == nil ? "  ⚠︎ not found in attachments" : "")")
+    }
+    for (label, value) in [
+        ("sheet", brand.sheet), ("background", brand.background),
+        ("accent", brand.accent), ("accentDim", brand.accentDim),
+        ("text", brand.text), ("textStrong", brand.textStrong), ("textMuted", brand.textMuted),
+        ("dim", brand.dim), ("border", brand.border),
+        ("codeBackground", brand.codeBackground), ("codeText", brand.codeText),
+        ("caret", brand.caret), ("selection", brand.selection),
+        ("font", brand.font), ("mono", brand.mono), ("titleFont", brand.titleFont),
+    ] where value != nil {
+        print("  \(label.padding(toLength: 10, withPad: " ", startingAt: 0)) \(value ?? "")")
+    }
+    for (label, value) in [
+        ("radius", brand.radius), ("fontSize", brand.fontSize), ("lineHeight", brand.lineHeight),
+        ("tint", brand.tint), ("tintRead", brand.tintRead), ("tintEdit", brand.tintEdit),
+    ] where value != nil {
+        print("  \(label.padding(toLength: 10, withPad: " ", startingAt: 0)) \(value ?? 0)")
+    }
+}
+
+/// The JSON face of a workspace: the stored definition plus the *effective*
+/// brand (style base + overlay) an agent would otherwise have to compute, and
+/// whether the mark actually resolves inside the attachments store.
+struct WorkspaceJSON: Encodable {
+    let name: String
+    let title: String
+    let style: String?
+    let brand: Treatment?
+    let effectiveBrand: Treatment
+    let noteCount: Int
+    let mark: MarkJSON?
+
+    struct MarkJSON: Encodable {
+        let path: String
+        let resolved: String?
+        let installed: Bool
+    }
+
+    init(name: String, workspace: Workspace, noteCount: Int, styles: [String: Treatment]?) {
+        self.name = name
+        title = workspace.title ?? name
+        style = workspace.style
+        brand = workspace.brand
+        effectiveBrand = workspace.resolvedBrand(styles: styles)
+        self.noteCount = noteCount
+        if let path = effectiveBrand.mark {
+            let url = BlinkPaths.attachment(named: path)
+            mark = MarkJSON(path: path, resolved: url?.path, installed: url != nil)
+        } else {
+            mark = nil
+        }
+    }
+}

--- a/Sources/BlinkCore/BlinkPaths.swift
+++ b/Sources/BlinkCore/BlinkPaths.swift
@@ -41,4 +41,48 @@ public enum BlinkPaths {
     ) -> URL {
         home(environment: environment).appendingPathComponent("attachments", isDirectory: true)
     }
+
+    /// Where installed brand marks live: `<home>/attachments/marks`. A
+    /// subdirectory rather than the attachments root so an installed brand asset
+    /// is never confused with a note's own embedded image.
+    public static func marks(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        attachments(environment: environment).appendingPathComponent("marks", isDirectory: true)
+    }
+
+    /// Resolve a treatment-supplied attachment reference to a real file URL, or
+    /// `nil` if it does not name a regular file *inside* the attachments
+    /// directory. This is the single containment rule for brand assets: the app
+    /// renders through it and the CLI validates through it, so the two can never
+    /// disagree about what is in bounds.
+    ///
+    /// Accepts a plain relative path (`marks/acme.svg`) or the `blink://`
+    /// attachment form the editor uses. Rejects absolute paths, and resolves
+    /// symlinks before the containment check so a link cannot escape the root.
+    /// A typo becomes an absent mark, never an arbitrary file read.
+    public static func attachment(
+        named raw: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("/"), !trimmed.hasPrefix("~") else { return nil }
+
+        let prefix = "blink://attachments/"
+        let relative = trimmed.hasPrefix(prefix) ? String(trimmed.dropFirst(prefix.count)) : trimmed
+        guard !relative.isEmpty else { return nil }
+
+        let root = attachments(environment: environment)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        let candidate = root.appendingPathComponent(relative)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        guard candidate.path.hasPrefix(root.path + "/"),
+              let values = try? candidate.resourceValues(forKeys: [.isRegularFileKey]),
+              values.isRegularFile == true
+        else { return nil }
+        return candidate
+    }
 }

--- a/Sources/BlinkCore/Frontmatter.swift
+++ b/Sources/BlinkCore/Frontmatter.swift
@@ -74,6 +74,7 @@ public enum Frontmatter {
         let p = note.presentation
         guard !p.isEmpty || !note.extraBlink.isEmpty else { return }
         lines.append("blink:")
+        if let v = p.workspace { lines.append("  workspace: \(quoteIfNeeded(v))") }
         if let v = p.style { lines.append("  style: \(v)") }
         if let v = p.sheet { lines.append("  sheet: \(v)") }
         if let v = p.accent { lines.append("  accent: \(quoteIfNeeded(v))") }
@@ -212,6 +213,7 @@ public enum Frontmatter {
             )
             guard !value.isEmpty else { unknown.append(raw); continue }
             switch key {
+            case "workspace": presentation.workspace = value
             case "style": presentation.style = value
             case "sheet": presentation.sheet = value
             case "accent": presentation.accent = value

--- a/Sources/BlinkCore/Note.swift
+++ b/Sources/BlinkCore/Note.swift
@@ -9,6 +9,11 @@ import Foundation
 /// (a non-numeric `slot`, say) is never coerced or dropped — it is preserved
 /// verbatim in `Note.extraBlink` and simply not surfaced here (never-erase).
 public struct NotePresentation: Equatable, Sendable, Codable {
+    /// The workspace this note belongs to — a name defined in `config.json` →
+    /// `workspaces.<name>`. Membership only: the brand itself never enters the
+    /// markdown, so the file stays portable and presentation-free. An unknown
+    /// or absent name renders unbranded.
+    public var workspace: String?
     /// Named treatment defined in `config.json` → `styles.<name>`.
     public var style: String?
     /// Sheet template: glass | card | dotted | bracket | marginalia.
@@ -32,7 +37,7 @@ public struct NotePresentation: Equatable, Sendable, Codable {
 
     /// True when no field is set — nothing for the codec to emit.
     public var isEmpty: Bool {
-        style == nil && sheet == nil && accent == nil && font == nil
+        workspace == nil && style == nil && sheet == nil && accent == nil && font == nil
             && fontSize == nil && lineHeight == nil && tint == nil
             && tintRead == nil && tintEdit == nil && radius == nil && slot == nil
     }

--- a/Sources/BlinkCore/Treatment.swift
+++ b/Sources/BlinkCore/Treatment.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+/// A named, reusable presentation preset — a *partial* overlay onto the
+/// panel/editor defaults, every field optional. Pure data: no AppKit, no
+/// rendering opinion, so the app, the CLI, and tests all speak one vocabulary.
+///
+/// Three things reference a treatment, in ascending precedence:
+/// a workspace's brand, a note's `blink.style`, and a note's loose `blink:`
+/// overrides. Field → surface mapping lives in `BlinkConfig.apply(treatment:)`;
+/// see `docs/notes-representation.md` Appendix A and `docs/workspaces.md`.
+///
+/// Every field is optional by design: an unset field means "inherit", which is
+/// what makes treatments composable and keeps unbranded the default.
+public struct Treatment: Codable, Equatable, Sendable {
+    // Surface
+    /// Sheet template: glass | card | dotted | bracket | marginalia.
+    public var sheet: String?
+    /// Opaque CSS surface color. Unset keeps the glass sheet transparent.
+    public var background: String?
+    /// Panel corner radius in px — the corner treatment.
+    public var radius: Double?
+    /// Glass tint shorthand (0–1); `tintRead`/`tintEdit` win over it.
+    public var tint: Double?
+    public var tintRead: Double?
+    public var tintEdit: Double?
+
+    // Typography
+    public var font: String?
+    public var mono: String?
+    public var titleFont: String?
+    public var fontSize: Double?
+    public var lineHeight: Double?
+
+    // Palette
+    public var text: String?
+    public var textStrong: String?
+    public var textMuted: String?
+    public var dim: String?
+    public var border: String?
+    public var accent: String?
+    public var accentDim: String?
+    public var codeBackground: String?
+    public var codeText: String?
+    public var caret: String?
+    public var selection: String?
+
+    // Identity
+    /// Relative path under `$BLINK_HOME/attachments` for a restrained identity
+    /// mark in the panel's top-left chrome. Never an absolute path — see
+    /// `BlinkPaths.attachment(named:)` for the containment rule.
+    public var mark: String?
+
+    public init() {}
+
+    /// Decode defensively: a missing key and an explicit `null` both mean
+    /// "inherit", so a hand-edited config never fails to load over a blank field.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        sheet = try c.decodeIfPresent(String.self, forKey: .sheet)
+        background = try c.decodeIfPresent(String.self, forKey: .background)
+        radius = try c.decodeIfPresent(Double.self, forKey: .radius)
+        tint = try c.decodeIfPresent(Double.self, forKey: .tint)
+        tintRead = try c.decodeIfPresent(Double.self, forKey: .tintRead)
+        tintEdit = try c.decodeIfPresent(Double.self, forKey: .tintEdit)
+        font = try c.decodeIfPresent(String.self, forKey: .font)
+        mono = try c.decodeIfPresent(String.self, forKey: .mono)
+        titleFont = try c.decodeIfPresent(String.self, forKey: .titleFont)
+        fontSize = try c.decodeIfPresent(Double.self, forKey: .fontSize)
+        lineHeight = try c.decodeIfPresent(Double.self, forKey: .lineHeight)
+        text = try c.decodeIfPresent(String.self, forKey: .text)
+        textStrong = try c.decodeIfPresent(String.self, forKey: .textStrong)
+        textMuted = try c.decodeIfPresent(String.self, forKey: .textMuted)
+        dim = try c.decodeIfPresent(String.self, forKey: .dim)
+        border = try c.decodeIfPresent(String.self, forKey: .border)
+        accent = try c.decodeIfPresent(String.self, forKey: .accent)
+        accentDim = try c.decodeIfPresent(String.self, forKey: .accentDim)
+        codeBackground = try c.decodeIfPresent(String.self, forKey: .codeBackground)
+        codeText = try c.decodeIfPresent(String.self, forKey: .codeText)
+        caret = try c.decodeIfPresent(String.self, forKey: .caret)
+        selection = try c.decodeIfPresent(String.self, forKey: .selection)
+        mark = try c.decodeIfPresent(String.self, forKey: .mark)
+    }
+
+    /// True when nothing is set — an empty overlay changes no surface.
+    public var isEmpty: Bool { self == Treatment() }
+
+    /// Overlay `other`'s set fields onto a copy of this treatment. Used to
+    /// compose a workspace's `style` base with its inline `brand` without
+    /// either side having to repeat the other's fields.
+    public func merging(_ other: Treatment) -> Treatment {
+        var t = self
+        if let v = other.sheet { t.sheet = v }
+        if let v = other.background { t.background = v }
+        if let v = other.radius { t.radius = v }
+        if let v = other.tint { t.tint = v }
+        if let v = other.tintRead { t.tintRead = v }
+        if let v = other.tintEdit { t.tintEdit = v }
+        if let v = other.font { t.font = v }
+        if let v = other.mono { t.mono = v }
+        if let v = other.titleFont { t.titleFont = v }
+        if let v = other.fontSize { t.fontSize = v }
+        if let v = other.lineHeight { t.lineHeight = v }
+        if let v = other.text { t.text = v }
+        if let v = other.textStrong { t.textStrong = v }
+        if let v = other.textMuted { t.textMuted = v }
+        if let v = other.dim { t.dim = v }
+        if let v = other.border { t.border = v }
+        if let v = other.accent { t.accent = v }
+        if let v = other.accentDim { t.accentDim = v }
+        if let v = other.codeBackground { t.codeBackground = v }
+        if let v = other.codeText { t.codeText = v }
+        if let v = other.caret { t.caret = v }
+        if let v = other.selection { t.selection = v }
+        if let v = other.mark { t.mark = v }
+        return t
+    }
+}
+
+/// A **workspace**: a named group of notes plus the brand they render under.
+///
+/// The definition lives in `config.json` → `workspaces.<name>`; *membership*
+/// lives in each note's own frontmatter (`blink.workspace`). That split is the
+/// whole design — config holds presentation, the note file holds one portable
+/// name, and deleting the definition costs a look, never a note.
+public struct Workspace: Codable, Equatable, Sendable {
+    /// Human-facing label. Defaults to the workspace name when unset.
+    public var title: String?
+    /// Optional base: the name of an entry in `config.json` → `styles`, so
+    /// several workspaces can share one house style and tint it differently.
+    public var style: String?
+    /// The workspace's own brand overlay, applied over `style`.
+    public var brand: Treatment?
+
+    public init(title: String? = nil, style: String? = nil, brand: Treatment? = nil) {
+        self.title = title
+        self.style = style
+        self.brand = brand
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        title = try c.decodeIfPresent(String.self, forKey: .title)
+        style = try c.decodeIfPresent(String.self, forKey: .style)
+        brand = try c.decodeIfPresent(Treatment.self, forKey: .brand)
+    }
+
+    /// The effective brand: the registered `style` base with `brand` overlaid.
+    /// `styles` is the config's style registry; an unknown name contributes
+    /// nothing rather than failing — an unbranded workspace is always valid.
+    public func resolvedBrand(styles: [String: Treatment]?) -> Treatment {
+        let base = style.flatMap { styles?[$0] } ?? Treatment()
+        return base.merging(brand ?? Treatment())
+    }
+}
+
+/// How a note's look is decided. The precedence rule is product logic, not
+/// rendering logic, so it lives here where it can be tested without AppKit —
+/// `BlinkConfig.resolved(for:)` is a thin loop over this chain.
+///
+/// Least specific first, so **later wins**:
+/// ```
+/// config defaults ← workspace brand ← named style ← loose per-note keys
+/// ```
+/// A note inherits its workspace's identity for free, a per-note `style` can
+/// still override the brand, and a loose `blink:` key beats both. An unknown
+/// workspace or style name contributes nothing rather than failing, so an
+/// unbranded note is always a valid note.
+public enum PresentationResolver {
+    /// The ordered treatments to overlay onto the config defaults for one note.
+    public static func chain(
+        for presentation: NotePresentation,
+        styles: [String: Treatment]?,
+        workspaces: [String: Workspace]?
+    ) -> [Treatment] {
+        var chain: [Treatment] = []
+        if let name = presentation.workspace, let workspace = workspaces?[name] {
+            let brand = workspace.resolvedBrand(styles: styles)
+            if !brand.isEmpty { chain.append(brand) }
+        }
+        if let name = presentation.style, let style = styles?[name] {
+            chain.append(style)
+        }
+        let loose = loose(from: presentation)
+        if !loose.isEmpty { chain.append(loose) }
+        return chain
+    }
+
+    /// The whole chain folded into one treatment — what a note effectively
+    /// looks like, relative to the config defaults.
+    public static func effective(
+        for presentation: NotePresentation,
+        styles: [String: Treatment]?,
+        workspaces: [String: Workspace]?
+    ) -> Treatment {
+        chain(for: presentation, styles: styles, workspaces: workspaces)
+            .reduce(Treatment()) { $0.merging($1) }
+    }
+
+    /// A note's loose `blink:` overrides as a treatment. `workspace`, `style`,
+    /// and `slot` are excluded: the first two select treatments rather than
+    /// being one, and `slot` is placement, not presentation.
+    public static func loose(from p: NotePresentation) -> Treatment {
+        var t = Treatment()
+        t.sheet = p.sheet
+        t.accent = p.accent
+        t.font = p.font
+        t.fontSize = p.fontSize
+        t.lineHeight = p.lineHeight
+        t.tint = p.tint
+        t.tintRead = p.tintRead
+        t.tintEdit = p.tintEdit
+        t.radius = p.radius
+        return t
+    }
+}

--- a/Sources/BlinkCore/WorkspaceStore.swift
+++ b/Sources/BlinkCore/WorkspaceStore.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+/// Errors thrown by `WorkspaceStore`.
+public enum WorkspaceStoreError: Error, Equatable, Sendable, CustomStringConvertible {
+    /// `config.json` exists but is not readable JSON. We refuse to write over a
+    /// file we cannot parse — a malformed config is a user's work to recover,
+    /// never ours to overwrite.
+    case configUnreadable(path: String)
+    case unknownWorkspace(name: String)
+    case invalidName(String)
+    case markNotFound(path: String)
+    /// The asset is not one of the image types a panel mark can render.
+    case markUnsupportedType(ext: String)
+    case markTooLarge(bytes: Int, limit: Int)
+
+    public var description: String {
+        switch self {
+        case .configUnreadable(let path):
+            "config at \(path) is not valid JSON — fix or move it, then retry"
+        case .unknownWorkspace(let name):
+            "no workspace named '\(name)' — create it with `blink workspace init \(name)`"
+        case .invalidName(let name):
+            "'\(name)' is not a usable workspace name (letters, digits, hyphens)"
+        case .markNotFound(let path):
+            "no readable file at \(path)"
+        case .markUnsupportedType(let ext):
+            "'\(ext)' is not a supported mark format (\(WorkspaceStore.markFormats.sorted().joined(separator: ", ")))"
+        case .markTooLarge(let bytes, let limit):
+            "mark is \(bytes) bytes; the limit is \(limit)"
+        }
+    }
+}
+
+/// Reads and writes the `workspaces` section of `config.json` **surgically**.
+///
+/// The config file is a shared surface: the app owns most of it, agents own the
+/// rest, and both write it. So this store never re-encodes a typed `BlinkConfig`
+/// — it parses the file as generic JSON, replaces exactly the one key it owns,
+/// and writes the rest back untouched. That is the same never-erase discipline
+/// the frontmatter codec applies to foreign keys, applied to config.
+///
+/// Writes are atomic (temp + fsync + rename), so the app's config watcher either
+/// sees the old file or the new one, never a half-written one, and hot-applies
+/// the change without a restart.
+public struct WorkspaceStore: Sendable {
+    /// Image formats a panel mark may use.
+    public static let markFormats: Set<String> = ["svg", "png", "jpg", "jpeg", "gif", "webp", "pdf", "tiff"]
+    /// Brand marks render at 20pt; anything past this is a mistake, not a logo.
+    public static let markSizeLimit = 2 * 1024 * 1024
+
+    private let home: URL
+    public let configURL: URL
+
+    public init(home: URL = BlinkPaths.home()) {
+        self.home = home
+        self.configURL = home.appendingPathComponent("config.json", isDirectory: false)
+    }
+
+    /// Where installed marks land: `<home>/attachments/marks`.
+    public var marksDirectory: URL {
+        home.appendingPathComponent("attachments", isDirectory: true)
+            .appendingPathComponent("marks", isDirectory: true)
+    }
+
+    // MARK: - Names
+
+    /// Workspace names are slugs — they are JSON keys, they appear in note
+    /// frontmatter, and an installed mark is filed under them. Normalizing up
+    /// front means `"Q3 Planning"` and `q3-planning` are the same workspace.
+    public static func normalize(_ name: String) throws -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Require at least one ASCII alphanumeric: those are the only characters
+        // `Slug` keeps, so anything else would collapse to the "untitled"
+        // fallback and quietly address the wrong workspace.
+        guard trimmed.contains(where: { $0.isASCII && ($0.isLetter || $0.isNumber) }) else {
+            throw WorkspaceStoreError.invalidName(name)
+        }
+        return Slug.generate(from: trimmed)
+    }
+
+    // MARK: - Read
+
+    /// Every defined workspace, keyed by name. Absent config → no workspaces,
+    /// which is the correct unbranded default rather than an error.
+    public func all() throws -> [String: Workspace] {
+        let raw = try configObject()
+        guard let dict = raw["workspaces"] as? [String: Any] else { return [:] }
+        return try decode([String: Workspace].self, from: dict)
+    }
+
+    public func workspace(named name: String) throws -> Workspace? {
+        try all()[try Self.normalize(name)]
+    }
+
+    /// The config's named style registry — the base a workspace's `style` names.
+    public func styles() throws -> [String: Treatment] {
+        let raw = try configObject()
+        guard let dict = raw["styles"] as? [String: Any] else { return [:] }
+        return try decode([String: Treatment].self, from: dict)
+    }
+
+    // MARK: - Write
+
+    /// Create or replace a workspace definition. Returns the normalized name.
+    @discardableResult
+    public func save(_ workspace: Workspace, named name: String) throws -> String {
+        let key = try Self.normalize(name)
+        try mutate { workspaces in
+            workspaces[key] = try encodeToObject(workspace)
+        }
+        return key
+    }
+
+    /// Read-modify-write one workspace in place, creating it if absent.
+    /// The whole point of the feature's write path: an agent adjusts one brand
+    /// field without restating the rest of the brand — or the rest of the config.
+    @discardableResult
+    public func update(
+        named name: String,
+        createIfMissing: Bool = true,
+        _ edit: (inout Workspace) throws -> Void
+    ) throws -> Workspace {
+        let key = try Self.normalize(name)
+        let existing = try all()[key]
+        if existing == nil, !createIfMissing {
+            throw WorkspaceStoreError.unknownWorkspace(name: key)
+        }
+        var workspace = existing ?? Workspace()
+        try edit(&workspace)
+        try save(workspace, named: key)
+        return workspace
+    }
+
+    /// Forget a workspace definition. Notes that reference it are untouched and
+    /// simply render unbranded — membership lives in the note, not here.
+    @discardableResult
+    public func remove(named name: String) throws -> Bool {
+        let key = try Self.normalize(name)
+        var removed = false
+        try mutate { workspaces in
+            removed = workspaces.removeValue(forKey: key) != nil
+        }
+        return removed
+    }
+
+    // MARK: - Brand assets
+
+    /// Copy a brand mark into `<home>/attachments/marks` and return the relative
+    /// path to record in a treatment (`marks/<name>.<ext>`).
+    ///
+    /// Installing rather than referencing an arbitrary path is the safe default:
+    /// the app only ever reads marks from inside the attachments directory (see
+    /// `BlinkPaths.attachment(named:)`), so a brand asset that lives anywhere
+    /// else would silently fail to render. Type and size are checked here so the
+    /// failure is a clear CLI error instead of a blank panel corner.
+    public func installMark(from source: URL, for name: String) throws -> String {
+        let key = try Self.normalize(name)
+        let src = source.standardizedFileURL.resolvingSymlinksInPath()
+
+        guard let values = try? src.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+              values.isRegularFile == true
+        else { throw WorkspaceStoreError.markNotFound(path: source.path) }
+
+        let ext = src.pathExtension.lowercased()
+        guard Self.markFormats.contains(ext) else {
+            throw WorkspaceStoreError.markUnsupportedType(ext: ext.isEmpty ? "(none)" : ext)
+        }
+        let size = values.fileSize ?? 0
+        guard size <= Self.markSizeLimit else {
+            throw WorkspaceStoreError.markTooLarge(bytes: size, limit: Self.markSizeLimit)
+        }
+
+        let data = try Data(contentsOf: src)
+        try FileManager.default.createDirectory(at: marksDirectory, withIntermediateDirectories: true)
+        let destination = marksDirectory.appendingPathComponent("\(key).\(ext)", isDirectory: false)
+        try data.write(to: destination, options: .atomic)
+        return "marks/\(key).\(ext)"
+    }
+
+    // MARK: - Config plumbing
+
+    /// The whole config file as a generic JSON object. Missing file → empty
+    /// object; unparseable file → throw, so we never overwrite what we can't read.
+    private func configObject() throws -> [String: Any] {
+        guard let data = try? Data(contentsOf: configURL), !data.isEmpty else { return [:] }
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any]
+        else { throw WorkspaceStoreError.configUnreadable(path: configURL.path) }
+        return dict
+    }
+
+    /// Mutate only the `workspaces` sub-object and write the file back whole.
+    private func mutate(_ edit: (inout [String: Any]) throws -> Void) throws {
+        var config = try configObject()
+        var workspaces = (config["workspaces"] as? [String: Any]) ?? [:]
+        try edit(&workspaces)
+        if workspaces.isEmpty {
+            config.removeValue(forKey: "workspaces")
+        } else {
+            config["workspaces"] = workspaces
+        }
+        try write(config)
+    }
+
+    /// Atomic write: temp file in the same directory, fsync, rename. Matches
+    /// `NoteFileStore.save` — the config watcher must never observe a torn file.
+    private func write(_ config: [String: Any]) throws {
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(
+            withJSONObject: config,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+
+        let temp = configURL.deletingLastPathComponent()
+            .appendingPathComponent(".config.json.tmp", isDirectory: false)
+        if FileManager.default.fileExists(atPath: temp.path) {
+            try FileManager.default.removeItem(at: temp)
+        }
+        FileManager.default.createFile(atPath: temp.path, contents: nil)
+
+        let handle = try FileHandle(forWritingTo: temp)
+        do {
+            try handle.write(contentsOf: data)
+            try handle.synchronize()
+            try handle.close()
+        } catch {
+            try? handle.close()
+            try? FileManager.default.removeItem(at: temp)
+            throw error
+        }
+
+        if FileManager.default.fileExists(atPath: configURL.path) {
+            _ = try FileManager.default.replaceItemAt(configURL, withItemAt: temp)
+        } else {
+            try FileManager.default.moveItem(at: temp, to: configURL)
+        }
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, from object: Any) throws -> T {
+        let data = try JSONSerialization.data(withJSONObject: object)
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    private func encodeToObject(_ value: some Encodable) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        return (try JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    }
+}

--- a/Tests/BlinkCoreTests/FrontmatterTests.swift
+++ b/Tests/BlinkCoreTests/FrontmatterTests.swift
@@ -255,6 +255,66 @@ struct FrontmatterTests {
         #expect(reDecoded.content == "# Body")
     }
 
+    // MARK: - Workspace membership
+
+    @Test("blink block: workspace membership decodes and round-trips")
+    func workspaceRoundTrip() throws {
+        let raw = """
+        ---
+        id: q3-planning
+        created: 2023-11-14T22:13:20.123Z
+        updated: 2023-11-14T22:13:20.123Z
+        blink:
+          workspace: acme-docs
+          slot: 6
+        ---
+        # Q3 Planning
+        """
+        let decoded = try Frontmatter.decode(raw)
+        #expect(decoded.presentation.workspace == "acme-docs")
+        #expect(decoded.presentation.slot == 6)
+
+        let reDecoded = try Frontmatter.decode(Frontmatter.encode(decoded))
+        #expect(reDecoded.presentation == decoded.presentation)
+        #expect(reDecoded.content == "# Q3 Planning")
+    }
+
+    /// The portability contract: a note in a branded workspace carries the
+    /// workspace *name* and nothing else. No color, font, or asset path ever
+    /// reaches the markdown — so the file stays a plain, portable note.
+    @Test("Workspace membership adds one name, never presentation bytes")
+    func workspaceCarriesNoBranding() throws {
+        var note = sampleNote(content: "# Branded\n")
+        note.presentation.workspace = "acme-docs"
+        let encoded = Frontmatter.encode(note)
+
+        #expect(encoded.contains("  workspace: acme-docs"))
+        let blinkLines = encoded
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { $0.hasPrefix("  ") }
+        #expect(blinkLines == ["  workspace: acme-docs"])
+    }
+
+    @Test("Workspace is emitted first in the blink block")
+    func workspaceOrdering() throws {
+        var note = sampleNote(content: "c")
+        note.presentation.workspace = "acme"
+        note.presentation.style = "focus"
+        let lines = Frontmatter.encode(note).split(separator: "\n").map(String.init)
+        let workspaceIdx = try #require(lines.firstIndex(of: "  workspace: acme"))
+        let styleIdx = try #require(lines.firstIndex(of: "  style: focus"))
+        #expect(workspaceIdx < styleIdx)
+    }
+
+    @Test("A workspace name needing quotes round-trips intact")
+    func workspaceQuoting() throws {
+        var note = sampleNote(content: "c")
+        // Defensive: names are normally slugs, but a hand-edited file may not be.
+        note.presentation.workspace = "acme: docs"
+        let decoded = try Frontmatter.decode(Frontmatter.encode(note))
+        #expect(decoded.presentation.workspace == "acme: docs")
+    }
+
     @Test("blink block: a #hex accent is emitted quoted")
     func blinkAccentQuoted() throws {
         var note = sampleNote(content: "x")

--- a/Tests/BlinkCoreTests/WorkspaceTests.swift
+++ b/Tests/BlinkCoreTests/WorkspaceTests.swift
@@ -1,0 +1,481 @@
+import Testing
+import Foundation
+@testable import BlinkCore
+
+@Suite("Treatment composition")
+struct TreatmentTests {
+    @Test("A fresh treatment is empty — unbranded is the default")
+    func emptyByDefault() {
+        #expect(Treatment().isEmpty)
+        var t = Treatment()
+        t.accent = "#a6ef87"
+        #expect(!t.isEmpty)
+    }
+
+    @Test("Merging overlays only the fields the other side sets")
+    func mergingIsPartial() {
+        var base = Treatment()
+        base.accent = "#base"
+        base.font = "Base Font"
+        base.radius = 12
+
+        var overlay = Treatment()
+        overlay.accent = "#overlay"
+
+        let merged = base.merging(overlay)
+        #expect(merged.accent == "#overlay")   // overlay wins
+        #expect(merged.font == "Base Font")    // untouched field inherits
+        #expect(merged.radius == 12)
+    }
+
+    @Test("Merging an empty treatment changes nothing")
+    func mergingEmptyIsIdentity() {
+        var base = Treatment()
+        base.background = "#070908"
+        base.mark = "marks/acme.svg"
+        #expect(base.merging(Treatment()) == base)
+    }
+
+    @Test("Decodes partial JSON and ignores foreign keys")
+    func decodesPartial() throws {
+        let json = ##"{"accent":"#a6ef87","radius":6,"somethingElse":"ignored"}"##
+        let t = try JSONDecoder().decode(Treatment.self, from: Data(json.utf8))
+        #expect(t.accent == "#a6ef87")
+        #expect(t.radius == 6)
+        #expect(t.background == nil)
+    }
+
+    @Test("Encoding omits unset fields, so a brand stays minimal on disk")
+    func encodesSparse() throws {
+        var t = Treatment()
+        t.accent = "#a6ef87"
+        let data = try JSONEncoder().encode(t)
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object.count == 1)
+        #expect(object["accent"] as? String == "#a6ef87")
+    }
+}
+
+@Suite("Workspace brand resolution")
+struct WorkspaceBrandTests {
+    @Test("An unbranded workspace resolves to an empty brand")
+    func unbranded() {
+        #expect(Workspace().resolvedBrand(styles: nil).isEmpty)
+    }
+
+    @Test("A named style is the base; the inline brand overlays it")
+    func styleThenBrand() {
+        var house = Treatment()
+        house.font = "House Font"
+        house.accent = "#house"
+
+        var brand = Treatment()
+        brand.accent = "#mine"
+
+        let ws = Workspace(title: "Mine", style: "house", brand: brand)
+        let resolved = ws.resolvedBrand(styles: ["house": house])
+        #expect(resolved.font == "House Font")  // inherited from the shared base
+        #expect(resolved.accent == "#mine")     // the workspace's own brand wins
+    }
+
+    @Test("An unknown style name contributes nothing rather than failing")
+    func unknownStyleIsIgnored() {
+        var brand = Treatment()
+        brand.accent = "#mine"
+        let ws = Workspace(style: "does-not-exist", brand: brand)
+        let resolved = ws.resolvedBrand(styles: ["other": Treatment()])
+        #expect(resolved.accent == "#mine")
+    }
+}
+
+@Suite("Presentation resolution order")
+struct PresentationResolverTests {
+    private func treatment(_ build: (inout Treatment) -> Void) -> Treatment {
+        var t = Treatment()
+        build(&t)
+        return t
+    }
+
+    private var styles: [String: Treatment] {
+        [
+            "house": treatment { $0.accent = "#house"; $0.font = "House"; $0.radius = 20 },
+            "focus": treatment { $0.accent = "#focus" },
+        ]
+    }
+
+    private var workspaces: [String: Workspace] {
+        [
+            "acme": Workspace(
+                title: "Acme",
+                style: "house",
+                brand: treatment { $0.accent = "#acme"; $0.background = "#0b0d0c" }
+            ),
+            "bare": Workspace(title: "Bare"),
+        ]
+    }
+
+    @Test("A note with no workspace and no style is unaffected — today's behavior")
+    func plainNoteIsUntouched() {
+        let effective = PresentationResolver.effective(
+            for: NotePresentation(), styles: styles, workspaces: workspaces
+        )
+        #expect(effective.isEmpty)
+        #expect(PresentationResolver.chain(
+            for: NotePresentation(), styles: styles, workspaces: workspaces
+        ).isEmpty)
+    }
+
+    @Test("A workspace note inherits the brand without carrying any of it")
+    func workspaceBrandApplies() {
+        var p = NotePresentation()
+        p.workspace = "acme"
+        let effective = PresentationResolver.effective(for: p, styles: styles, workspaces: workspaces)
+        #expect(effective.accent == "#acme")        // workspace brand over its style base
+        #expect(effective.background == "#0b0d0c")
+        #expect(effective.font == "House")          // inherited through the base style
+        #expect(effective.radius == 20)
+    }
+
+    /// The escape hatch that keeps a brand from being a cage: a note in a
+    /// branded workspace can still name its own style, and that wins.
+    @Test("A per-note style overrides the workspace brand")
+    func styleBeatsWorkspace() {
+        var p = NotePresentation()
+        p.workspace = "acme"
+        p.style = "focus"
+        let effective = PresentationResolver.effective(for: p, styles: styles, workspaces: workspaces)
+        #expect(effective.accent == "#focus")       // the note's style wins
+        #expect(effective.background == "#0b0d0c")  // brand still supplies the rest
+    }
+
+    @Test("Loose per-note keys beat both the style and the workspace brand")
+    func looseKeysWinOutright() {
+        var p = NotePresentation()
+        p.workspace = "acme"
+        p.style = "focus"
+        p.accent = "#mine"
+        p.radius = 3
+        let effective = PresentationResolver.effective(for: p, styles: styles, workspaces: workspaces)
+        #expect(effective.accent == "#mine")
+        #expect(effective.radius == 3)
+    }
+
+    @Test("Precedence is workspace → style → loose, in that order")
+    func chainOrder() {
+        var p = NotePresentation()
+        p.workspace = "acme"
+        p.style = "focus"
+        p.accent = "#mine"
+        let chain = PresentationResolver.chain(for: p, styles: styles, workspaces: workspaces)
+        #expect(chain.count == 3)
+        #expect(chain[0].accent == "#acme")   // workspace brand, least specific
+        #expect(chain[1].accent == "#focus")  // named style
+        #expect(chain[2].accent == "#mine")   // loose per-note key, most specific
+    }
+
+    @Test("An unknown workspace name renders unbranded rather than failing")
+    func unknownWorkspaceIsIgnored() {
+        var p = NotePresentation()
+        p.workspace = "was-forgotten"
+        let effective = PresentationResolver.effective(for: p, styles: styles, workspaces: workspaces)
+        #expect(effective.isEmpty)
+    }
+
+    @Test("A workspace with no brand contributes nothing to the chain")
+    func unbrandedWorkspaceIsNoOp() {
+        var p = NotePresentation()
+        p.workspace = "bare"
+        #expect(PresentationResolver.chain(for: p, styles: styles, workspaces: workspaces).isEmpty)
+    }
+
+    @Test("Notes still resolve when no workspaces are configured at all")
+    func backwardCompatibleWithoutWorkspaces() {
+        var p = NotePresentation()
+        p.workspace = "acme"
+        p.style = "focus"
+        let effective = PresentationResolver.effective(for: p, styles: styles, workspaces: nil)
+        #expect(effective.accent == "#focus")
+    }
+
+    @Test("Slot is placement, not presentation — it never enters the chain")
+    func slotIsNotPresentation() {
+        var p = NotePresentation()
+        p.slot = 6
+        #expect(PresentationResolver.chain(for: p, styles: nil, workspaces: nil).isEmpty)
+    }
+}
+
+@Suite("Attachment containment")
+struct AttachmentPathTests {
+    private func sandbox() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("BlinkWorkspaceTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func env(_ home: URL) -> [String: String] { ["BLINK_HOME": home.path] }
+
+    @Test("Resolves a real file inside the attachments directory")
+    func resolvesInside() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let marks = BlinkPaths.marks(environment: env(home))
+        try FileManager.default.createDirectory(at: marks, withIntermediateDirectories: true)
+        try Data("<svg/>".utf8).write(to: marks.appendingPathComponent("acme.svg"))
+
+        let url = BlinkPaths.attachment(named: "marks/acme.svg", environment: env(home))
+        #expect(url != nil)
+        #expect(url?.lastPathComponent == "acme.svg")
+    }
+
+    @Test("Accepts the blink:// attachment form the editor uses")
+    func acceptsBlinkScheme() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let marks = BlinkPaths.marks(environment: env(home))
+        try FileManager.default.createDirectory(at: marks, withIntermediateDirectories: true)
+        try Data("<svg/>".utf8).write(to: marks.appendingPathComponent("acme.svg"))
+
+        #expect(BlinkPaths.attachment(named: "blink://attachments/marks/acme.svg", environment: env(home)) != nil)
+    }
+
+    @Test("Rejects absolute paths, traversal, tildes, and missing files")
+    func rejectsOutOfBounds() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        try FileManager.default.createDirectory(
+            at: BlinkPaths.attachments(environment: env(home)), withIntermediateDirectories: true
+        )
+        // A real file that lives outside the attachments root.
+        let outside = home.appendingPathComponent("secret.svg")
+        try Data("<svg/>".utf8).write(to: outside)
+
+        let e = env(home)
+        #expect(BlinkPaths.attachment(named: "/etc/passwd", environment: e) == nil)
+        #expect(BlinkPaths.attachment(named: outside.path, environment: e) == nil)
+        #expect(BlinkPaths.attachment(named: "../secret.svg", environment: e) == nil)
+        #expect(BlinkPaths.attachment(named: "~/secret.svg", environment: e) == nil)
+        #expect(BlinkPaths.attachment(named: "marks/nope.svg", environment: e) == nil)
+        #expect(BlinkPaths.attachment(named: "", environment: e) == nil)
+        #expect(BlinkPaths.attachment(named: nil, environment: e) == nil)
+    }
+
+    @Test("Rejects a symlink that escapes the attachments directory")
+    func rejectsEscapingSymlink() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let attachments = BlinkPaths.attachments(environment: env(home))
+        try FileManager.default.createDirectory(at: attachments, withIntermediateDirectories: true)
+        let outside = home.appendingPathComponent("secret.svg")
+        try Data("<svg/>".utf8).write(to: outside)
+        try FileManager.default.createSymbolicLink(
+            at: attachments.appendingPathComponent("escape.svg"), withDestinationURL: outside
+        )
+
+        #expect(BlinkPaths.attachment(named: "escape.svg", environment: env(home)) == nil)
+    }
+
+    @Test("A directory is not an attachment")
+    func rejectsDirectory() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let marks = BlinkPaths.marks(environment: env(home))
+        try FileManager.default.createDirectory(at: marks, withIntermediateDirectories: true)
+        #expect(BlinkPaths.attachment(named: "marks", environment: env(home)) == nil)
+    }
+}
+
+@Suite("WorkspaceStore")
+struct WorkspaceStoreTests {
+    private func sandbox() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("BlinkWorkspaceStore-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func write(_ json: String, to home: URL) throws {
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        try Data(json.utf8).write(to: home.appendingPathComponent("config.json"))
+    }
+
+    private func readConfig(_ home: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: home.appendingPathComponent("config.json"))
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    // MARK: Names
+
+    @Test("Names normalize to slugs so one workspace has one identity")
+    func normalizesNames() throws {
+        #expect(try WorkspaceStore.normalize("Q3 Planning") == "q3-planning")
+        #expect(try WorkspaceStore.normalize("  acme_docs  ") == "acme-docs")
+    }
+
+    @Test("Names with no usable characters are rejected, not silently collapsed")
+    func rejectsUnusableNames() {
+        #expect(throws: WorkspaceStoreError.self) { try WorkspaceStore.normalize("") }
+        #expect(throws: WorkspaceStoreError.self) { try WorkspaceStore.normalize("   ") }
+        #expect(throws: WorkspaceStoreError.self) { try WorkspaceStore.normalize("---") }
+    }
+
+    // MARK: Read/write
+
+    @Test("Missing config means no workspaces, not an error")
+    func absentConfigIsEmpty() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        #expect(try WorkspaceStore(home: home).all().isEmpty)
+    }
+
+    @Test("Save then read round-trips a branded workspace")
+    func roundTrip() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = WorkspaceStore(home: home)
+
+        var brand = Treatment()
+        brand.accent = "#a6ef87"
+        brand.radius = 6
+        brand.mark = "marks/acme.svg"
+        try store.save(Workspace(title: "Acme Docs", brand: brand), named: "Acme Docs")
+
+        let loaded = try #require(try store.workspace(named: "acme-docs"))
+        #expect(loaded.title == "Acme Docs")
+        #expect(loaded.brand?.accent == "#a6ef87")
+        #expect(loaded.brand?.radius == 6)
+        #expect(loaded.brand?.mark == "marks/acme.svg")
+    }
+
+    /// The load-bearing guarantee: config.json is a shared surface, so writing a
+    /// workspace must not disturb any other key — including keys this build has
+    /// never heard of.
+    @Test("Writing a workspace preserves every other config key verbatim")
+    func preservesForeignConfig() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        try write(
+            """
+            {
+              "appearance": "dark",
+              "hotkeys": { "newNote": "hyper+n", "blink": "hyper+b" },
+              "panel": { "sheet": "glass", "cornerRadius": 12, "tintRead": 0.18 },
+              "styles": { "focus": { "accent": "#d08770" } },
+              "somethingFromTheFuture": { "nested": [1, 2, 3], "flag": true }
+            }
+            """,
+            to: home
+        )
+
+        try WorkspaceStore(home: home).save(Workspace(title: "Acme"), named: "acme")
+
+        let config = try readConfig(home)
+        #expect(config["appearance"] as? String == "dark")
+        #expect((config["hotkeys"] as? [String: Any])?["newNote"] as? String == "hyper+n")
+        #expect((config["panel"] as? [String: Any])?["cornerRadius"] as? Double == 12)
+        #expect((config["panel"] as? [String: Any])?["tintRead"] as? Double == 0.18)
+        #expect(((config["styles"] as? [String: Any])?["focus"] as? [String: Any])?["accent"] as? String == "#d08770")
+        let future = try #require(config["somethingFromTheFuture"] as? [String: Any])
+        #expect(future["flag"] as? Bool == true)
+        #expect((future["nested"] as? [Int]) == [1, 2, 3])
+        #expect(config["workspaces"] != nil)
+    }
+
+    @Test("An unreadable config is never overwritten")
+    func refusesToClobberBadConfig() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let broken = "{ this is not json"
+        try write(broken, to: home)
+
+        #expect(throws: WorkspaceStoreError.self) {
+            try WorkspaceStore(home: home).save(Workspace(), named: "acme")
+        }
+        let after = try String(contentsOf: home.appendingPathComponent("config.json"), encoding: .utf8)
+        #expect(after == broken)
+    }
+
+    @Test("update edits one field without restating the brand")
+    func partialUpdate() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = WorkspaceStore(home: home)
+
+        var brand = Treatment()
+        brand.accent = "#old"
+        brand.font = "Keep Me"
+        try store.save(Workspace(title: "Acme", brand: brand), named: "acme")
+
+        try store.update(named: "acme") { ws in
+            ws.brand?.accent = "#new"
+        }
+
+        let loaded = try #require(try store.workspace(named: "acme"))
+        #expect(loaded.brand?.accent == "#new")
+        #expect(loaded.brand?.font == "Keep Me")
+        #expect(loaded.title == "Acme")
+    }
+
+    @Test("update refuses to invent a workspace when told not to")
+    func updateRequiresExisting() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        #expect(throws: WorkspaceStoreError.self) {
+            try WorkspaceStore(home: home).update(named: "ghost", createIfMissing: false) { _ in }
+        }
+    }
+
+    @Test("Removing the last workspace drops the key instead of leaving an empty object")
+    func removeCleansUp() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = WorkspaceStore(home: home)
+        try store.save(Workspace(), named: "acme")
+        #expect(try store.remove(named: "acme"))
+        #expect(try !store.remove(named: "acme"))
+        #expect(try readConfig(home)["workspaces"] == nil)
+    }
+
+    @Test("Styles registry is readable for brand composition")
+    func readsStyles() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        try write(##"{"styles":{"focus":{"accent":"#d08770","radius":7}}}"##, to: home)
+        let styles = try WorkspaceStore(home: home).styles()
+        #expect(styles["focus"]?.accent == "#d08770")
+        #expect(styles["focus"]?.radius == 7)
+    }
+
+    // MARK: Marks
+
+    @Test("Installing a mark copies it into attachments and returns a relative path")
+    func installsMark() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = WorkspaceStore(home: home)
+
+        let source = home.appendingPathComponent("logo.svg")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        try Data("<svg/>".utf8).write(to: source)
+
+        let relative = try store.installMark(from: source, for: "Acme Docs")
+        #expect(relative == "marks/acme-docs.svg")
+        #expect(BlinkPaths.attachment(named: relative, environment: ["BLINK_HOME": home.path]) != nil)
+    }
+
+    @Test("Rejects a non-image, a missing file, and an oversized asset")
+    func rejectsBadMarks() throws {
+        let home = sandbox()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let store = WorkspaceStore(home: home)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+
+        let script = home.appendingPathComponent("evil.sh")
+        try Data("rm -rf /".utf8).write(to: script)
+        #expect(throws: WorkspaceStoreError.self) { try store.installMark(from: script, for: "acme") }
+
+        let missing = home.appendingPathComponent("nope.svg")
+        #expect(throws: WorkspaceStoreError.self) { try store.installMark(from: missing, for: "acme") }
+
+        let huge = home.appendingPathComponent("huge.png")
+        try Data(repeating: 0, count: WorkspaceStore.markSizeLimit + 1).write(to: huge)
+        #expect(throws: WorkspaceStoreError.self) { try store.installMark(from: huge, for: "acme") }
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,7 +41,27 @@ blink write <id> [text ...] [--json]   # replace content wholesale, silently (no
 blink search <query> [--json]     # case-insensitive substring over title + content
 blink rm <id> [--json]            # delete a note
 blink path [<id>]                 # the notes directory, or a note's file path
+blink workspace <subcommand>      # named groups of notes + their brand
 ```
+
+`workspace` is the grouping/branding verb set — see `docs/workspaces.md` for the
+full guide:
+
+```sh
+blink workspace init <name> [--title T] [brand flags…]   # create (idempotent)
+blink workspace ls                                       # list + note counts
+blink workspace show <name>                              # definition + effective brand
+blink workspace brand <name> [brand flags…]              # mark, palette, type, corners
+blink workspace add <name> <id>…                         # put notes in it
+blink workspace remove <id>…                             # take notes out
+blink workspace notes <name>                             # list member notes
+blink workspace rm <name> [--detach]                     # forget the definition
+```
+
+`new` and `present` also take `--workspace <name>` so a note can be filed on
+creation. Membership is one `blink.workspace:` key in the note's frontmatter;
+the brand itself lives in `config.json`, so note markdown stays portable and
+free of presentation-only branding.
 
 `present` is the compound arrival verb: it sets a note's markdown **and** its
 `blink:` presentation (see `notes-representation.md`) in one write, get-or-create
@@ -71,6 +91,11 @@ blink write standup < revised-standup.md       # replace the body, no animation
 blink cat grocery-run
 blink search standup --json | jq '.[0].id'
 open "$(blink path grocery-run)"           # hand the file to anything
+
+blink workspace init "Acme Docs"                     # a named, brandable group
+blink new --workspace acme-docs "# Q3 Planning"      # file a note into it
+blink workspace brand acme-docs --accent "#7aa2f7" --install-mark ~/acme.svg
+blink workspace notes acme-docs --json | jq -r '.[].id'
 ```
 
 ## JSON shape

--- a/docs/config.md
+++ b/docs/config.md
@@ -147,12 +147,13 @@ Maximum-contrast writing mode:
 }
 ```
 
-Reusable treatment with a restrained identity mark:
+Reusable treatment with a restrained identity mark (a neutral house style —
+substitute your own colors, faces, and mark):
 
 ```json
 {
   "styles": {
-    "scout-control": {
+    "terminal": {
       "background": "#070908",
       "text": "#f2f4ef",
       "textStrong": "#f2f4ef",
@@ -169,20 +170,21 @@ Reusable treatment with a restrained identity mark:
       "caret": "#a6ef87",
       "selection": "rgba(166,239,135,.1)",
       "radius": 6,
-      "mark": "theme-marks/openscout-scout-hex.svg"
+      "mark": "marks/terminal.svg"
     }
   }
 }
 ```
 
-`panel.mark` and `styles.<name>.mark` are relative paths under
-`$BLINK_HOME/attachments` (or the default Blink attachments directory). The
-mark appears at 20px in a 24pt top-left chrome cell and yields that position to
-the close control on hover. Marked themes receive a compact content gutter so
-the identity never overlaps the first heading or editor source. Keeping it in
-the treatment instead of the markdown body preserves the note as portable,
-presentation-free Markdown. Absolute paths and paths escaping the attachments
-directory are ignored.
+`panel.mark`, `styles.<name>.mark`, and a workspace brand's `mark` are relative
+paths under `$BLINK_HOME/attachments` (or the default Blink attachments
+directory). The mark appears at 20px in a 24pt top-left chrome cell and yields
+that position to the close control on hover. Marked themes receive a compact
+content gutter so the identity never overlaps the first heading or editor
+source. Keeping it in the treatment instead of the markdown body preserves the
+note as portable, presentation-free Markdown. Absolute paths and paths escaping
+the attachments directory are ignored — `blink workspace brand … --install-mark`
+copies an asset into bounds for you.
 
 Treatments are partial overlays. In addition to the original
 `sheet`/`accent`/`font`/`fontSize`/`lineHeight`/`tint*`/`radius` fields, they
@@ -190,6 +192,46 @@ accept `background`, `text`, `textStrong`, `textMuted`, `accentDim`, `mono`,
 `titleFont`, `dim`, `border`, `codeBackground`, `codeText`, `caret`, and
 `selection`. These map to the same editor and sheet variables as their global
 config counterparts, but apply only to notes that reference that named style.
+
+## Workspaces
+
+A **workspace** is a named group of notes plus the brand they render under. The
+definition lives here; membership lives in each note's `blink.workspace`
+frontmatter key, so note markdown never carries a color, face, or asset path.
+
+```json
+{
+  "workspaces": {
+    "acme-docs": {
+      "title": "Acme Documentation",
+      "style": "terminal",
+      "brand": {
+        "accent": "#7aa2f7",
+        "background": "#0b0d0c",
+        "radius": 6,
+        "mark": "marks/acme-docs.svg"
+      }
+    }
+  }
+}
+```
+
+`style` names an entry in `styles` to use as a base; `brand` is a treatment
+overlaid on top of it, so several workspaces can share one house style and tint
+it differently. Both are optional — a workspace with neither is unbranded, and
+its notes render with Blink's defaults.
+
+A note's look resolves least-specific first, so **later wins**:
+
+```
+config defaults ← workspaces[blink.workspace].brand ← styles[blink.style] ← loose blink: keys
+```
+
+Unknown workspace and style names contribute nothing rather than failing, so a
+note whose workspace was forgotten still opens — just unbranded. Agents should
+drive this through `blink workspace` (see `docs/workspaces.md`) rather than
+hand-editing, because the CLI writes only the `workspaces` key and leaves every
+other config key byte-for-byte intact.
 
 ## Motion (Arrival)
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,0 +1,208 @@
+# Notes Workspaces — the agent-facing guide
+
+> A **workspace** is a named group of notes plus the brand they render under.
+> One command creates it, one command brands it, and the notes inside stay
+> plain, portable Markdown. Companion to `cli.md` (the full CLI),
+> `config.json` (`docs/config.md`), and `notes-representation.md` Appendix A.
+
+## The one thing to understand
+
+A workspace is two halves, kept deliberately apart:
+
+| Half | Lives in | Holds |
+|---|---|---|
+| **Definition** | `config.json` → `workspaces.<name>` | title + brand (mark, palette, typography, corners) |
+| **Membership** | each note's frontmatter → `blink.workspace` | one name. Nothing else. |
+
+That split is the whole design. The brand is edited in exactly one place, and a
+note carries a workspace *name* — never a color, a font, or an asset path. So a
+branded note is still a boring `.md` file that works in Obsidian, git, or
+`grep`, five years after Blink is uninstalled.
+
+```markdown
+---
+id: q3-planning
+created: 2026-07-25T22:39:44.042Z
+updated: 2026-07-25T22:39:44.042Z
+tags: []
+pinned: false
+blink:
+  workspace: acme-docs
+---
+# Q3 Planning
+```
+
+That is the entire on-disk cost of belonging to a fully branded workspace.
+
+## Quick start
+
+```sh
+blink workspace init "Acme Docs" --title "Acme Documentation"
+blink new --workspace acme-docs "# Q3 Planning"
+blink new --workspace acme-docs "# Onboarding"
+
+blink workspace brand acme-docs \
+  --background "#0b0d0c" --text "#f2f4ef" --accent "#7aa2f7" \
+  --title-font "Inter, system-ui" --radius 6 \
+  --install-mark ~/brand/acme.svg
+
+blink workspace notes acme-docs      # what's in here
+```
+
+The running app picks all of it up live — it watches both the notes directory
+and `config.json`, so a brand change re-themes open panels without a restart.
+
+## Commands
+
+```sh
+blink workspace init <name> [--title T] [brand flags…]   # create (idempotent)
+blink workspace ls                                       # list + note counts
+blink workspace show <name>                              # definition + effective brand
+blink workspace brand <name> [brand flags…]              # set/adjust the brand
+blink workspace add <name> <id>…                         # put notes in it
+blink workspace remove <id>…                             # take notes out
+blink workspace notes <name>                             # list member notes
+blink workspace rm <name> [--detach]                     # forget the definition
+```
+
+Plus membership on the note verbs you already use:
+
+```sh
+blink new --workspace <name> "# Title"
+blink present <id> --workspace <name> [--style … --slot …]
+```
+
+Every command takes `--json`. Errors go to stderr with a non-zero exit code.
+
+Names are normalized to slugs, so `"Acme Docs"` and `acme-docs` address the same
+workspace and you can pass whichever you have.
+
+## Defining a brand
+
+A brand is a **treatment** — the same generic, reusable preset `styles` uses, so
+there is one presentation vocabulary in Blink, not two. Every field is optional;
+what you don't set is inherited.
+
+| Group | Flags |
+|---|---|
+| Surface | `--sheet --background --radius --tint --tint-read --tint-edit` |
+| Typography | `--font --mono --title-font --font-size --line-height` |
+| Palette | `--text --text-strong --text-muted --dim --border --accent --accent-dim --code-background --code-text --caret --selection` |
+| Identity | `--mark` (reference) · `--install-mark` (copy in) |
+| Bulk | `--brand-from <file.json>` · `--style <name>` · `--clear <field>` |
+
+`brand` is a partial overlay, so adjusting one color never restates the rest:
+
+```sh
+blink workspace brand acme-docs --accent "#9ece6a"     # only the accent moves
+blink workspace brand acme-docs --clear mark           # back to inheriting
+```
+
+To define a whole brand in one call, hand it a JSON file:
+
+```sh
+cat > acme-brand.json <<'JSON'
+{
+  "background": "#0b0d0c",
+  "text": "#f2f4ef",
+  "accent": "#7aa2f7",
+  "border": "rgba(239,244,237,.09)",
+  "titleFont": "Inter, system-ui",
+  "radius": 6
+}
+JSON
+blink workspace brand acme-docs --brand-from acme-brand.json
+```
+
+### Sharing a house style
+
+`--style <name>` names an entry in `config.json` → `styles` to use as the brand's
+base, with the workspace's own brand overlaid on top. Several workspaces can
+then share one house style and differ only where they mean to:
+
+```sh
+blink workspace brand acme-docs   --style terminal --accent "#7aa2f7"
+blink workspace brand acme-alerts --style terminal --accent "#f7768e"
+```
+
+`blink workspace show <name> --json` reports both the stored `brand` and the
+`effectiveBrand` (base + overlay, already composed) so an agent never has to
+recompute the merge itself.
+
+## Brand assets, safely
+
+Blink renders marks **only** from inside `$BLINK_HOME/attachments`. That is a
+containment boundary, not a convention: absolute paths, `../` traversal, and
+symlinks pointing out of the directory are all refused, so a bad brand value
+becomes an absent mark rather than an arbitrary file read.
+
+Two ways to set one, and the first is the one to reach for:
+
+```sh
+# Install: copies the asset into attachments/marks/<workspace>.<ext> and
+# records the relative path for you. Validates type and size (≤2 MB).
+blink workspace brand acme-docs --install-mark ~/brand/acme.svg
+
+# Reference: for an asset already inside the attachments directory.
+blink workspace brand acme-docs --mark marks/acme.svg
+```
+
+Supported: `svg png jpg jpeg gif webp pdf tiff`. The mark renders at 20px in the
+panel's top-left chrome and yields that spot to the close control on hover;
+marked panels get a slightly wider content gutter so the identity never collides
+with the first heading.
+
+`show` tells you whether a mark actually resolves — a mark recorded but missing
+from disk is flagged rather than silently ignored:
+
+```sh
+blink workspace show acme-docs --json | jq '.mark'
+# { "path": "marks/acme.svg", "resolved": "/…/attachments/marks/acme.svg", "installed": true }
+```
+
+## How a note's look is decided
+
+Least specific first, so **later wins**:
+
+```
+config defaults ← workspace brand ← blink.style ← loose blink: keys
+```
+
+A note inherits its workspace's identity for free; a per-note `style` still
+overrides the brand; a loose `blink:` key beats both. The brand is a default,
+never a cage.
+
+```sh
+blink present exception --workspace acme-docs --accent "#f7768e"
+# ↑ Acme's brand, except this one note runs a red accent.
+```
+
+## Defaults and compatibility
+
+- **Unbranded is the default.** A Blink with no workspaces behaves exactly as it
+  did before this feature existed. A workspace with no brand is valid and
+  renders with Blink's defaults.
+- **Unknown names never fail.** A note pointing at a workspace or style that
+  isn't defined renders unbranded — it always opens.
+- **Existing notes and configs are untouched.** `blink.workspace` is a new,
+  optional key in the `blink:` block; `workspaces` is a new, optional config key.
+  Notes without them are unaffected, and `blink.style` keeps working exactly as
+  before.
+- **Your config is not rewritten.** `blink workspace` parses `config.json` as
+  generic JSON, replaces only the `workspaces` key, and writes everything else
+  back verbatim — including keys this build has never heard of. A config it
+  cannot parse is refused, never overwritten.
+- **Forgetting a workspace costs a look, never a note.** `blink workspace rm`
+  removes the definition only; member notes keep their content and simply render
+  unbranded. Add `--detach` to also clear membership from each member note.
+
+## What this is not
+
+`blink workspace` manages *durable* state — the files and the config. It does
+not open panels or move them on screen; that is the live plane, and it belongs
+to the running app (see `agent-api.md`, layer 2.5, still proposed). To reopen a
+workspace today, list it and open the notes:
+
+```sh
+blink workspace notes acme-docs --json | jq -r '.[].id'
+```

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arach/blink",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Spatial notes for macOS — native floating panels and an agent-first CLI over local Markdown.",
   "homepage": "https://blink.arach.dev",
   "bugs": {


### PR DESCRIPTION
## Summary
- add first-class workspaces with branded note treatments and safe config persistence
- add workspace-aware CLI commands, guide, command palette, activity catalog, and refreshed settings
- document workspace/config behavior and bump the app + npm package to 2.0.4

## Verification
- swift test --skip-build (126 tests, 15 suites)
- swift build -c release --product BlinkApp
- web/editor: bun install && bun run build
- .build/debug/blink --version → 2.0.4
- ./tools/release/ship.sh --dry-run