### PR TITLE
🎨 Polish landing: agent case study, theme contrast, GA

### DIFF
--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -7,102 +7,123 @@
   :root {
     --bg: #e8e2d4;
     --bg-2: #efeae0;
-    --panel: #f3efe6;
-    --panel-2: #faf7f0;
-    --line: #d5cdb9;
-    --line-2: #c5bba3;
-    --text: #1c1814;
-    --dim: #5c5648;
-    --faint: #8a8270;
-    --ghost: #b8b09a;
-    --acc: #1a1612;
-    --acc-rgb: 26, 22, 18;
+    --panel: #f6f2e9;
+    --panel-2: #fcfaf5;
+    --line: #cfc6b2;
+    --line-2: #b8ae98;
+    --text: #0c0a08;
+    --dim: #3f3a32;
+    --faint: #6a6356;
+    --ghost: #a89f8c;
+    --acc: #0a0806;
+    --acc-rgb: 10, 8, 6;
     --acc-soft: rgba(var(--acc-rgb), 0.08);
-    --on-acc: #f7f2e8;
-    --amber: #1a1612;
-    --cyan: #5c5648;
-    --red: #1a1612;
+    --on-acc: #faf7f0;
+    --amber: #0a0806;
+    --cyan: #3f3a32;
+    --red: #0a0806;
     --bg-rgb: 232, 226, 212;
-    --line-rgb: 213, 205, 185;
-    --grid: rgba(120, 96, 52, 0.045);
+    --line-rgb: 207, 198, 178;
+    --grid: rgba(60, 48, 32, 0.055);
     /* Spatial demo “desktop”: layered desk, not a flat fill */
-    --demo-surface: #cfc6b4;
-    --demo-surface-mid: #ddd4c4;
+    --demo-surface: #c8bfab;
+    --demo-surface-mid: #d9d0bc;
     --demo-surface-hi: #ebe4d6;
-    --demo-vignette: rgba(72, 58, 40, 0.22);
-    --demo-glow: rgba(255, 250, 242, 0.55);
-    --demo-grid-line: rgba(60, 48, 32, 0.08);
-    --demo-chrome: linear-gradient(180deg, #faf7f0 0%, #f0ebe0 100%);
-    --demo-chrome-border: #cfc6b4;
+    --demo-vignette: rgba(48, 38, 24, 0.28);
+    --demo-glow: rgba(255, 252, 246, 0.55);
+    --demo-grid-line: rgba(40, 32, 20, 0.1);
+    --demo-chrome: linear-gradient(180deg, #fcfaf5 0%, #f0ebe0 100%);
+    --demo-chrome-border: #b8ae98;
     /* mono syntax — ink only */
-    --syn-key: #1c1814;
-    --syn-str: #1c1814;
-    --syn-num: #1c1814;
-    --syn-bool: #1c1814;
-    --syn-punct: #5c5648;
-    --syn-comment: #8a8270;
+    --syn-key: #0c0a08;
+    --syn-str: #0c0a08;
+    --syn-num: #0c0a08;
+    --syn-bool: #0c0a08;
+    --syn-punct: #3f3a32;
+    --syn-comment: #6a6356;
 
     --background: 40 22% 88%;
-    --foreground: 30 16% 10%;
-    --card: 40 28% 94%;
-    --card-foreground: 30 16% 10%;
-    --popover: 40 28% 94%;
-    --popover-foreground: 30 16% 10%;
-    --primary: 30 12% 10%;
-    --primary-foreground: 40 30% 95%;
+    --foreground: 30 16% 4%;
+    --card: 40 30% 96%;
+    --card-foreground: 30 16% 4%;
+    --popover: 40 30% 96%;
+    --popover-foreground: 30 16% 4%;
+    --primary: 30 14% 4%;
+    --primary-foreground: 40 30% 96%;
     --secondary: 40 14% 90%;
-    --secondary-foreground: 30 16% 10%;
+    --secondary-foreground: 30 16% 4%;
     --muted: 40 14% 90%;
-    --muted-foreground: 30 8% 40%;
+    --muted-foreground: 30 10% 28%;
     --accent: 40 14% 90%;
-    --accent-foreground: 30 12% 10%;
+    --accent-foreground: 30 14% 4%;
     --destructive: 5 70% 42%;
     --destructive-foreground: 40 30% 95%;
-    --border: 40 14% 78%;
-    --input: 40 14% 78%;
-    --ring: 30 12% 10%;
+    --border: 40 16% 72%;
+    --input: 40 16% 72%;
+    --ring: 30 14% 4%;
     --radius: 0.375rem;
   }
 
-  /* black — pure dark mono */
+  /*
+   * black — true mono, not “soft charcoal.”
+   * Surfaces stay near black; type is near white; secondary steps are wide
+   * so the page reads ink-on-void instead of a gray scale.
+   */
   [data-theme="black"] {
-    --bg: #0a0a0b;
-    --bg-2: #0c0c0e;
-    --panel: #111113;
-    --panel-2: #161618;
-    --line: #222226;
-    --line-2: #303036;
-    --text: #e6e6e8;
-    --dim: #98989e;
-    --faint: #6e6e76;
-    --ghost: #4a4a52;
-    --acc: #f0ece4;
-    --acc-rgb: 240, 236, 228;
-    --acc-soft: rgba(var(--acc-rgb), 0.1);
-    --on-acc: #0a0a0b;
-    --amber: #f0ece4;
-    --cyan: #98989e;
-    --red: #f0ece4;
-    --bg-rgb: 10, 10, 11;
-    --line-rgb: 34, 34, 38;
-    --grid: rgba(255, 255, 255, 0.014);
-    --demo-surface: #0c0c0e;
-    --demo-surface-mid: #121214;
-    --demo-surface-hi: #1a1a1e;
-    --demo-vignette: rgba(0, 0, 0, 0.55);
-    --demo-glow: rgba(240, 236, 228, 0.06);
-    --demo-grid-line: rgba(240, 236, 228, 0.07);
-    --demo-chrome: linear-gradient(180deg, #18181b 0%, #111113 100%);
-    --demo-chrome-border: #2a2a30;
-    /* mono syntax — cream only */
-    --syn-key: #e6e6e8;
-    --syn-str: #f0ece4;
-    --syn-num: #f0ece4;
-    --syn-bool: #e6e6e8;
-    --syn-punct: #98989e;
-    --syn-comment: #6e6e76;
-    --background: 240 6% 4%;
-    --foreground: 240 6% 90%;
+    --bg: #000000;
+    --bg-2: #050505;
+    --panel: #0a0a0a;
+    --panel-2: #111111;
+    --line: #2a2a2a;
+    --line-2: #404040;
+    --text: #fafafa;
+    --dim: #b3b3b3;
+    --faint: #8a8a8a;
+    --ghost: #525252;
+    --acc: #ffffff;
+    --acc-rgb: 255, 255, 255;
+    --acc-soft: rgba(255, 255, 255, 0.1);
+    --on-acc: #000000;
+    --amber: #ffffff;
+    --cyan: #b3b3b3;
+    --red: #ffffff;
+    --bg-rgb: 0, 0, 0;
+    --line-rgb: 42, 42, 42;
+    --grid: rgba(255, 255, 255, 0.04);
+    --demo-surface: #070707;
+    --demo-surface-mid: #0e0e0e;
+    --demo-surface-hi: #171717;
+    --demo-vignette: rgba(0, 0, 0, 0.75);
+    --demo-glow: rgba(255, 255, 255, 0.045);
+    --demo-grid-line: rgba(255, 255, 255, 0.09);
+    --demo-chrome: linear-gradient(180deg, #141414 0%, #0a0a0a 100%);
+    --demo-chrome-border: #333333;
+    /* mono syntax — white / gray only */
+    --syn-key: #fafafa;
+    --syn-str: #ffffff;
+    --syn-num: #ffffff;
+    --syn-bool: #fafafa;
+    --syn-punct: #b3b3b3;
+    --syn-comment: #8a8a8a;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 4%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 4%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 100%;
+    --primary-foreground: 0 0% 0%;
+    --secondary: 0 0% 8%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 8%;
+    --muted-foreground: 0 0% 70%;
+    --accent: 0 0% 8%;
+    --accent-foreground: 0 0% 100%;
+    --destructive: 0 70% 50%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 0 0% 16%;
+    --input: 0 0% 16%;
+    --ring: 0 0% 100%;
   }
 }
 
@@ -117,10 +138,10 @@
     0 1px 2px rgba(60, 48, 28, 0.12);
 }
 [data-theme="black"] .kbd {
-  background: linear-gradient(180deg, #191920, #0e0e12);
-  border-color: var(--line-2);
-  color: var(--dim);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 2px 0 rgba(0, 0, 0, 0.5);
+  background: linear-gradient(180deg, #1a1a1a, #0a0a0a);
+  border-color: #3a3a3a;
+  color: #e5e5e5;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 2px 0 rgba(0, 0, 0, 0.8);
 }
 
 /* Cream default: no CRT flicker; warm wash + light frame on demo */
@@ -159,10 +180,10 @@ body {
   color: #0a0a0b;
 }
 [data-theme="black"] ::-webkit-scrollbar-thumb {
-  background: #26262c;
+  background: #2e2e2e;
   border-color: var(--bg);
 }
-[data-theme="black"] ::-webkit-scrollbar-thumb:hover { background: #36363e; }
+[data-theme="black"] ::-webkit-scrollbar-thumb:hover { background: #454545; }
 [data-theme="black"] body {
   background-image:
     linear-gradient(var(--grid) 1px, transparent 1px),
@@ -223,30 +244,30 @@ body {
   }
   .hairline-t { border-top: 1px solid var(--line); }
   .hairline-b { border-bottom: 1px solid var(--line); }
-  /* Floating note panels — dark HUD glass on either page theme */
+  /* Floating note panels — dark HUD glass (cream page) / pure black glass (black page) */
   .glass-note {
     background:
-      linear-gradient(165deg, rgba(58, 56, 54, 0.72) 0%, rgba(28, 28, 30, 0.78) 48%, rgba(16, 16, 18, 0.82) 100%);
-    backdrop-filter: blur(18px) saturate(1.15);
-    -webkit-backdrop-filter: blur(18px) saturate(1.15);
-    border: 1px solid rgba(255, 248, 236, 0.16);
+      linear-gradient(165deg, rgba(42, 40, 38, 0.88) 0%, rgba(18, 18, 18, 0.92) 48%, rgba(8, 8, 8, 0.94) 100%);
+    backdrop-filter: blur(18px) saturate(1.1);
+    -webkit-backdrop-filter: blur(18px) saturate(1.1);
+    border: 1px solid rgba(255, 255, 255, 0.14);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.14),
-      inset 0 -1px 0 rgba(0, 0, 0, 0.25),
-      0 1px 2px rgba(0, 0, 0, 0.12),
-      0 12px 28px -6px rgba(0, 0, 0, 0.38),
-      0 28px 56px -16px rgba(0, 0, 0, 0.32);
+      inset 0 1px 0 rgba(255, 255, 255, 0.12),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.35),
+      0 1px 2px rgba(0, 0, 0, 0.18),
+      0 12px 28px -6px rgba(0, 0, 0, 0.42),
+      0 28px 56px -16px rgba(0, 0, 0, 0.36);
   }
   [data-theme="black"] .glass-note {
     background:
-      linear-gradient(165deg, rgba(48, 48, 52, 0.65) 0%, rgba(22, 22, 26, 0.78) 50%, rgba(12, 12, 14, 0.88) 100%);
-    border-color: rgba(240, 236, 228, 0.14);
+      linear-gradient(165deg, rgba(28, 28, 28, 0.92) 0%, rgba(12, 12, 12, 0.96) 50%, rgba(0, 0, 0, 0.98) 100%);
+    border-color: rgba(255, 255, 255, 0.18);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.1),
-      inset 0 -1px 0 rgba(0, 0, 0, 0.4),
-      0 1px 2px rgba(0, 0, 0, 0.4),
-      0 16px 36px -8px rgba(0, 0, 0, 0.65),
-      0 32px 64px -20px rgba(0, 0, 0, 0.55);
+      inset 0 1px 0 rgba(255, 255, 255, 0.12),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.6),
+      0 0 0 1px rgba(0, 0, 0, 0.6),
+      0 16px 36px -8px rgba(0, 0, 0, 0.75),
+      0 32px 64px -20px rgba(0, 0, 0, 0.65);
   }
 
   /* Premium desktop plate inside the spatial demo */
@@ -314,12 +335,21 @@ body {
 }
 .note-spawn { animation: noteSpawn 0.34s cubic-bezier(0.2, 0.9, 0.25, 1.15) backwards; }
 
+/* Case-study desk panels — ease in, no flash / overshoot */
+@keyframes deskNoteIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.desk-note-in {
+  animation: deskNoteIn 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
 @keyframes noteVanish {
   to { opacity: 0; transform: scale(0.94); filter: brightness(1.8); }
 }
 .note-vanish { animation: noteVanish 0.22s ease-in both; }
 
-/* soft pulse dot */
+/* soft pulse dot — opt-in only (avoid on calm surfaces) */
 @keyframes pulseDot {
   0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(var(--acc-rgb), 0.45); }
   50% { opacity: 0.75; box-shadow: 0 0 0 5px rgba(var(--acc-rgb), 0); }

--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -3,125 +3,139 @@
 @tailwind utilities;
 
 @layer base {
+  /* Default: cream / paper — warm stock, ink. Optional: data-theme="black". */
   :root {
-    --bg: #0a0a0b;
-    --bg-2: #0c0c0e;
-    --panel: #0f0f11;
-    --panel-2: #121214;
-    --line: #1e1e22;
-    --line-2: #2b2b31;
-    --text: #d8d8dc;
-    --dim: #8e8e96;
-    --faint: #5a5a62;
-    --ghost: #3a3a40;
-    --acc: #f0b45a;
-    --acc-rgb: 240, 180, 90;
-    --acc-soft: rgba(var(--acc-rgb), 0.12);
-    --on-acc: #17120a;  /* text that sits ON the accent (buttons) */
-    --amber: #f0b45a;
-    --cyan: #7cc7e8;
-    --red: #ff7a6e;
-    /* rgb() forms so surfaces/borders/decoration can retint per theme */
-    --bg-rgb: 10, 10, 11;
-    --line-rgb: 30, 30, 34;
-    --grid: rgba(255, 255, 255, 0.028);
-    --demo-surface: #09090b;  /* the interactive demo's canvas */
-    /* code syntax — tuned for a dark surface by default */
-    --syn-key: #7cc7e8; --syn-str: #f0b45a; --syn-num: #f0b45a;
-    --syn-bool: #ff7a6e; --syn-punct: #8e8e96; --syn-comment: #5a5a62;
+    --bg: #e8e2d4;
+    --bg-2: #efeae0;
+    --panel: #f3efe6;
+    --panel-2: #faf7f0;
+    --line: #d5cdb9;
+    --line-2: #c5bba3;
+    --text: #1c1814;
+    --dim: #5c5648;
+    --faint: #8a8270;
+    --ghost: #b8b09a;
+    --acc: #1a1612;
+    --acc-rgb: 26, 22, 18;
+    --acc-soft: rgba(var(--acc-rgb), 0.08);
+    --on-acc: #f7f2e8;
+    --amber: #1a1612;
+    --cyan: #5c5648;
+    --red: #1a1612;
+    --bg-rgb: 232, 226, 212;
+    --line-rgb: 213, 205, 185;
+    --grid: rgba(120, 96, 52, 0.045);
+    /* Spatial demo “desktop”: layered desk, not a flat fill */
+    --demo-surface: #cfc6b4;
+    --demo-surface-mid: #ddd4c4;
+    --demo-surface-hi: #ebe4d6;
+    --demo-vignette: rgba(72, 58, 40, 0.22);
+    --demo-glow: rgba(255, 250, 242, 0.55);
+    --demo-grid-line: rgba(60, 48, 32, 0.08);
+    --demo-chrome: linear-gradient(180deg, #faf7f0 0%, #f0ebe0 100%);
+    --demo-chrome-border: #cfc6b4;
+    /* mono syntax — ink only */
+    --syn-key: #1c1814;
+    --syn-str: #1c1814;
+    --syn-num: #1c1814;
+    --syn-bool: #1c1814;
+    --syn-punct: #5c5648;
+    --syn-comment: #8a8270;
 
-    --background: 120 14% 3%;
-    --foreground: 120 12% 86%;
-    --card: 120 14% 4%;
-    --card-foreground: 120 12% 86%;
-    --popover: 120 14% 4%;
-    --popover-foreground: 120 12% 86%;
-    --primary: 136 100% 65%;
-    --primary-foreground: 120 30% 5%;
-    --secondary: 120 10% 10%;
-    --secondary-foreground: 120 12% 86%;
-    --muted: 120 10% 10%;
-    --muted-foreground: 120 8% 55%;
-    --accent: 120 10% 10%;
-    --accent-foreground: 136 100% 65%;
-    --destructive: 5 90% 65%;
-    --destructive-foreground: 120 30% 5%;
-    --border: 120 12% 12%;
-    --input: 120 12% 12%;
-    --ring: 136 100% 65%;
+    --background: 40 22% 88%;
+    --foreground: 30 16% 10%;
+    --card: 40 28% 94%;
+    --card-foreground: 30 16% 10%;
+    --popover: 40 28% 94%;
+    --popover-foreground: 30 16% 10%;
+    --primary: 30 12% 10%;
+    --primary-foreground: 40 30% 95%;
+    --secondary: 40 14% 90%;
+    --secondary-foreground: 30 16% 10%;
+    --muted: 40 14% 90%;
+    --muted-foreground: 30 8% 40%;
+    --accent: 40 14% 90%;
+    --accent-foreground: 30 12% 10%;
+    --destructive: 5 70% 42%;
+    --destructive-foreground: 40 30% 95%;
+    --border: 40 14% 78%;
+    --input: 40 14% 78%;
+    --ring: 30 12% 10%;
     --radius: 0.375rem;
   }
 
-  /* Full-palette themes: each overrides the whole surface — background, panels,
-     lines, text tones, the body grid, and accent — so the page changes mood, not
-     just its highlight. Amber (default) lives in :root; set data-theme on <html>. */
-
-  /* green phosphor — a P1 CRT terminal */
-  [data-theme="green"] {
-    --bg: #060907; --bg-2: #080c09; --panel: #0b100c; --panel-2: #0e140f;
-    --line: #17251b; --line-2: #23331f; --text: #c7e8cf; --dim: #7ba883;
-    --faint: #4c6b53; --ghost: #2f4636;
-    --acc: #6ee787; --acc-rgb: 110, 231, 135; --amber: #6ee787;
-    --bg-rgb: 6, 9, 7; --line-rgb: 23, 37, 27; --grid: rgba(110, 231, 135, 0.04);
-  }
-
-  /* blueprint — cool slate + cyan */
-  [data-theme="blue"] {
-    --bg: #070a10; --bg-2: #0a0e16; --panel: #0c111b; --panel-2: #0f1521;
-    --line: #1a2233; --line-2: #26314a; --text: #cdd7ea; --dim: #808da8;
-    --faint: #515d76; --ghost: #333c52;
-    --acc: #7cc7e8; --acc-rgb: 124, 199, 232; --amber: #7cc7e8;
-    --bg-rgb: 7, 10, 16; --line-rgb: 26, 34, 51; --grid: rgba(124, 199, 232, 0.035);
-  }
-
-  /* synth — deep violet + magenta */
-  [data-theme="violet"] {
-    --bg: #0a0810; --bg-2: #0d0a16; --panel: #110c1a; --panel-2: #150f21;
-    --line: #241a33; --line-2: #33264a; --text: #ddd3ea; --dim: #948aa8;
-    --faint: #5c5176; --ghost: #3a3352;
-    --acc: #c792ea; --acc-rgb: 199, 146, 234; --amber: #c792ea;
-    --bg-rgb: 10, 8, 16; --line-rgb: 36, 26, 51; --grid: rgba(199, 146, 234, 0.035);
-  }
-
-  /* paper — a printed man page, ink on warm stock (light) */
-  [data-theme="paper"] {
-    --bg: #e8e2d4; --bg-2: #efeae0; --panel: #f3efe6; --panel-2: #faf7f0;
-    --line: #d5cdb9; --line-2: #c5bba3; --text: #262019; --dim: #6a6250;
-    --faint: #9a927c; --ghost: #c0b8a2;
-    --acc: #9c5a16; --acc-rgb: 156, 90, 22; --amber: #9c5a16;
-    --on-acc: #fbf6ec;
-    --bg-rgb: 232, 226, 212; --line-rgb: 213, 205, 185;
-    --grid: rgba(120, 96, 52, 0.06);       /* warm sepia rule, like engineering paper */
-    --demo-surface: #ded5c1;               /* the demo becomes a light plate; notes stay dark glass */
-    --syn-key: #1a6a9e; --syn-str: #8f6a10; --syn-num: #a85418;
-    --syn-bool: #b23a2a; --syn-punct: #736b57; --syn-comment: #9a927c;
-    --background: 40 22% 88%; --foreground: 40 16% 12%;
+  /* black — pure dark mono */
+  [data-theme="black"] {
+    --bg: #0a0a0b;
+    --bg-2: #0c0c0e;
+    --panel: #111113;
+    --panel-2: #161618;
+    --line: #222226;
+    --line-2: #303036;
+    --text: #e6e6e8;
+    --dim: #98989e;
+    --faint: #6e6e76;
+    --ghost: #4a4a52;
+    --acc: #f0ece4;
+    --acc-rgb: 240, 236, 228;
+    --acc-soft: rgba(var(--acc-rgb), 0.1);
+    --on-acc: #0a0a0b;
+    --amber: #f0ece4;
+    --cyan: #98989e;
+    --red: #f0ece4;
+    --bg-rgb: 10, 10, 11;
+    --line-rgb: 34, 34, 38;
+    --grid: rgba(255, 255, 255, 0.014);
+    --demo-surface: #0c0c0e;
+    --demo-surface-mid: #121214;
+    --demo-surface-hi: #1a1a1e;
+    --demo-vignette: rgba(0, 0, 0, 0.55);
+    --demo-glow: rgba(240, 236, 228, 0.06);
+    --demo-grid-line: rgba(240, 236, 228, 0.07);
+    --demo-chrome: linear-gradient(180deg, #18181b 0%, #111113 100%);
+    --demo-chrome-border: #2a2a30;
+    /* mono syntax — cream only */
+    --syn-key: #e6e6e8;
+    --syn-str: #f0ece4;
+    --syn-num: #f0ece4;
+    --syn-bool: #e6e6e8;
+    --syn-punct: #98989e;
+    --syn-comment: #6e6e76;
+    --background: 240 6% 4%;
+    --foreground: 240 6% 90%;
   }
 }
 
-/* Keycaps: molded dark keys by default; on paper, printed light keys with ink glyphs. */
+/* Keycaps: cream = printed paper keys; black = molded dark keys */
 .kbd {
-  background: linear-gradient(180deg, #191920, #0e0e12);
-  border: 1px solid var(--line-2);
-  color: var(--dim);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 2px 0 rgba(0, 0, 0, 0.5);
-}
-[data-theme="paper"] .kbd {
   background: linear-gradient(180deg, #ffffff, #ece5d6);
-  border-color: #cbc0a9;
+  border: 1px solid #cbc0a9;
   color: #4a4230;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.9),
     0 2px 0 rgba(150, 135, 105, 0.4),
     0 1px 2px rgba(60, 48, 28, 0.12);
 }
+[data-theme="black"] .kbd {
+  background: linear-gradient(180deg, #191920, #0e0e12);
+  border-color: var(--line-2);
+  color: var(--dim);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 2px 0 rgba(0, 0, 0, 0.5);
+}
 
-/* Paper is print, not a screen — drop the CRT decoration, warm the page, frame the figure. */
-[data-theme="paper"] .crt { animation: none; }
-[data-theme="paper"] .scanline { display: none; }
-[data-theme="paper"] ::selection { color: #262019; }
-[data-theme="paper"] ::-webkit-scrollbar-thumb { background: #cfc7b4; border-color: var(--bg); }
-[data-theme="paper"] body {
+/* Cream default: no CRT flicker; warm wash + light frame on demo */
+.crt { animation: none; }
+::selection {
+  background: rgba(var(--acc-rgb), 0.18);
+  color: var(--text);
+}
+::-webkit-scrollbar-thumb {
+  background: #cfc7b4;
+  border: 2px solid var(--bg);
+  border-radius: 6px;
+}
+::-webkit-scrollbar-thumb:hover { background: #b8b09a; }
+body {
   background-image:
     linear-gradient(var(--grid) 1px, transparent 1px),
     linear-gradient(90deg, var(--grid) 1px, transparent 1px),
@@ -129,14 +143,41 @@
   background-size: 56px 56px, 56px 56px, 100% 100%;
   background-attachment: scroll, scroll, fixed;
 }
-/* the dark-glass demo becomes a light plate; lift it off the page like a pasted figure */
-[data-theme="paper"] .corner-frame {
+.corner-frame {
   border-radius: 8px;
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.6), 0 22px 50px -22px rgba(80, 60, 30, 0.3);
 }
-/* the accent corner ticks are a screen/CRT flourish — drop them on print */
-[data-theme="paper"] .corner-frame::before,
-[data-theme="paper"] .corner-frame::after { display: none; }
+.corner-frame::before,
+.corner-frame::after { display: none; }
+
+/* Black theme restores screen treatment */
+[data-theme="black"] .crt {
+  animation: crtFlicker 6s steps(1) infinite;
+}
+[data-theme="black"] ::selection {
+  background: rgba(var(--acc-rgb), 0.25);
+  color: #0a0a0b;
+}
+[data-theme="black"] ::-webkit-scrollbar-thumb {
+  background: #26262c;
+  border-color: var(--bg);
+}
+[data-theme="black"] ::-webkit-scrollbar-thumb:hover { background: #36363e; }
+[data-theme="black"] body {
+  background-image:
+    linear-gradient(var(--grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+  background-size: 56px 56px;
+  background-attachment: scroll;
+}
+[data-theme="black"] .corner-frame {
+  border-radius: 0;
+  box-shadow: none;
+}
+[data-theme="black"] .corner-frame::before,
+[data-theme="black"] .corner-frame::after {
+  display: block;
+}
 
 @layer base {
   * {
@@ -144,26 +185,19 @@
   }
   html {
     scroll-behavior: smooth;
+    scroll-padding-top: 4rem;
     overflow-x: clip;
   }
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
     background-color: var(--bg);
-    background-image:
-      linear-gradient(var(--grid) 1px, transparent 1px),
-      linear-gradient(90deg, var(--grid) 1px, transparent 1px);
-    background-size: 56px 56px;
     -webkit-font-smoothing: antialiased;
     overflow-x: clip;
   }
   :focus-visible {
     outline: 1px solid var(--acc);
     outline-offset: 3px;
-  }
-  ::selection {
-    background: rgba(var(--acc-rgb), 0.25);
-    color: #fff7ea;
   }
 }
 
@@ -189,14 +223,57 @@
   }
   .hairline-t { border-top: 1px solid var(--line); }
   .hairline-b { border-bottom: 1px solid var(--line); }
+  /* Floating note panels — dark HUD glass on either page theme */
   .glass-note {
-    background: linear-gradient(160deg, rgba(42, 42, 46, 0.55), rgba(18, 18, 20, 0.65));
-    backdrop-filter: blur(14px) saturate(1.2);
-    -webkit-backdrop-filter: blur(14px) saturate(1.2);
-    border: 1px solid rgba(214,204,184, 0.22);
+    background:
+      linear-gradient(165deg, rgba(58, 56, 54, 0.72) 0%, rgba(28, 28, 30, 0.78) 48%, rgba(16, 16, 18, 0.82) 100%);
+    backdrop-filter: blur(18px) saturate(1.15);
+    -webkit-backdrop-filter: blur(18px) saturate(1.15);
+    border: 1px solid rgba(255, 248, 236, 0.16);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.07),
-      0 18px 40px rgba(0, 0, 0, 0.55);
+      inset 0 1px 0 rgba(255, 255, 255, 0.14),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.25),
+      0 1px 2px rgba(0, 0, 0, 0.12),
+      0 12px 28px -6px rgba(0, 0, 0, 0.38),
+      0 28px 56px -16px rgba(0, 0, 0, 0.32);
+  }
+  [data-theme="black"] .glass-note {
+    background:
+      linear-gradient(165deg, rgba(48, 48, 52, 0.65) 0%, rgba(22, 22, 26, 0.78) 50%, rgba(12, 12, 14, 0.88) 100%);
+    border-color: rgba(240, 236, 228, 0.14);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.1),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.4),
+      0 1px 2px rgba(0, 0, 0, 0.4),
+      0 16px 36px -8px rgba(0, 0, 0, 0.65),
+      0 32px 64px -20px rgba(0, 0, 0, 0.55);
+  }
+
+  /* Premium desktop plate inside the spatial demo */
+  .demo-desktop {
+    background-color: var(--demo-surface);
+    background-image:
+      radial-gradient(ellipse 90% 70% at 50% 18%, var(--demo-glow), transparent 62%),
+      radial-gradient(ellipse 120% 90% at 50% 100%, var(--demo-vignette), transparent 55%),
+      linear-gradient(180deg, var(--demo-surface-hi) 0%, var(--demo-surface-mid) 42%, var(--demo-surface) 100%);
+  }
+  .demo-desktop[data-grid='true'] {
+    background-image:
+      linear-gradient(var(--demo-grid-line) 1px, transparent 1px),
+      linear-gradient(90deg, var(--demo-grid-line) 1px, transparent 1px),
+      radial-gradient(ellipse 90% 70% at 50% 18%, var(--demo-glow), transparent 62%),
+      radial-gradient(ellipse 120% 90% at 50% 100%, var(--demo-vignette), transparent 55%),
+      linear-gradient(180deg, var(--demo-surface-hi) 0%, var(--demo-surface-mid) 42%, var(--demo-surface) 100%);
+    background-size:
+      40px 40px,
+      40px 40px,
+      100% 100%,
+      100% 100%,
+      100% 100%;
+  }
+  .demo-chrome {
+    background: var(--demo-chrome);
+    border-color: var(--demo-chrome-border);
   }
   .corner-frame {
     position: relative;
@@ -235,9 +312,6 @@
   60% { opacity: 1; filter: brightness(1.35); }
   100% { opacity: 1; transform: scale(1) translateY(0); filter: brightness(1); }
 }
-/* backwards (not both): pre-applies the 0% frame to avoid a spawn flash, but
-   does NOT hold opacity:1 afterward — otherwise the forwards fill overrides the
-   `opacity-0` used to blink notes out, and they'd stay visible. */
 .note-spawn { animation: noteSpawn 0.34s cubic-bezier(0.2, 0.9, 0.25, 1.15) backwards; }
 
 @keyframes noteVanish {
@@ -252,30 +326,13 @@
 }
 .pulse-dot { animation: pulseDot 2.4s ease-in-out infinite; }
 
-/* scanline sweep across demo surface */
-@keyframes scanSweep {
-  0% { top: -12%; opacity: 0; }
-  8% { opacity: 1; }
-  92% { opacity: 1; }
-  100% { top: 112%; opacity: 0; }
-}
-.scanline {
-  position: absolute;
-  left: 0; right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(var(--acc-rgb), 0.35), transparent);
-  animation: scanSweep 7s linear infinite;
-  pointer-events: none;
-}
-
-/* faint screen flicker for CRT feel — very subtle */
+/* faint screen flicker for black theme only */
 @keyframes crtFlicker {
   0%, 100% { opacity: 1; }
   97% { opacity: 1; }
   98% { opacity: 0.986; }
   99% { opacity: 0.995; }
 }
-.crt { animation: crtFlicker 6s steps(1) infinite; }
 
 /* staggered rise-in on load */
 @keyframes riseIn {
@@ -291,8 +348,6 @@
 /* scrollbars */
 ::-webkit-scrollbar { width: 10px; height: 10px; }
 ::-webkit-scrollbar-track { background: var(--bg); }
-::-webkit-scrollbar-thumb { background: #26262c; border: 2px solid var(--bg); border-radius: 6px; }
-::-webkit-scrollbar-thumb:hover { background: #36363e; }
 
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
@@ -302,3 +357,31 @@
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ambient light behind the hero — a quiet warm wash, theme-tinted */
+.hero-glow {
+  background:
+    radial-gradient(55% 60% at 72% 28%, rgba(var(--acc-rgb), 0.075), transparent 65%),
+    radial-gradient(42% 48% at 18% 18%, rgba(var(--acc-rgb), 0.045), transparent 70%);
+}
+[data-theme="paper"] .hero-glow { opacity: 0.55; }
+
+/* scroll reveal — armed on the client by <Reveal>, plays once */
+.reveal {
+  opacity: 0;
+  transform: translateY(18px);
+  transition:
+    opacity 0.8s cubic-bezier(0.2, 0.7, 0.2, 1),
+    transform 0.8s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.reveal.reveal-in {
+  opacity: 1;
+  transform: none;
+}
+
+/* sheet preview swap — a quick settle, not a slide */
+@keyframes sheetIn {
+  from { opacity: 0; transform: scale(0.985); }
+  to { opacity: 1; transform: none; }
+}
+.sheet-swap { animation: sheetIn 0.3s ease both; }

--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -35,11 +35,11 @@ export default function RootLayout({
     // React hydrates, so the server markup and client DOM intentionally differ.
     <html lang="en" className={jetBrainsMono.variable} suppressHydrationWarning>
       <body>
-        {/* Apply the saved/URL theme before paint — no flash of the default. */}
+        {/* Apply cream (default) or black before paint — no flash. */}
         <script
           dangerouslySetInnerHTML={{
             __html:
-              "try{var p=new URLSearchParams(location.search).get('theme');var t=p||localStorage.getItem('blink-theme');if(p){try{localStorage.setItem('blink-theme',p)}catch(e){}}if(t&&t!=='amber')document.documentElement.setAttribute('data-theme',t);else document.documentElement.removeAttribute('data-theme')}catch(e){}",
+              "try{var p=new URLSearchParams(location.search).get('theme');var t=p||localStorage.getItem('blink-theme');if(p){try{localStorage.setItem('blink-theme',p==='black'?'black':'cream')}catch(e){}}if(t==='black')document.documentElement.setAttribute('data-theme','black');else document.documentElement.removeAttribute('data-theme')}catch(e){}",
           }}
         />
         {children}

--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react"
 import type { Metadata } from "next"
 import { JetBrains_Mono } from "next/font/google"
+import { GoogleAnalytics } from "@/components/GoogleAnalytics"
 import "./globals.css"
 
 const jetBrainsMono = JetBrains_Mono({
@@ -43,6 +44,7 @@ export default function RootLayout({
           }}
         />
         {children}
+        <GoogleAnalytics />
       </body>
     </html>
   )

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -1,11 +1,10 @@
 "use client"
 
-import { TopBar, StatusBar } from "@/components/homepage/Chrome"
+import { TopBar } from "@/components/homepage/Chrome"
 import Hero from "@/components/homepage/Hero"
-import { SpecStrip, Architecture } from "@/components/homepage/Architecture"
+import { SpecStrip } from "@/components/homepage/Architecture"
 import Sheets from "@/components/homepage/Sheets"
 import FilesystemAPI from "@/components/homepage/FilesystemAPI"
-import { ConfigSection } from "@/components/homepage/Config"
 import Keys from "@/components/homepage/Keys"
 import { Install, Footer } from "@/components/homepage/Install"
 
@@ -16,15 +15,12 @@ export default function Home() {
       <main>
         <Hero />
         <SpecStrip />
-        <Architecture />
-        <Sheets />
         <FilesystemAPI />
-        <ConfigSection />
+        <Sheets />
         <Keys />
         <Install />
       </main>
       <Footer />
-      <StatusBar />
     </div>
   )
 }

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -5,6 +5,7 @@ import Hero from "@/components/homepage/Hero"
 import { SpecStrip } from "@/components/homepage/Architecture"
 import Sheets from "@/components/homepage/Sheets"
 import FilesystemAPI from "@/components/homepage/FilesystemAPI"
+import AgentCaseStudy from "@/components/homepage/AgentCaseStudy"
 import Keys from "@/components/homepage/Keys"
 import { Install, Footer } from "@/components/homepage/Install"
 
@@ -16,6 +17,7 @@ export default function Home() {
         <Hero />
         <SpecStrip />
         <FilesystemAPI />
+        <AgentCaseStudy />
         <Sheets />
         <Keys />
         <Install />

--- a/landing/components/GoogleAnalytics.tsx
+++ b/landing/components/GoogleAnalytics.tsx
@@ -1,0 +1,25 @@
+import Script from 'next/script'
+
+/** Shared arach.dev property — same tag as portfolio and sibling GH Pages sites. */
+const GA_MEASUREMENT_ID = 'G-GSHDZPFRZG'
+
+export function GoogleAnalytics() {
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}', {
+            page_path: window.location.pathname,
+          });
+        `}
+      </Script>
+    </>
+  )
+}

--- a/landing/components/homepage/AgentCaseStudy.tsx
+++ b/landing/components/homepage/AgentCaseStudy.tsx
@@ -1,0 +1,424 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { SectionHeader, Reveal } from './shared'
+
+/** Distilled priority note placed on the desk. */
+type DeskNote = {
+  id: string
+  stack: 'p0' | 'p1'
+  file: string
+  line: string
+  /** percent positions inside the desktop surface */
+  x: number
+  y: number
+  w: number
+}
+
+const NOTES: DeskNote[] = [
+  {
+    id: 'p0a',
+    stack: 'p0',
+    file: 'p0-landing.md',
+    line: 'Ship cream landing — default theme + cut man-page chrome',
+    x: 4,
+    y: 12,
+    w: 46,
+  },
+  {
+    id: 'p0b',
+    stack: 'p0',
+    file: 'p0-fling.md',
+    line: 'Fix fling-to-edge crash before the next release',
+    x: 7,
+    y: 42,
+    w: 44,
+  },
+  {
+    id: 'p0c',
+    stack: 'p0',
+    file: 'p0-save.md',
+    line: 'Flush pending saves on panel close / quit — never trust debounce',
+    x: 5,
+    y: 70,
+    w: 47,
+  },
+  {
+    id: 'p1a',
+    stack: 'p1',
+    file: 'p1-scout.md',
+    line: 'Scout broker reconnect on wake — dispatch recovery path',
+    x: 54,
+    y: 14,
+    w: 42,
+  },
+  {
+    id: 'p1b',
+    stack: 'p1',
+    file: 'p1-workspaces.md',
+    line: 'Workspace brands as generic treatments, not product skins',
+    x: 52,
+    y: 42,
+    w: 44,
+  },
+  {
+    id: 'p1c',
+    stack: 'p1',
+    file: 'p1-cli.md',
+    line: 'Document blink workspace + live reconcile for agents',
+    x: 56,
+    y: 68,
+    w: 40,
+  },
+]
+
+/**
+ * Script beats.
+ * - `tool` with `silent: true` still drives the desk, but stays out of the transcript
+ *   (writes are felt on the desktop, not as a wall of log lines).
+ * - Non-silent tools are a whisper under the prose.
+ */
+type Event =
+  | { kind: 'user'; text: string }
+  | { kind: 'text'; text: string }
+  | {
+      kind: 'tool'
+      name: string
+      detail: string
+      silent?: boolean
+      revealId?: string
+    }
+  | { kind: 'done'; text: string }
+
+const SCRIPT: Event[] = [
+  {
+    kind: 'user',
+    text: 'look at my last 24h and group my notes by top priorities — then lay them out on my desktop',
+  },
+  {
+    kind: 'text',
+    text: 'Scanning what you touched today, ranking into P0 / P1, then parking a one-liner per item on the desk.',
+  },
+  {
+    kind: 'tool',
+    name: 'bash',
+    detail: 'blink ls --since 24h',
+  },
+  {
+    kind: 'tool',
+    name: 'read',
+    detail: 'standup.md',
+  },
+  {
+    kind: 'tool',
+    name: 'bash',
+    detail: 'blink search --since 24h',
+  },
+  {
+    kind: 'text',
+    text: 'P0 is ship-or-break. P1 is this week. Placing summaries now.',
+  },
+  // writes: silent — the panels are the feedback
+  { kind: 'tool', name: 'write', detail: 'p0-landing.md', silent: true, revealId: 'p0a' },
+  { kind: 'tool', name: 'write', detail: 'p0-fling.md', silent: true, revealId: 'p0b' },
+  { kind: 'tool', name: 'write', detail: 'p0-save.md', silent: true, revealId: 'p0c' },
+  { kind: 'tool', name: 'write', detail: 'p1-scout.md', silent: true, revealId: 'p1a' },
+  { kind: 'tool', name: 'write', detail: 'p1-workspaces.md', silent: true, revealId: 'p1b' },
+  { kind: 'tool', name: 'write', detail: 'p1-cli.md', silent: true, revealId: 'p1c' },
+  {
+    kind: 'done',
+    text: 'Laid out 6 panels from the last 24h — P0 left, P1 right. Everything else stays in the folder.',
+  },
+]
+
+type LogItem =
+  | { kind: 'user'; text: string }
+  | { kind: 'text'; text: string }
+  | { kind: 'tool'; name: string; detail: string }
+  | { kind: 'done'; text: string }
+
+function UserBubble({ text }: { text: string }) {
+  return (
+    <div className="flex gap-2.5">
+      <span className="mt-[2px] shrink-0 text-[11px] text-acc" aria-hidden>
+        ❯
+      </span>
+      <p className="text-[12.5px] leading-[1.55] text-[var(--text)]">{text}</p>
+    </div>
+  )
+}
+
+function AssistantText({ text }: { text: string }) {
+  return <p className="text-[12.5px] leading-[1.65] text-dimx pl-[1.15rem]">{text}</p>
+}
+
+/** Secondary to prose — quieter, but still legible on cream. */
+function ToolWhisper({ name, detail }: { name: string; detail: string }) {
+  return (
+    <div className="pl-[1.15rem] text-[10.5px] leading-[1.5] text-dimx/80 truncate font-mono">
+      <span className="text-faintx">{name}</span>
+      <span className="mx-1.5 text-faintx">·</span>
+      <span>{detail}</span>
+    </div>
+  )
+}
+
+function DoneLine({ text }: { text: string }) {
+  return <p className="pl-[1.15rem] text-[12.5px] leading-[1.55] text-[var(--text)]">{text}</p>
+}
+
+function TicketPanel({ note, active }: { note: DeskNote; active: boolean }) {
+  return (
+    <div
+      className={[
+        'absolute rounded-[7px] glass-note overflow-hidden',
+        active ? 'desk-note-in' : 'opacity-0 pointer-events-none',
+      ].join(' ')}
+      style={{
+        left: `${note.x}%`,
+        top: `${note.y}%`,
+        width: `${note.w}%`,
+        maxWidth: 220,
+        zIndex: active ? 10 : 1,
+        transition: 'opacity 0.85s ease',
+      }}
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-[rgba(255,255,255,0.12)] px-2 py-1">
+        <span className="truncate text-[9px] font-medium text-[rgba(250,250,250,0.92)]">{note.file}</span>
+        <span className="shrink-0 text-[8px] uppercase tracking-[0.12em] text-[rgba(220,220,220,0.65)]">
+          {note.stack}
+        </span>
+      </div>
+      <div className="px-2 py-1.5">
+        <p className="text-[10px] leading-[1.45] text-[rgba(240,240,240,0.92)] line-clamp-2">{note.line}</p>
+      </div>
+    </div>
+  )
+}
+
+export default function AgentCaseStudy() {
+  const [log, setLog] = useState<LogItem[]>([])
+  const [visible, setVisible] = useState<Set<string>>(() => new Set())
+  const [status, setStatus] = useState<'idle' | 'working' | 'done'>('idle')
+  /** One rolling whisper while silent writes land panels. */
+  const [placing, setPlacing] = useState<string | null>(null)
+  const logBoxRef = useRef<HTMLDivElement>(null)
+  const cancelledRef = useRef(false)
+
+  useEffect(() => {
+    cancelledRef.current = false
+    const timeouts: number[] = []
+    const reduced =
+      typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const wait = (ms: number) =>
+      new Promise<void>((res) => {
+        // Keep reduced-motion short, but never frantic in the normal path
+        const id = window.setTimeout(res, reduced ? Math.min(ms, 40) : ms)
+        timeouts.push(id)
+      })
+
+    const run = async () => {
+      while (!cancelledRef.current) {
+        setLog([])
+        setVisible(new Set())
+        setStatus('idle')
+        setPlacing(null)
+        await wait(1200)
+
+        for (const step of SCRIPT) {
+          if (cancelledRef.current) return
+
+          if (step.kind === 'user') {
+            setLog((prev) => [...prev, step])
+            setStatus('working')
+            await wait(1400)
+            continue
+          }
+
+          if (step.kind === 'text') {
+            setLog((prev) => [...prev, step])
+            await wait(1600)
+            continue
+          }
+
+          if (step.kind === 'tool') {
+            if (!step.silent) {
+              setLog((prev) => [...prev, { kind: 'tool', name: step.name, detail: step.detail }])
+              await wait(reduced ? 50 : 700)
+            } else {
+              // silent write: one rolling line, desk gets the panel — unhurried
+              setPlacing(step.detail)
+              await wait(reduced ? 40 : 720)
+            }
+
+            if (cancelledRef.current) return
+
+            if (step.revealId) {
+              setVisible((prev) => {
+                const next = new Set(prev)
+                next.add(step.revealId!)
+                return next
+              })
+              await wait(reduced ? 30 : 480)
+            }
+            continue
+          }
+
+          if (step.kind === 'done') {
+            setPlacing(null)
+            setLog((prev) => [...prev, step])
+            setStatus('done')
+            // Rest on the finished board — no rush to loop
+            await wait(reduced ? 2400 : 11000)
+            // Soft clear: fade panels first, then restart
+            setVisible(new Set())
+            await wait(reduced ? 200 : 900)
+          }
+        }
+      }
+    }
+
+    run()
+    return () => {
+      cancelledRef.current = true
+      timeouts.forEach((t) => clearTimeout(t))
+    }
+  }, [])
+
+  // Gentle stick-to-bottom — no smooth-scroll chase
+  useEffect(() => {
+    const box = logBoxRef.current
+    if (!box) return
+    box.scrollTop = box.scrollHeight
+  }, [log, placing])
+
+  const p0Count = NOTES.filter((n) => n.stack === 'p0' && visible.has(n.id)).length
+  const p1Count = NOTES.filter((n) => n.stack === 'p1' && visible.has(n.id)).length
+
+  return (
+    <section id="desk" className="scroll-mt-16 py-20 md:py-28 border-t border-linex">
+      <div className="mx-auto max-w-5xl px-4 md:px-6">
+        <SectionHeader
+          tag="CASE STUDY"
+          title={
+            <>
+              Last 24 hours, <span className="text-acc">laid out by priority.</span>
+            </>
+          }
+          sub={
+            <>
+              Ask your coding agent to read what you touched, group it into top priorities, and
+              park a one-liner per item on the desktop. The rest stays in the folder — only what
+              matters is in view.
+            </>
+          }
+        />
+
+        <Reveal className="grid gap-5 lg:grid-cols-[0.95fr_1.15fr] items-start">
+          {/* coding-agent transcript — conversation leads; tools whisper */}
+          <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden flex flex-col h-[380px] sm:h-[420px]">
+            <div className="flex shrink-0 items-center justify-between border-b border-linex bg-panel2x px-3.5 py-2">
+              <div className="flex min-w-0 items-center gap-2">
+                <span className="text-[11px] font-semibold text-[var(--text)]">claude</span>
+                <span className="text-[10px] text-dimx truncate">~/Notes · last 24h</span>
+              </div>
+              <div className="flex shrink-0 items-center gap-2 text-[10px]">
+                {status === 'working' && <span className="text-dimx">working</span>}
+                {status === 'done' && <span className="text-acc font-medium">done</span>}
+                {status === 'idle' && <span className="text-dimx">ready</span>}
+              </div>
+            </div>
+
+            <div
+              ref={logBoxRef}
+              className="flex-1 min-h-0 px-3.5 py-3.5 space-y-3.5 overflow-y-auto"
+              aria-live="polite"
+              aria-atomic="false"
+            >
+              {log.map((item, i) => {
+                if (item.kind === 'user') return <UserBubble key={i} text={item.text} />
+                if (item.kind === 'text') return <AssistantText key={i} text={item.text} />
+                if (item.kind === 'tool')
+                  return <ToolWhisper key={i} name={item.name} detail={item.detail} />
+                return <DoneLine key={i} text={item.text} />
+              })}
+
+              {/* rolling whisper while silent writes land — never a list of six writes */}
+              {placing && (
+                <div className="pl-[1.15rem] text-[10.5px] leading-[1.5] text-dimx/80 truncate font-mono">
+                  <span className="text-faintx">write</span>
+                  <span className="mx-1.5 text-faintx">·</span>
+                  <span>{placing}</span>
+                </div>
+              )}
+            </div>
+
+            <div className="shrink-0 flex items-center justify-between border-t border-linex px-3.5 py-2 text-[10px] text-dimx">
+              <span>{status === 'done' ? 'desk ready' : status === 'working' ? 'ranking…' : 'ready'}</span>
+              <span className="hidden sm:inline text-faintx">panels update live</span>
+            </div>
+          </div>
+
+          {/* desktop with priority stacks */}
+          <div className="corner-frame flex flex-col h-[380px] sm:h-[420px]">
+            <div className="demo-chrome flex shrink-0 items-center justify-between gap-2 border border-b-0 rounded-t-[8px] px-3 min-h-10 py-1.5">
+              <div className="flex min-w-0 items-center gap-2 text-[11px]">
+                <span className="text-[var(--text)] font-semibold truncate">~/Desktop</span>
+                <span className="hidden sm:inline shrink-0 text-dimx">— prioritized board</span>
+              </div>
+              <div className="flex shrink-0 items-center gap-2 text-[10px] text-dimx">
+                <span>
+                  p0 <span className="text-acc font-semibold tabular-nums">{p0Count}</span>
+                </span>
+                <span className="text-faintx">·</span>
+                <span>
+                  p1 <span className="text-acc font-semibold tabular-nums">{p1Count}</span>
+                </span>
+              </div>
+            </div>
+
+            <div
+              className="demo-desktop relative flex-1 min-h-0 overflow-hidden rounded-b-[8px] border border-linex"
+              role="img"
+              aria-label="Desktop with priority notes laid out by the agent"
+            >
+              <div
+                className="pointer-events-none absolute inset-y-4 left-3 w-[48%] rounded-[10px] border border-dashed border-[rgba(var(--line-rgb),0.75)] bg-[rgba(var(--bg-rgb),0.18)]"
+                aria-hidden
+              />
+              <div
+                className="pointer-events-none absolute inset-y-4 right-3 w-[44%] rounded-[10px] border border-dashed border-[rgba(var(--line-rgb),0.75)] bg-[rgba(var(--bg-rgb),0.14)]"
+                aria-hidden
+              />
+              <div className="pointer-events-none absolute top-3 left-5 text-[9px] tracking-[0.14em] uppercase font-semibold text-dimx">
+                p0 · today
+              </div>
+              <div className="pointer-events-none absolute top-3 right-[calc(3%+0.5rem)] text-[9px] tracking-[0.14em] uppercase font-semibold text-dimx">
+                p1 · this week
+              </div>
+
+              {NOTES.map((note) => (
+                <TicketPanel key={note.id} note={note} active={visible.has(note.id)} />
+              ))}
+
+              {visible.size === 0 && (
+                <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                  <p className="text-[12px] text-dimx text-center max-w-[15rem] leading-relaxed">
+                    agent is ranking the last 24h…
+                  </p>
+                </div>
+              )}
+
+              <div className="absolute bottom-2 left-3 right-3 flex justify-between text-[10px] text-dimx pointer-events-none">
+                <span>
+                  panels: {visible.size}/{NOTES.length}
+                </span>
+                <span className="hidden sm:inline">summaries only · rest stays filed</span>
+              </div>
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  )
+}

--- a/landing/components/homepage/Architecture.tsx
+++ b/landing/components/homepage/Architecture.tsx
@@ -1,191 +1,34 @@
-import { SectionHeader } from './shared'
-
-/* ------------------------------- spec strip ------------------------------- */
+/* Spec strip only — architecture deep-dive removed from the landing distill. */
 
 const SPECS = [
   { k: 'hotkeys', v: 'carbon', d: 'global chords, no accessibility grant' },
   { k: 'runtime', v: 'native', d: 'Swift + AppKit, zero Electron' },
-  { k: 'format', v: '.md', d: 'yaml frontmatter, utf-8' },
-  { k: 'identity', v: 'uuidv5', d: 'deterministic identity from slug' },
-  { k: 'sync', v: 'live', d: 'external edits reconcile in place' },
-  { k: 'cloud', v: 'none', d: 'no account, notes stay local' },
+  { k: 'format', v: '.md', d: 'yaml frontmatter, files you own' },
+  { k: 'cloud', v: 'none', d: 'no account — notes stay local' },
 ]
 
 export function SpecStrip() {
   return (
-    <section className="border-y border-linex bg-[rgba(var(--bg-rgb),0.6)]">
-      <div className="mx-auto max-w-6xl px-4 md:px-6">
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6">
+    <section className="border-y border-linex bg-[rgba(var(--bg-rgb),0.6)]" aria-label="Technical highlights">
+      <div className="mx-auto max-w-5xl px-4 md:px-6">
+        <div className="grid grid-cols-2 lg:grid-cols-4">
           {SPECS.map((s, i) => (
             <div
               key={s.k}
-              className={`px-4 py-5 ${i !== 0 ? 'border-l border-[rgba(var(--line-rgb),0.7)]' : ''} ${
-                i >= 2 ? 'max-lg:border-t max-lg:border-[rgba(var(--line-rgb),0.7)]' : ''
-              } ${i === 2 || i === 4 ? 'max-lg:border-l-0' : ''} ${i === 3 ? 'max-lg:border-l' : ''}`}
+              className={[
+                'px-4 py-6 first:pl-0 lg:last:pr-0',
+                i % 2 === 1 ? 'border-l border-[rgba(var(--line-rgb),0.7)]' : '',
+                i >= 2 ? 'border-t border-[rgba(var(--line-rgb),0.7)] lg:border-t-0' : '',
+                i >= 1 ? 'lg:border-l lg:border-[rgba(var(--line-rgb),0.7)]' : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
             >
-              <div className="text-[9px] tracking-[0.16em] text-faintx uppercase">{s.k}</div>
-              <div className="mt-1.5 text-[17px] font-bold text-acc">{s.v}</div>
-              <div className="mt-1 text-[10px] leading-snug text-dimx">{s.d}</div>
+              <div className="text-[9px] tracking-[0.18em] text-faintx uppercase">{s.k}</div>
+              <div className="mt-2 text-[19px] font-bold tracking-[-0.01em] text-acc">{s.v}</div>
+              <div className="mt-1 text-[10.5px] leading-[1.55] text-dimx">{s.d}</div>
             </div>
           ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* ----------------------------- architecture ------------------------------- */
-
-const LAYERS = [
-  {
-    layer: 'window',
-    tech: 'NSPanel + NSVisualEffectView',
-    note: 'borderless, non-activating HUD glass; floats above workspaces without stealing focus',
-  },
-  {
-    layer: 'hotkeys',
-    tech: 'Carbon RegisterEventHotKey',
-    note: 'three chords reachable from any app; hyper = ⌃⌥⇧⌘, every binding rewritable',
-  },
-  {
-    layer: 'editor',
-    tech: 'CodeMirror 6 — no react',
-    note: 'a lean web view inside the native shell; flip read ⇄ edit in place, scroll preserved',
-  },
-  {
-    layer: 'render',
-    tech: 'marked (GFM)',
-    note: 'github-flavored markdown, tables and [[wiki-links]] included',
-  },
-  {
-    layer: 'storage',
-    tech: 'frontmatter md · atomic writes',
-    note: 'write tmp → rename; a note is never half-written, saved before create() returns',
-  },
-  {
-    layer: 'watch',
-    tech: 'directory watch + reconcile',
-    note: 'directory watcher merges outside edits live — they type themselves in, caret included',
-  },
-]
-
-function Diagram() {
-  const box = (x: number, y: number, w: number, h: number) => ({ x, y, w, h })
-  const boxes = {
-    hotkey: box(20, 18, 200, 44),
-    panel: box(150, 96, 260, 54),
-    webview: box(150, 182, 260, 54),
-    store: box(150, 268, 260, 62),
-    cli: box(20, 268, 110, 62),
-  }
-  const stroke = '#2c2c32'
-  const acc = '#f0b45a'
-  const dim = '#8e8e96'
-  const faint = '#5a5a62'
-
-  const Rect = ({ b, title, sub, accent = false }: { b: { x: number; y: number; w: number; h: number }; title: string; sub: string; accent?: boolean }) => (
-    <g>
-      <rect x={b.x} y={b.y} width={b.w} height={b.h} rx={6} fill="#0f0f11" stroke={accent ? 'rgba(var(--acc-rgb),0.55)' : stroke} strokeWidth={1} />
-      <text x={b.x + 12} y={b.y + 21} fill={accent ? acc : '#d8d8dc'} fontSize={11} fontWeight={700} fontFamily="JetBrains Mono, monospace">
-        {title}
-      </text>
-      <text x={b.x + 12} y={b.y + 38} fill={dim} fontSize={9} fontFamily="JetBrains Mono, monospace">
-        {sub}
-      </text>
-    </g>
-  )
-
-  const Arrow = ({ x1, y1, x2, y2, label, dashed = false }: { x1: number; y1: number; x2: number; y2: number; label?: string; dashed?: boolean }) => (
-    <g>
-      <line x1={x1} y1={y1} x2={x2} y2={y2} stroke={acc} strokeOpacity={0.5} strokeWidth={1} strokeDasharray={dashed ? '3 3' : undefined} markerEnd="url(#arr)" />
-      {label && (
-        <text x={(x1 + x2) / 2 + 8} y={(y1 + y2) / 2 + 3} fill={faint} fontSize={8.5} fontFamily="JetBrains Mono, monospace">
-          {label}
-        </text>
-      )}
-    </g>
-  )
-
-  return (
-    <svg viewBox="0 0 470 356" className="w-full h-auto">
-      <defs>
-        <marker id="arr" markerWidth="7" markerHeight="7" refX="5.5" refY="3" orient="auto">
-          <path d="M0,0 L6,3 L0,6 Z" fill={acc} fillOpacity={0.7} />
-        </marker>
-      </defs>
-
-      <Rect b={boxes.hotkey} title="⌃⌥⇧⌘ — global chords" sub="from any application" />
-      <Rect b={boxes.panel} title="NSPanel · AppKit shell" sub="borderless glass · menubar resident" accent />
-      <Rect b={boxes.webview} title="WKWebView → CodeMirror 6" sub="edit ⇄ marked (GFM) render" />
-      <Rect b={boxes.store} title="~/…/Blink/Notes/*.md" sub="frontmatter · atomic write → rename" accent />
-      <Rect b={boxes.cli} title="blink CLI" sub="agents · scripts" />
-
-      <Arrow x1={220} y1={62} x2={260} y2={94} label="spawn panel" />
-      <Arrow x1={280} y1={150} x2={280} y2={180} label="native bridge" />
-      <Arrow x1={280} y1={236} x2={280} y2={266} />
-      <Arrow x1={150} y1={299} x2={132} y2={299} label="" />
-      <Arrow x1={75} y1={266} x2={150} y2={250} label="" dashed />
-      <text x={26} y={252} fill={faint} fontSize={8.5} fontFamily="JetBrains Mono, monospace">
-        read / write
-      </text>
-      <text x={272} y={254} fill={faint} fontSize={8.5} fontFamily="JetBrains Mono, monospace" textAnchor="end">
-        atomic write
-      </text>
-      <text x={290} y={254} fill={faint} fontSize={8.5} fontFamily="JetBrains Mono, monospace">
-        ↑ fs events reconcile
-      </text>
-    </svg>
-  )
-}
-
-export function Architecture() {
-  return (
-    <section id="architecture" className="py-20 md:py-28">
-      <div className="mx-auto max-w-6xl px-4 md:px-6">
-        <SectionHeader
-          index="01"
-          tag="ARCHITECTURE"
-          title={
-            <>
-              Native bones, <span className="text-acc">web typography</span>.
-            </>
-          }
-          sub="No Electron shell around a web app — an AppKit panel hosting exactly one web view, writing exactly one file format. Every layer is replaceable because the filesystem is the contract."
-        />
-
-        <div className="grid gap-10 lg:grid-cols-[1.15fr_1fr] lg:gap-14 items-start">
-          {/* layer table */}
-          <div className="border border-linex rounded-[8px] overflow-hidden bg-panelx">
-            <div className="grid grid-cols-[86px_1fr] gap-0 border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] tracking-[0.14em] text-faintx uppercase">
-              <span>layer</span>
-              <span>implementation</span>
-            </div>
-            {LAYERS.map((l) => (
-              <div
-                key={l.layer}
-                className="group grid grid-cols-[86px_1fr] gap-0 border-b border-[rgba(var(--line-rgb),0.55)] last:border-b-0 px-4 py-3.5 transition-colors hover:bg-[rgba(var(--acc-rgb),0.03)]"
-              >
-                <span className="text-[11px] font-bold text-acc pt-[1px]">{l.layer}</span>
-                <div>
-                  <div className="text-[12.5px] font-semibold text-[var(--text)]">{l.tech}</div>
-                  <div className="mt-1 text-[11px] leading-[1.65] text-dimx">{l.note}</div>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {/* diagram */}
-          <div className="border border-linex rounded-[8px] bg-panelx p-4 md:p-5">
-            <div className="mb-3 flex items-center justify-between text-[10px] text-faintx">
-              <span className="tracking-[0.14em] uppercase">fig. 2 — data flow</span>
-              <span className="text-acc">swift · appkit</span>
-            </div>
-            <Diagram />
-            <p className="mt-3 text-[11px] leading-[1.7] text-faintx">
-              One process, one folder. The CLI and any agent tooling hit the same markdown store the
-              panels render — directory changes flow back through the same reconciliation path.
-            </p>
-          </div>
         </div>
       </div>
     </section>

--- a/landing/components/homepage/Chrome.tsx
+++ b/landing/components/homepage/Chrome.tsx
@@ -3,6 +3,7 @@ import { BlinkMark } from './BlinkMark'
 
 const LINKS = [
   { href: '#how', label: 'how' },
+  { href: '#desk', label: 'desk' },
   { href: '#keys', label: 'keys' },
   { href: '#install', label: 'install' },
 ]

--- a/landing/components/homepage/Chrome.tsx
+++ b/landing/components/homepage/Chrome.tsx
@@ -1,49 +1,28 @@
-import { useEffect, useState } from 'react'
 import { ThemeSwitcher } from './ThemeSwitcher'
 import { BlinkMark } from './BlinkMark'
 
 const LINKS = [
-  { href: '#architecture', label: 'arch' },
-  { href: '#sheets', label: 'sheets' },
-  { href: '#api', label: 'fs-api' },
-  { href: '#config', label: 'config' },
+  { href: '#how', label: 'how' },
   { href: '#keys', label: 'keys' },
   { href: '#install', label: 'install' },
 ]
 
 export function TopBar() {
-  const [time, setTime] = useState('')
-  useEffect(() => {
-    const tick = () => {
-      const d = new Date()
-      setTime(
-        `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(
-          d.getSeconds(),
-        ).padStart(2, '0')}`,
-      )
-    }
-    tick()
-    const t = setInterval(tick, 1000)
-    return () => clearInterval(t)
-  }, [])
-
   return (
     <header className="fixed top-0 inset-x-0 z-50 border-b border-linex bg-[rgba(var(--bg-rgb),0.82)] backdrop-blur-md">
-      <div className="mx-auto flex h-12 max-w-6xl items-center justify-between px-4 md:px-6">
+      <div className="mx-auto flex h-12 max-w-5xl items-center justify-between px-4 md:px-6">
         <a href="#top" className="flex items-center gap-2.5 text-[13px] font-bold text-[var(--text)]">
           <BlinkMark className="h-[18px] w-[18px] text-acc" />
           blink
-          <span className="hidden md:inline text-[11px] font-normal text-faintx">v2 · menubar resident</span>
         </a>
 
-        <nav className="hidden lg:flex items-center gap-5">
-          {LINKS.map((l, i) => (
+        <nav className="hidden sm:flex items-center gap-5" aria-label="Page">
+          {LINKS.map((l) => (
             <a
               key={l.href}
               href={l.href}
               className="text-[11px] text-dimx hover:text-acc transition-colors"
             >
-              <span className="text-faintx">{String(i + 1).padStart(2, '0')}:</span>
               {l.label}
             </a>
           ))}
@@ -51,70 +30,19 @@ export function TopBar() {
 
         <div className="flex items-center gap-3">
           <ThemeSwitcher />
-          <span className="hidden md:inline h-3.5 w-px bg-linex" />
-          <span className="hidden md:inline text-[11px] text-faintx tabular-nums">{time}</span>
           <a
             href="https://github.com/arach/blink"
             target="_blank"
             rel="noreferrer"
-            className="inline-flex h-8 items-center gap-1.5 rounded-[5px] border border-line2x bg-panelx px-3 text-[11px] text-dimx hover:text-[var(--text)] hover:border-[#3f3f48] transition-colors"
+            className="inline-flex h-8 items-center gap-1.5 rounded-[5px] border border-line2x bg-panelx px-3 text-[11px] text-dimx hover:text-[var(--text)] hover:border-[var(--line-2)] hover:bg-panel2x transition-colors"
           >
             <svg viewBox="0 0 16 16" className="h-3.5 w-3.5 fill-current" aria-hidden>
               <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
             </svg>
-            arach/blink
+            github
           </a>
         </div>
       </div>
     </header>
-  )
-}
-
-export function StatusBar() {
-  const [pos, setPos] = useState({ x: 0, y: 0 })
-  const [prog, setProg] = useState(0)
-
-  useEffect(() => {
-    const onMove = (e: MouseEvent) => setPos({ x: e.clientX, y: e.clientY })
-    const onScroll = () => {
-      const h = document.documentElement
-      const max = h.scrollHeight - h.clientHeight
-      setProg(max > 0 ? Math.round((h.scrollTop / max) * 100) : 0)
-    }
-    window.addEventListener('mousemove', onMove, { passive: true })
-    window.addEventListener('scroll', onScroll, { passive: true })
-    onScroll()
-    return () => {
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('scroll', onScroll)
-    }
-  }, [])
-
-  return (
-    <div className="fixed bottom-0 inset-x-0 z-50 border-t border-linex bg-[rgba(var(--bg-rgb),0.9)] backdrop-blur-md">
-      <div className="mx-auto flex h-8 max-w-6xl items-center justify-between px-4 md:px-6 text-[10px] text-faintx tabular-nums">
-        <div className="flex items-center gap-3">
-          <span className="flex items-center gap-1.5">
-            <span className="inline-block h-[6px] w-[6px] rounded-full bg-[var(--acc)]" />
-            <span className="text-dimx font-semibold">blink(1)</span>
-          </span>
-          <span className="hidden sm:inline">native · swift + appkit · no electron</span>
-        </div>
-        <div className="hidden md:flex items-center gap-4">
-          <span>
-            x:<span className="text-acc">{String(pos.x).padStart(4, '0')}</span> y:
-            <span className="text-acc">{String(pos.y).padStart(4, '0')}</span>
-          </span>
-          <span>markdown · utf-8 · lf</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="hidden sm:inline">scroll</span>
-          <span className="text-dimx">{String(prog).padStart(3, '0')}%</span>
-          <span className="relative h-[3px] w-16 overflow-hidden rounded-full bg-[var(--line)]">
-            <span className="absolute inset-y-0 left-0 bg-[var(--acc)]" style={{ width: `${prog}%` }} />
-          </span>
-        </div>
-      </div>
-    </div>
   )
 }

--- a/landing/components/homepage/Config.tsx
+++ b/landing/components/homepage/Config.tsx
@@ -40,7 +40,6 @@ export function ConfigSection() {
     <section id="config" className="py-20 md:py-28 border-t border-linex">
       <div className="mx-auto max-w-6xl px-4 md:px-6">
         <SectionHeader
-          index="04"
           tag="CONFIGURATION"
           title={
             <>

--- a/landing/components/homepage/FilesystemAPI.tsx
+++ b/landing/components/homepage/FilesystemAPI.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { SectionHeader, Chip } from './shared'
+import { SectionHeader, Chip, Reveal } from './shared'
 
 interface TermLine {
   kind: 'cmd' | 'out' | 'json'
@@ -18,12 +18,18 @@ export default function FilesystemAPI() {
   useEffect(() => {
     cancelledRef.current = false
     const timeouts: number[] = []
+    const reduced =
+      typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
     const wait = (ms: number) =>
       new Promise<void>((res) => {
-        const id = window.setTimeout(res, ms)
+        const id = window.setTimeout(res, reduced ? Math.min(ms, 80) : ms)
         timeouts.push(id)
       })
     const typeInto = async (text: string, set: (s: string) => void, cps = 34) => {
+      if (reduced) {
+        set(text)
+        return
+      }
       for (let i = 1; i <= text.length; i++) {
         if (cancelledRef.current) return
         set(text.slice(0, i))
@@ -42,7 +48,6 @@ export default function FilesystemAPI() {
         setNoteCaret(false)
         await wait(900)
 
-        /* 1 — create */
         await typeInto('blink new "# Standup"', setCmd)
         if (cancelledRef.current) return
         await wait(240)
@@ -53,7 +58,6 @@ export default function FilesystemAPI() {
         setNote(['# Standup'])
         await wait(900)
 
-        /* 2 — append via agent, note types it in */
         await typeInto('blink append standup "shipped the landing ✓"', setCmd)
         if (cancelledRef.current) return
         await wait(240)
@@ -70,7 +74,6 @@ export default function FilesystemAPI() {
         setNoteCaret(false)
         await wait(1000)
 
-        /* 3 — search json */
         await typeInto('blink search "roadmap" --json', setCmd)
         if (cancelledRef.current) return
         await wait(240)
@@ -78,7 +81,7 @@ export default function FilesystemAPI() {
         setCmd('')
         await wait(150)
         push({ kind: 'json', text: '[{ "id": "roadmap", "title": "Roadmap" }]' })
-        await wait(4200)
+        await wait(reduced ? 2400 : 4200)
       }
     }
     run()
@@ -89,29 +92,31 @@ export default function FilesystemAPI() {
   }, [])
 
   return (
-    <section id="api" className="py-20 md:py-28 border-t border-linex">
-      <div className="mx-auto max-w-6xl px-4 md:px-6">
+    <section id="how" className="scroll-mt-16 py-20 md:py-28 border-t border-linex">
+      <div className="mx-auto max-w-5xl px-4 md:px-6">
         <SectionHeader
-          index="03"
           tag="AGENT-FIRST"
           title={
             <>
               The filesystem <span className="text-acc">is the API</span>.
             </>
           }
-          sub="Built to be driven by more than a keyboard. A CLI, a hot-reloading config file, and live reconciliation mean your agents read and write the same notes you do — no plugins, no integrations."
+          sub="Notes are markdown files in a folder you own. Agents and the CLI write the same files the panels render — live, no plugins."
         />
 
-        <div className="grid gap-6 lg:grid-cols-2 items-stretch">
-          {/* terminal */}
+        <Reveal className="grid gap-5 lg:grid-cols-2 items-stretch">
           <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden flex flex-col">
             <div className="flex items-center gap-2 border-b border-linex bg-panel2x px-4 py-2.5">
-              <span className="h-[9px] w-[9px] rounded-full bg-[#ff5f57]" />
-              <span className="h-[9px] w-[9px] rounded-full bg-[#febc2e]" />
-              <span className="h-[9px] w-[9px] rounded-full bg-[#28c840]" />
-              <span className="ml-2 text-[11px] text-faintx">blink — the notes CLI</span>
+              <span className="h-[9px] w-[9px] rounded-full bg-[var(--ghost)]" />
+              <span className="h-[9px] w-[9px] rounded-full bg-[var(--faint)]" />
+              <span className="h-[9px] w-[9px] rounded-full bg-[var(--dim)]" />
+              <span className="ml-2 text-[11px] text-faintx">blink CLI</span>
             </div>
-            <div className="flex-1 p-4 md:p-5 text-[12px] md:text-[12.5px] leading-[1.9] min-h-[240px]">
+            <div
+              className="flex-1 p-4 md:p-5 text-[12px] md:text-[12.5px] leading-[1.9] min-h-[200px]"
+              aria-live="polite"
+              aria-atomic="false"
+            >
               {term.map((l, i) => (
                 <div key={i} className="whitespace-pre-wrap break-all">
                   {l.kind === 'cmd' && (
@@ -121,44 +126,37 @@ export default function FilesystemAPI() {
                     </span>
                   )}
                   {l.kind === 'out' && <span className="text-dimx">  {l.text}</span>}
-                  {l.kind === 'json' && <span className="text-cyanx">  {l.text}</span>}
+                  {l.kind === 'json' && <span className="text-[var(--syn-key)]">  {l.text}</span>}
                 </div>
               ))}
               <div>
                 <span className="text-acc font-bold">❯ </span>
                 <span className="text-[var(--text)]">{cmd}</span>
-                <span className="caret-blink text-acc">▊</span>
+                <span className="caret-blink text-acc" aria-hidden>
+                  ▊
+                </span>
               </div>
-            </div>
-            <div className="border-t border-linex px-4 py-2 text-[10px] text-faintx flex justify-between">
-              <span>zsh · replay loop</span>
-              <span>stdin: tty · stdout: piped</span>
             </div>
           </div>
 
-          {/* reconciling note */}
           <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden flex flex-col">
             <div className="flex items-center justify-between border-b border-linex bg-panel2x px-4 py-2.5">
               <span className="text-[11px] text-dimx">standup.md</span>
-              <span
-                className={`transition-opacity duration-300 ${badge ? 'opacity-100' : 'opacity-0'}`}
-              >
+              <span className={`transition-opacity duration-300 ${badge ? 'opacity-100' : 'opacity-0'}`}>
                 <Chip tone="acc">
                   <span className="inline-block h-[5px] w-[5px] rounded-full bg-[var(--acc)]" />
-                  typed by claude
+                  typed by agent
                 </Chip>
               </span>
             </div>
-            <div className="flex-1 p-4 md:p-5 min-h-[240px]">
+            <div className="flex-1 p-4 md:p-5 min-h-[200px]">
               {note.map((l, i) => (
                 <div
                   key={i}
                   className={`leading-[1.9] ${
                     l.startsWith('# ')
                       ? 'text-[15px] font-bold text-[var(--text)]'
-                      : l.startsWith('##')
-                        ? 'text-[12px] font-semibold text-dimx mt-1'
-                        : 'text-[12.5px] text-dimx'
+                      : 'text-[12.5px] text-dimx'
                   }`}
                 >
                   {l.startsWith('# ') ? l.slice(2) : l}
@@ -171,29 +169,14 @@ export default function FilesystemAPI() {
                 </div>
               )}
               {note.length === 0 && !noteTyping && (
-                <div className="text-[11px] text-faintx italic">— waiting for filesystem events…</div>
+                <div className="text-[11px] text-faintx italic">waiting for filesystem events…</div>
               )}
             </div>
             <div className="border-t border-linex px-4 py-2.5 text-[10px] leading-[1.6] text-faintx">
-              External edits don't just appear — they{' '}
-              <span className="text-dimx">type themselves in</span>, with a caret and a soft tick, so
-              you notice without a notification stealing focus.
+              Outside edits type themselves in — caret and all — so you notice without a notification.
             </div>
           </div>
-        </div>
-
-        <div className="mt-6 grid gap-4 sm:grid-cols-3">
-          {[
-            { k: 'blink new|append|search', v: 'scriptable CRUD over the notes folder' },
-            { k: '--json on everything', v: 'pipe into jq, fzf, or an agent loop' },
-            { k: 'exit codes, no daemon', v: 'the CLI talks to files, not a server' },
-          ].map((c) => (
-            <div key={c.k} className="border border-linex rounded-[7px] bg-panelx px-4 py-3.5">
-              <div className="text-[11.5px] font-bold text-acc">{c.k}</div>
-              <div className="mt-1 text-[11px] leading-[1.6] text-dimx">{c.v}</div>
-            </div>
-          ))}
-        </div>
+        </Reveal>
       </div>
     </section>
   )

--- a/landing/components/homepage/Hero.tsx
+++ b/landing/components/homepage/Hero.tsx
@@ -6,14 +6,8 @@ export default function Hero() {
     <section id="top" className="relative overflow-hidden pt-32 md:pt-36 pb-16 md:pb-24">
       <div className="hero-glow pointer-events-none absolute inset-0" aria-hidden />
       <div className="relative mx-auto max-w-5xl px-4 md:px-6">
-        <div className="rise-in rise-1 flex items-center justify-between border-y border-linex py-2 text-[10px] md:text-[11px] tracking-[0.08em] text-faintx">
-          <span className="text-dimx font-semibold">BLINK(1)</span>
-          <span className="hidden sm:inline">spatial notes · macOS</span>
-          <span className="text-dimx font-semibold">BLINK(1)</span>
-        </div>
-
-        <div className="mt-10 md:mt-12 grid gap-10 lg:grid-cols-[1fr_1.05fr] lg:gap-12 items-start">
-          <div className="rise-in rise-2">
+        <div className="grid gap-10 lg:grid-cols-[1fr_1.05fr] lg:gap-12 items-start">
+          <div className="rise-in rise-1">
             <h1 className="text-balance">
               <span className="block text-[40px] md:text-[48px] font-bold tracking-[-0.03em] leading-[1.05] text-[var(--text)]">
                 blink
@@ -58,7 +52,7 @@ export default function Hero() {
             </p>
           </div>
 
-          <div className="rise-in rise-3">
+          <div className="rise-in rise-2">
             <SpatialDemo />
             <p className="mt-3 text-[11px] leading-relaxed text-faintx">
               Panels remember position and size · native NSPanel glass

--- a/landing/components/homepage/Hero.tsx
+++ b/landing/components/homepage/Hero.tsx
@@ -1,101 +1,67 @@
 import SpatialDemo from './SpatialDemo'
 import { Chord, PrimaryButton, GhostButton } from './shared'
 
-function ManRow({ term, children }: { term: string; children: React.ReactNode }) {
-  return (
-    <div className="grid grid-cols-[110px_1fr] md:grid-cols-[150px_1fr] gap-3 md:gap-6 py-4 border-b border-[rgba(var(--line-rgb),0.6)] last:border-b-0">
-      <div className="text-[11px] font-bold tracking-[0.14em] text-acc pt-[2px]">{term}</div>
-      <div className="text-[13px] md:text-[14px] leading-[1.8] text-dimx">{children}</div>
-    </div>
-  )
-}
-
 export default function Hero() {
   return (
-    <section id="top" className="relative pt-28 md:pt-36 pb-16 md:pb-24">
-      <div className="mx-auto max-w-6xl px-4 md:px-6">
-        {/* man page header rule */}
+    <section id="top" className="relative overflow-hidden pt-32 md:pt-36 pb-16 md:pb-24">
+      <div className="hero-glow pointer-events-none absolute inset-0" aria-hidden />
+      <div className="relative mx-auto max-w-5xl px-4 md:px-6">
         <div className="rise-in rise-1 flex items-center justify-between border-y border-linex py-2 text-[10px] md:text-[11px] tracking-[0.08em] text-faintx">
           <span className="text-dimx font-semibold">BLINK(1)</span>
-          <span className="hidden sm:inline">General Commands Manual</span>
+          <span className="hidden sm:inline">spatial notes · macOS</span>
           <span className="text-dimx font-semibold">BLINK(1)</span>
         </div>
 
-        <div className="mt-10 md:mt-14 grid gap-12 lg:grid-cols-[1fr_1.05fr] lg:gap-10 items-start">
-          {/* man page body */}
+        <div className="mt-10 md:mt-12 grid gap-10 lg:grid-cols-[1fr_1.05fr] lg:gap-12 items-start">
           <div className="rise-in rise-2">
-            <ManRow term="NAME">
-              <p>
-                <span className="text-[var(--text)] font-bold text-[22px] md:text-[30px] tracking-[-0.02em]">
-                  blink
-                </span>
-                <span className="text-faintx"> — </span>
-                <span className="text-[var(--text)] text-[17px] md:text-[21px] font-medium">
-                  spatial notes for your Mac
-                </span>
-              </p>
-            </ManRow>
+            <h1 className="text-balance">
+              <span className="block text-[40px] md:text-[48px] font-bold tracking-[-0.03em] leading-[1.05] text-[var(--text)]">
+                blink
+              </span>
+              <span className="mt-3 block text-[19px] md:text-[23px] font-medium tracking-[-0.01em] leading-[1.35] text-dimx">
+                spatial notes for your Mac
+              </span>
+            </h1>
 
-            <ManRow term="SYNOPSIS">
-              <div className="space-y-2.5">
-                <div className="flex items-center gap-4">
-                  <Chord keys={['⌃', '⌥', '⇧', '⌘', 'N']} />
-                  <span className="text-faintx">→</span>
-                  <span>borderless glass note, summoned anywhere</span>
-                </div>
-                <div className="flex items-center gap-4">
-                  <Chord keys={['⌃', '⌥', '⇧', '⌘', 'B']} />
-                  <span className="text-faintx">→</span>
-                  <span>blink every panel in / out of view</span>
-                </div>
-                <div className="flex items-center gap-4">
-                  <Chord keys={['⌃', '⌥', '⇧', '⌘', 'C']} />
-                  <span className="text-faintx">→</span>
-                  <span>grid overlay — survey the whole board</span>
-                </div>
+            <p className="mt-6 max-w-md text-[14px] leading-[1.75] text-dimx">
+              A menubar app. Press Hyper+N anywhere and a glass note lands on your
+              screen —{' '}
+              <span className="text-acc">placed in space, remembered there</span>.
+              Plain markdown you own. Open to your agents.
+            </p>
+
+            <div className="mt-7 space-y-2.5 text-[13px] text-dimx">
+              <div className="flex items-center gap-3 flex-wrap">
+                <Chord keys={['⌃', '⌥', '⇧', '⌘', 'N']} />
+                <span className="text-faintx">new note</span>
               </div>
-            </ManRow>
-
-            <ManRow term="DESCRIPTION">
-              <p>
-                A menubar app for macOS. Press <span className="text-[var(--text)]">Hyper+N</span> in any
-                application and a note lands on your screen —{' '}
-                <span className="text-acc">placed in space, and remembered there</span>. Each panel
-                persists its position, size and sheet across launches, so your desk becomes muscle
-                memory.
-              </p>
-              <p className="mt-3">
-                Notes are frontmatter markdown files in a folder you own. No account, no sync
-                service, no lock-in — and external edits reconcile live, so your agents read and
-                write the same files you do.
-              </p>
-            </ManRow>
+              <div className="flex items-center gap-3 flex-wrap">
+                <Chord keys={['⌃', '⌥', '⇧', '⌘', 'B']} />
+                <span className="text-faintx">blink all panels</span>
+              </div>
+            </div>
 
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <PrimaryButton href="https://github.com/arach/blink/releases/latest">
-                <span className="text-[15px] leading-none">↓</span> download for macOS
+                <span className="text-[15px] leading-none" aria-hidden>
+                  ↓
+                </span>{' '}
+                download for macOS
               </PrimaryButton>
               <GhostButton href="https://github.com/arach/blink">
-                view on github <span className="text-faintx">↗</span>
+                github <span className="text-faintx" aria-hidden>↗</span>
               </GhostButton>
             </div>
 
-            <div className="mt-6 flex flex-wrap gap-x-6 gap-y-2 text-[11px] text-faintx">
-              <span>
-                <span className="text-acc">exit 0</span> · free & open source
-              </span>
-              <span>os: macOS 14+</span>
-              <span>arch: Apple Silicon</span>
-            </div>
+            <p className="mt-5 text-[11px] text-faintx">
+              free & open source · macOS 14+ · Apple Silicon
+            </p>
           </div>
 
-          {/* interactive demo */}
           <div className="rise-in rise-3">
             <SpatialDemo />
             <p className="mt-3 text-[11px] leading-relaxed text-faintx">
-              <span className="text-dimx font-semibold">fig. 1</span> — the spatial model, running in
-              your browser. Panels remember <span className="text-acc">(x, y, w, h)</span>; the real
-              thing renders as native NSPanel glass.
+              Panels remember position and size · native NSPanel glass
             </p>
           </div>
         </div>

--- a/landing/components/homepage/Install.tsx
+++ b/landing/components/homepage/Install.tsx
@@ -78,7 +78,7 @@ export function Footer() {
           </div>
         </div>
         <div className="mt-6 text-[10px] text-[var(--ghost)]">
-          JetBrains Mono · no tracking · no cookies
+          JetBrains Mono · blink.arach.dev
         </div>
       </div>
     </footer>

--- a/landing/components/homepage/Install.tsx
+++ b/landing/components/homepage/Install.tsx
@@ -1,112 +1,48 @@
-import { SectionHeader, PrimaryButton, GhostButton } from './shared'
+import { SectionHeader, PrimaryButton, GhostButton, Reveal } from './shared'
 import { BlinkMark } from './BlinkMark'
-
-const REQS: [string, string][] = [
-  ['os', 'macOS 14 (Sonoma) or later'],
-  ['arch', 'Apple Silicon'],
-  ['app', 'single native bundle'],
-  ['runtime', 'menubar resident — no dock icon'],
-  ['permissions', 'global hotkeys only'],
-  ['network', 'none — no account, no cloud'],
-]
 
 export function Install() {
   return (
-    <section id="install" className="py-20 md:py-28 border-t border-linex">
-      <div className="mx-auto max-w-6xl px-4 md:px-6">
+    <section id="install" className="scroll-mt-16 py-20 md:py-28 border-t border-linex">
+      <div className="mx-auto max-w-5xl px-4 md:px-6">
         <SectionHeader
-          index="06"
           tag="INSTALL"
           title={
             <>
               Free, open source, <span className="text-acc">and yours</span>.
             </>
           }
-          sub="A single native app for macOS. No account, no sign-in — download it, press ⌃⌥⇧⌘N, and start."
+          sub="A single native app for macOS. No account — download it, press Hyper+N, and start."
         />
 
-        <div className="grid gap-8 lg:grid-cols-[1fr_1.1fr] lg:gap-12 items-start">
-          <div>
+        <Reveal>
+          <div className="corner-frame">
             <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden">
-              <div className="border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] tracking-[0.14em] uppercase text-faintx">
-                release — latest
-              </div>
-              <div className="p-5 md:p-6">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <div className="text-[15px] font-bold text-[var(--text)]">Blink.dmg</div>
-                    <div className="mt-1 text-[11px] text-faintx">Apple Silicon · notarized</div>
-                  </div>
-                  <div className="text-right text-[11px] text-dimx">
-                    <div>native app</div>
-                    <div className="text-faintx">arm64</div>
-                  </div>
-                </div>
-                <div className="mt-5 flex flex-wrap gap-3">
-                  <PrimaryButton href="https://github.com/arach/blink/releases/latest">
-                    <span className="text-[15px] leading-none">↓</span> download for macOS
-                  </PrimaryButton>
-                  <GhostButton href="https://github.com/arach/blink">
-                    source on github <span className="text-faintx">↗</span>
-                  </GhostButton>
-                </div>
-                <div className="mt-5 rounded-[6px] border border-linex bg-[#09090b] px-3.5 py-3 text-[11px] leading-[1.8]">
-                  <span className="text-faintx"># or from your terminal</span>
-                  <br />
-                  <span className="text-acc">❯ </span>
-                  <span className="text-[var(--text)]">open -a Blink</span>
-                  <span className="text-faintx">  # then: ⌃⌥⇧⌘N, anywhere</span>
-                </div>
+          <div className="border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] tracking-[0.14em] uppercase text-faintx">
+            release — latest
+          </div>
+          <div className="flex flex-col gap-6 p-5 md:flex-row md:items-center md:justify-between md:gap-8 md:p-6">
+            <div className="min-w-0">
+              <div className="text-[15px] font-bold text-[var(--text)]">Blink.dmg</div>
+              <div className="mt-1 text-[11px] text-faintx">
+                Apple Silicon · macOS 14+ · notarized · no account
               </div>
             </div>
-
-            <div className="mt-4 grid grid-cols-3 gap-3">
-              {[
-                { k: 'free & open source', v: 'on GitHub' },
-                { k: 'native macOS app', v: 'swift + appkit' },
-                { k: 'no account', v: 'notes stay local' },
-              ].map((c) => (
-                <div key={c.k} className="border border-linex rounded-[7px] bg-panelx px-3 py-3 text-center">
-                  <div className="text-[11px] font-bold text-[var(--text)]">{c.k}</div>
-                  <div className="mt-0.5 text-[10px] text-faintx">{c.v}</div>
-                </div>
-              ))}
+            <div className="flex flex-wrap gap-3 shrink-0">
+              <PrimaryButton href="https://github.com/arach/blink/releases/latest">
+                <span className="text-[15px] leading-none" aria-hidden>
+                  ↓
+                </span>{' '}
+                download for macOS
+              </PrimaryButton>
+              <GhostButton href="https://github.com/arach/blink">
+                source <span className="text-faintx" aria-hidden>↗</span>
+              </GhostButton>
             </div>
           </div>
-
-          {/* requirements */}
-          <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden">
-            <div className="border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] tracking-[0.14em] uppercase text-faintx">
-              requirements — blink(1)
-            </div>
-            <div>
-              {REQS.map(([k, v]) => (
-                <div
-                  key={k}
-                  className="grid grid-cols-[110px_1fr] border-b border-[rgba(var(--line-rgb),0.55)] last:border-b-0 px-4 py-3"
-                >
-                  <span className="text-[11px] font-bold text-acc">{k}</span>
-                  <span className="text-[11.5px] text-dimx">{v}</span>
-                </div>
-              ))}
-            </div>
-            <div className="border-t border-linex px-4 py-3 text-[10.5px] leading-[1.7] text-faintx">
-              SEE ALSO —{' '}
-              <a href="https://github.com/arach/blink" target="_blank" rel="noreferrer" className="text-cyanx hover:underline">
-                github.com/arach/blink
-              </a>
-              {' · '}
-              <a
-                href="https://github.com/arach/blink/releases/latest"
-                target="_blank"
-                rel="noreferrer"
-                className="text-cyanx hover:underline"
-              >
-                releases
-              </a>
             </div>
           </div>
-        </div>
+        </Reveal>
       </div>
     </section>
   )
@@ -114,18 +50,21 @@ export function Install() {
 
 export function Footer() {
   return (
-    <footer className="border-t border-linex pb-16 pt-10">
-      <div className="mx-auto max-w-6xl px-4 md:px-6">
-        <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
-          <div className="text-[12px]">
-            <span className="flex items-center gap-2 font-bold text-[var(--text)]">
-              <BlinkMark className="h-[16px] w-[16px] text-acc" />
-              blink
-            </span>
-            <p className="mt-2 text-[11px] text-faintx">spatial notes for your Mac — placed in space, remembered there.</p>
+    <footer className="border-t border-linex pb-12 pt-8">
+      <div className="mx-auto max-w-5xl px-4 md:px-6">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="flex items-center gap-2 text-[12px] font-bold text-[var(--text)]">
+            <BlinkMark className="h-[16px] w-[16px] text-acc" />
+            blink
+            <span className="font-normal text-faintx">· spatial notes for your Mac</span>
           </div>
-          <div className="flex items-center gap-6 text-[11px] text-dimx">
-            <a href="https://github.com/arach/blink" target="_blank" rel="noreferrer" className="hover:text-acc transition-colors">
+          <div className="flex items-center gap-5 text-[11px] text-dimx">
+            <a
+              href="https://github.com/arach/blink"
+              target="_blank"
+              rel="noreferrer"
+              className="hover:text-acc transition-colors"
+            >
               github
             </a>
             <a
@@ -136,12 +75,10 @@ export function Footer() {
             >
               releases
             </a>
-            <span className="text-faintx">native · open source</span>
           </div>
         </div>
-        <div className="mt-8 border-t border-[rgba(var(--line-rgb),0.6)] pt-4 flex flex-wrap justify-between gap-2 text-[10px] text-[#3a3a40]">
-          <span>set in JetBrains Mono · no tracking · no cookies</span>
-          <span>BLINK(1) · end of manual</span>
+        <div className="mt-6 text-[10px] text-[var(--ghost)]">
+          JetBrains Mono · no tracking · no cookies
         </div>
       </div>
     </footer>

--- a/landing/components/homepage/Keys.tsx
+++ b/landing/components/homepage/Keys.tsx
@@ -1,69 +1,56 @@
-import { SectionHeader, Chord } from './shared'
+import { SectionHeader, Chord, Reveal } from './shared'
 
-const GLOBAL: { action: string; keys: string[]; note: string }[] = [
-  { action: 'new note, anywhere', keys: ['⌃', '⌥', '⇧', '⌘', 'N'], note: 'panel spawns on the active space' },
-  { action: 'blink — all notes / none', keys: ['⌃', '⌥', '⇧', '⌘', 'B'], note: 'clear the screen, recall on repeat' },
-  { action: 'grid overlay', keys: ['⌃', '⌥', '⇧', '⌘', 'C'], note: 'every panel, tiled for a survey' },
+const KEYS: { action: string; keys: string[]; scope: 'global' | 'panel' }[] = [
+  { action: 'new note, anywhere', keys: ['⌃', '⌥', '⇧', '⌘', 'N'], scope: 'global' },
+  { action: 'blink all notes', keys: ['⌃', '⌥', '⇧', '⌘', 'B'], scope: 'global' },
+  { action: 'grid overlay', keys: ['⌃', '⌥', '⇧', '⌘', 'C'], scope: 'global' },
+  { action: 'flip read / edit', keys: ['⌘', '⇧', 'P'], scope: 'panel' },
+  { action: 'close panel', keys: ['⌘', 'W'], scope: 'panel' },
 ]
-
-const PANEL: { action: string; keys: string[]; note: string }[] = [
-  { action: 'flip read / edit', keys: ['⌘', '⇧', 'P'], note: 'in place, scroll position preserved' },
-  { action: 'focus — quiet everything else', keys: ['⌘', '.'], note: 'dims all other panels' },
-  { action: 'step down — leave edit, drop focus', keys: ['⎋'], note: 'one level per press' },
-  { action: 'close panel', keys: ['⌘', 'W'], note: 'file stays; the panel goes' },
-]
-
-function KeyTable({ title, rows }: { title: string; rows: typeof GLOBAL }) {
-  return (
-    <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden">
-      <div className="border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] tracking-[0.16em] uppercase text-faintx">
-        {title}
-      </div>
-      <div>
-        {rows.map((r) => (
-          <div
-            key={r.action}
-            className="group flex items-center justify-between gap-4 border-b border-[rgba(var(--line-rgb),0.55)] last:border-b-0 px-4 py-4 transition-colors hover:bg-[rgba(var(--acc-rgb),0.03)]"
-          >
-            <div>
-              <div className="text-[12.5px] font-semibold text-[var(--text)]">{r.action}</div>
-              <div className="mt-0.5 text-[10.5px] text-faintx">{r.note}</div>
-            </div>
-            <Chord keys={r.keys} />
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
 
 export default function Keys() {
   return (
-    <section id="keys" className="py-20 md:py-28 border-t border-linex">
-      <div className="mx-auto max-w-6xl px-4 md:px-6">
+    <section id="keys" className="scroll-mt-16 py-20 md:py-28 border-t border-linex">
+      <div className="mx-auto max-w-5xl px-4 md:px-6">
         <SectionHeader
-          index="05"
-          tag="KEYBOARD INTERFACE"
+          tag="KEYS"
           title={
             <>
               Everything is <span className="text-acc">a keystroke away</span>.
             </>
           }
-          sub="Three global chords reach Blink from any app; the rest act on the panel you're in. Hyper is ⌃⌥⇧⌘ — a modifier no app already owns. Every binding is rewritable in config.json."
+          sub={
+            <span className="inline-flex flex-wrap items-center gap-x-1.5 gap-y-1">
+              <span>Hyper is</span>
+              <Chord keys={['⌃', '⌥', '⇧', '⌘']} />
+              <span>— a modifier no app already owns. Every binding is rewritable in config.json.</span>
+            </span>
+          }
         />
 
-        <div className="grid gap-6 lg:grid-cols-2 items-start">
-          <KeyTable title="global — from any application" rows={GLOBAL} />
-          <KeyTable title="in a panel" rows={PANEL} />
-        </div>
-
-        <div className="mt-6 border border-linex rounded-[7px] bg-panelx px-4 py-3.5 flex flex-wrap items-center gap-x-8 gap-y-2 text-[11px] text-dimx">
-          <span>
-            <span className="text-acc">hyper</span> = <Chord keys={['⌃', '⌥', '⇧', '⌘']} />
-          </span>
-          <span className="text-faintx">remap: "hotkeys": {`{ "newNote": "cmd+shift+j" }`}</span>
-          <span className="text-faintx">no accessibility permissions required</span>
-        </div>
+        <Reveal className="border border-linex rounded-[8px] bg-panelx overflow-hidden">
+          <div className="hidden sm:grid grid-cols-[1fr_5.5rem_auto] gap-6 border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] tracking-[0.14em] uppercase text-faintx">
+            <span>action</span>
+            <span>scope</span>
+            <span className="text-right">chord</span>
+          </div>
+          {KEYS.map((r) => (
+            <div
+              key={r.action}
+              className="grid grid-cols-1 sm:grid-cols-[1fr_5.5rem_auto] items-center gap-2 sm:gap-6 border-b border-[rgba(var(--line-rgb),0.55)] last:border-b-0 px-4 py-3.5 transition-colors hover:bg-[rgba(var(--acc-rgb),0.03)]"
+            >
+              <div className="text-[13px] text-[var(--text)]">{r.action}</div>
+              <div>
+                <span className="inline-flex items-center rounded-[3px] border border-linex px-1.5 py-[2px] text-[9px] tracking-[0.12em] uppercase text-faintx">
+                  {r.scope}
+                </span>
+              </div>
+              <div className="sm:justify-self-end">
+                <Chord keys={r.keys} />
+              </div>
+            </div>
+          ))}
+        </Reveal>
       </div>
     </section>
   )

--- a/landing/components/homepage/Sheets.tsx
+++ b/landing/components/homepage/Sheets.tsx
@@ -1,19 +1,17 @@
 import { useEffect, useState } from 'react'
-import { SectionHeader } from './shared'
+import { SectionHeader, Reveal } from './shared'
 
 type SheetId = 'glass' | 'card' | 'dotted' | 'bracket' | 'marginalia'
 
-const SHEETS: { id: SheetId; name: string; desc: string; spec: string }[] = [
-  { id: 'glass', name: 'glass', desc: 'The default — a HUD panel of real macOS blur.', spec: 'NSVisualEffectView · .hudWindow' },
-  { id: 'card', name: 'card', desc: 'Opaque paper. No blur — a solid surface that reads anywhere.', spec: 'NSWindow · opaque, +4% radius' },
-  { id: 'dotted', name: 'dotted', desc: 'A flat sheet with a dotted margin, like a notebook.', spec: 'flat bg · dot-grid @ 18px pitch' },
-  { id: 'bracket', name: 'bracket', desc: 'Corner brackets frame the text and nothing else.', spec: 'borderless · 4× corner ticks' },
-  { id: 'marginalia', name: 'marginalia', desc: 'A ruled left margin for annotations in the wild.', spec: 'ruled gutter · 56px margin col' },
+const SHEETS: { id: SheetId; name: string; desc: string }[] = [
+  { id: 'glass', name: 'glass', desc: 'HUD blur — the default.' },
+  { id: 'card', name: 'card', desc: 'Opaque paper, solid anywhere.' },
+  { id: 'dotted', name: 'dotted', desc: 'Notebook margin dots.' },
+  { id: 'bracket', name: 'bracket', desc: 'Corner ticks, nothing else.' },
+  { id: 'marginalia', name: 'marginalia', desc: 'Ruled left margin.' },
 ]
 
 function NoteBody({ compact = false }: { compact?: boolean }) {
-  // Sheets are always dark app surfaces, so this text uses the fixed dark-app
-  // palette (never the page-theme tokens) — otherwise it goes dark-on-dark on paper.
   return (
     <div className={compact ? 'space-y-[3px]' : 'space-y-[6px]'}>
       <div className={`${compact ? 'text-[10px]' : 'text-[15px]'} font-bold text-[#eceaef]`}>
@@ -21,9 +19,10 @@ function NoteBody({ compact = false }: { compact?: boolean }) {
       </div>
       <div className={`${compact ? 'text-[8.5px]' : 'text-[11.5px]'} text-[#b6b6bf]`}>Ship v2 · port the palette</div>
       <div className={`${compact ? 'text-[8.5px]' : 'text-[11.5px]'} leading-[1.6] text-[#8d8d97]`}>
-        Notes land where you <span className="underline decoration-[rgba(240,180,90,0.5)] underline-offset-2">leave them</span>.
+        Notes land where you{' '}
+        <span className="underline decoration-[rgba(var(--acc-rgb),0.5)] underline-offset-2">leave them</span>.
         <br />
-        see <span className="text-[#f0b45a]">[[roadmap]]</span>
+        see <span className="text-[var(--acc)]">[[roadmap]]</span>
       </div>
     </div>
   )
@@ -35,10 +34,9 @@ function SheetSurface({ id, compact = false }: { id: SheetId; compact?: boolean 
   if (id === 'glass') {
     return (
       <div className={`relative h-full w-full overflow-hidden ${compact ? 'rounded-[5px]' : 'rounded-[10px]'}`}>
-        {/* backdrop content to blur */}
-        <div className="absolute inset-0" style={{ background: 'linear-gradient(135deg, #3d3423 0%, #1a2330 45%, #2b2436 100%)' }}>
-          <div className="absolute h-24 w-24 rounded-full bg-[rgba(var(--acc-rgb),0.25)] blur-2xl" style={{ left: '10%', top: '55%' }} />
-          <div className="absolute h-20 w-20 rounded-full bg-[rgba(124,199,232,0.2)] blur-2xl" style={{ right: '8%', top: '12%' }} />
+        <div className="absolute inset-0" style={{ background: 'linear-gradient(135deg, #2a2824 0%, #1a1a1c 50%, #242428 100%)' }}>
+          <div className="absolute h-24 w-24 rounded-full bg-[rgba(255,255,255,0.08)] blur-2xl" style={{ left: '10%', top: '55%' }} />
+          <div className="absolute h-20 w-20 rounded-full bg-[rgba(255,255,255,0.05)] blur-2xl" style={{ right: '8%', top: '12%' }} />
         </div>
         <div className={`relative h-full glass-note ${pad}`} style={{ borderRadius: 'inherit' }}>
           <NoteBody compact={compact} />
@@ -73,25 +71,20 @@ function SheetSurface({ id, compact = false }: { id: SheetId; compact?: boolean 
   }
   if (id === 'bracket') {
     const c = compact ? 'h-[7px] w-[7px]' : 'h-[12px] w-[12px]'
-    const b = compact ? 'border-[#f0b45a]' : 'border-[#f0b45a]'
     return (
       <div className={`relative h-full w-full ${pad}`} style={{ background: 'transparent' }}>
-        <span className={`absolute left-0 top-0 ${c} border-l border-t ${b}`} />
-        <span className={`absolute right-0 top-0 ${c} border-r border-t ${b}`} />
-        <span className={`absolute bottom-0 left-0 ${c} border-b border-l ${b}`} />
-        <span className={`absolute bottom-0 right-0 ${c} border-b border-r ${b}`} />
+        <span className={`absolute left-0 top-0 ${c} border-l border-t border-[var(--acc)]`} />
+        <span className={`absolute right-0 top-0 ${c} border-r border-t border-[var(--acc)]`} />
+        <span className={`absolute bottom-0 left-0 ${c} border-b border-l border-[var(--acc)]`} />
+        <span className={`absolute bottom-0 right-0 ${c} border-b border-r border-[var(--acc)]`} />
         <NoteBody compact={compact} />
       </div>
     )
   }
-  // marginalia
   return (
     <div
-      className={`h-full w-full border border-linex ${compact ? 'rounded-[5px] pl-[26px] pr-2.5 py-2.5' : 'rounded-[10px] pl-[52px] pr-5 py-5'}`}
-      style={{
-        background: '#0d0d0f',
-        backgroundImage: 'linear-gradient(90deg, transparent 0, transparent 100%)',
-      }}
+      className={`relative h-full w-full border border-linex ${compact ? 'rounded-[5px] pl-[26px] pr-2.5 py-2.5' : 'rounded-[10px] pl-[52px] pr-5 py-5'}`}
+      style={{ background: '#0d0d0f' }}
     >
       <span
         className="absolute"
@@ -100,7 +93,7 @@ function SheetSurface({ id, compact = false }: { id: SheetId; compact?: boolean 
           top: compact ? 6 : 10,
           bottom: compact ? 6 : 10,
           width: 1,
-          background: 'rgba(255,122,110,0.45)',
+          background: 'rgba(var(--acc-rgb),0.45)',
         }}
       />
       <NoteBody compact={compact} />
@@ -114,6 +107,9 @@ export default function Sheets() {
 
   useEffect(() => {
     if (touched) return
+    if (typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return
+    }
     const t = setInterval(() => {
       setActive((a) => {
         const i = SHEETS.findIndex((s) => s.id === a)
@@ -126,79 +122,67 @@ export default function Sheets() {
   const current = SHEETS.find((s) => s.id === active)!
 
   return (
-    <section id="sheets" className="py-20 md:py-28 border-t border-linex">
-      <div className="mx-auto max-w-6xl px-4 md:px-6">
+    <section id="sheets" className="scroll-mt-16 py-20 md:py-28 border-t border-linex">
+      <div className="mx-auto max-w-5xl px-4 md:px-6">
         <SectionHeader
-          index="02"
           tag="SHEETS"
           title={
             <>
               Every note is its <span className="text-acc">own surface</span>.
             </>
           }
-          sub="Five render sheets, assignable per note or as your default. Set one key in config.json and Blink hot-applies it to every open panel in under a second."
+          sub="Five render sheets, per note or as default. One key in config — hot-applied to every open panel."
         />
 
-        <div className="grid gap-10 lg:grid-cols-[1fr_1.2fr] lg:gap-14 items-start">
-          {/* selector list */}
-          <div className="space-y-2">
-            {SHEETS.map((s) => (
-              <button
-                key={s.id}
-                onClick={() => {
-                  setActive(s.id)
-                  setTouched(true)
-                }}
-                className={`w-full text-left rounded-[7px] border px-4 py-3.5 transition-all ${
-                  active === s.id
-                    ? 'border-[rgba(var(--acc-rgb),0.45)] bg-[rgba(var(--acc-rgb),0.05)]'
-                    : 'border-linex bg-panelx hover:border-line2x'
-                }`}
-              >
-                <div className="flex items-center justify-between">
-                  <span className={`text-[13px] font-bold ${active === s.id ? 'text-acc' : 'text-[var(--text)]'}`}>
+        <Reveal className="grid gap-8 lg:grid-cols-[minmax(0,14rem)_1fr] lg:gap-10 items-start">
+          <div
+            className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1 lg:mx-0 lg:px-0 lg:flex-col lg:overflow-visible lg:pb-0 lg:gap-1"
+            role="tablist"
+            aria-label="Sheet styles"
+          >
+            {SHEETS.map((s) => {
+              const on = active === s.id
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={on}
+                  onClick={() => {
+                    setActive(s.id)
+                    setTouched(true)
+                  }}
+                  className={`shrink-0 text-left rounded-[6px] border px-3.5 py-2.5 transition-colors ${
+                    on
+                      ? 'border-[rgba(var(--acc-rgb),0.45)] bg-[rgba(var(--acc-rgb),0.05)]'
+                      : 'border-linex bg-panelx hover:border-line2x lg:border-transparent lg:bg-transparent lg:hover:border-linex'
+                  }`}
+                >
+                  <span className={`text-[13px] font-bold ${on ? 'text-acc' : 'text-[var(--text)]'}`}>
                     {s.name}
                   </span>
-                  <span className="text-[10px] text-faintx">{s.spec}</span>
-                </div>
-                <p className="mt-1.5 text-[11px] leading-[1.6] text-dimx">{s.desc}</p>
-              </button>
-            ))}
+                  <span className="mt-0.5 block text-[11px] text-dimx whitespace-nowrap lg:whitespace-normal">
+                    {s.desc}
+                  </span>
+                </button>
+              )
+            })}
           </div>
 
-          {/* stage */}
-          <div>
-            <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden">
-              <div className="flex items-center justify-between border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] text-faintx">
-                <span className="tracking-[0.14em] uppercase">preview — weekly-review.md</span>
-                <span className="text-acc">sheet: {current.name}</span>
-              </div>
-              <div className="h-[240px] md:h-[280px] p-5 md:p-7" style={{ background: 'radial-gradient(ellipse 90% 80% at 50% 20%, rgba(88, 72, 42,0.25), transparent 70%), #0b0b0d' }}>
-                <SheetSurface id={active} />
-              </div>
-              <div className="border-t border-linex bg-[#09090b] px-4 py-3">
-                <code className="text-[11px] leading-[1.7]">
-                  <span className="text-faintx">{'// hot-applied to all panels <1s'}</span>
-                  <br />
-                  <span className="text-cyanx">"panel"</span>
-                  <span className="text-dimx">: {'{'} </span>
-                  <span className="text-cyanx">"sheet"</span>
-                  <span className="text-dimx">: </span>
-                  <span className="text-amberx">"{current.name}"</span>
-                  <span className="text-dimx"> {'}'}</span>
-                </code>
-              </div>
+          <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden min-w-0">
+            <div className="flex items-center justify-between border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] text-faintx">
+              <span>preview</span>
+              <span className="text-acc">sheet: {current.name}</span>
             </div>
-            <div className="mt-3 flex gap-1.5">
-              {SHEETS.map((s) => (
-                <span
-                  key={s.id}
-                  className={`h-[3px] flex-1 rounded-full transition-colors ${active === s.id ? 'bg-[var(--acc)]' : 'bg-[var(--line)]'}`}
-                />
-              ))}
+            <div className="demo-desktop h-[220px] md:h-[260px] p-5 md:p-7">
+              <div className="mx-auto h-full max-w-[560px]">
+                <div key={active} className="sheet-swap h-full">
+                  <SheetSurface id={active} />
+                </div>
+              </div>
             </div>
           </div>
-        </div>
+        </Reveal>
       </div>
     </section>
   )

--- a/landing/components/homepage/SpatialDemo.tsx
+++ b/landing/components/homepage/SpatialDemo.tsx
@@ -99,6 +99,27 @@ export default function SpatialDemo() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [spawn])
 
+  /* seed a composed scene on load — staggered spawns so the hero opens with
+     notes landing in place instead of an empty desktop */
+  const seededRef = useRef(false)
+  useEffect(() => {
+    if (seededRef.current) return
+    seededRef.current = true
+    const el = ref.current
+    if (!el) return
+    const r = el.getBoundingClientRect()
+    const spots: [number, number][] = [
+      [r.width * 0.06, 30],
+      [r.width * 0.5, 92],
+      [r.width * 0.26, 200],
+    ]
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const timers = spots.map(([x, y], i) =>
+      window.setTimeout(() => spawn(x, y), reduced ? 0 : 550 + i * 420),
+    )
+    return () => timers.forEach((t) => clearTimeout(t))
+  }, [spawn])
+
   const toggleBlink = useCallback(() => {
     setAllHidden((h) => {
       const target = !h
@@ -144,58 +165,63 @@ export default function SpatialDemo() {
     mouseRef.current = { x: e.clientX - r.left, y: e.clientY - r.top }
   }
 
+  const demoBtn =
+    'rounded-[4px] border px-2 py-1 text-[10px] transition-colors border-line2x bg-[var(--panel)] text-dimx hover:text-acc hover:border-[rgba(var(--acc-rgb),0.4)]'
+  const demoBtnOn =
+    'rounded-[4px] border px-2 py-1 text-[10px] transition-colors border-[rgba(var(--acc-rgb),0.45)] text-acc bg-[var(--acc-soft)]'
+
   return (
-    <div className="corner-frame select-none">
+    <div className="corner-frame select-none" role="region" aria-label="Spatial notes demo">
       {/* window chrome */}
-      <div className="flex items-center justify-between border border-linex border-b-0 rounded-t-[8px] bg-panel2x px-3.5 h-10">
-        <div className="flex items-center gap-2 text-[11px] text-faintx">
-          <span className="inline-block h-[7px] w-[7px] rounded-full bg-[var(--acc)] pulse-dot" />
-          <span className="text-dimx font-semibold">~/Desktop</span>
-          <span className="hidden sm:inline">— spatial surface · live demo</span>
+      <div className="demo-chrome flex items-center justify-between gap-2 border border-b-0 rounded-t-[8px] px-3 min-h-10 py-1.5">
+        <div className="flex min-w-0 items-center gap-2 text-[11px] text-faintx">
+          <span className="inline-block h-[7px] w-[7px] shrink-0 rounded-full bg-[var(--acc)] pulse-dot" aria-hidden />
+          <span className="text-dimx font-semibold truncate">~/Desktop</span>
+          <span className="hidden md:inline shrink-0 text-faintx">— live demo</span>
         </div>
-        <div className="flex items-center gap-1.5">
-          <button
-            onClick={() => spawn()}
-            title="new note (or press N)"
-            className="rounded-[4px] border border-line2x bg-[var(--panel)] px-2 py-1 text-[10px] text-dimx hover:text-acc hover:border-[rgba(var(--acc-rgb),0.4)] transition-colors"
-          >
-            ⌃⌥⇧⌘N
+        <div className="flex shrink-0 items-center gap-1">
+          <button type="button" onClick={() => spawn()} title="New note (N)" aria-label="New note" className={demoBtn}>
+            <span className="sm:hidden">N</span>
+            <span className="hidden sm:inline">⌃⌥⇧⌘N</span>
           </button>
           <button
+            type="button"
             onClick={toggleBlink}
-            title="blink all / none (or press B)"
-            className={`rounded-[4px] border px-2 py-1 text-[10px] transition-colors ${
-              allHidden
-                ? 'border-[rgba(var(--acc-rgb),0.45)] text-acc bg-[var(--acc-soft)]'
-                : 'border-line2x bg-[var(--panel)] text-dimx hover:text-acc hover:border-[rgba(var(--acc-rgb),0.4)]'
-            }`}
+            title="Blink all / none (B)"
+            aria-label="Blink all panels"
+            aria-pressed={allHidden}
+            className={allHidden ? demoBtnOn : demoBtn}
           >
-            ⌃⌥⇧⌘B
+            <span className="sm:hidden">B</span>
+            <span className="hidden sm:inline">⌃⌥⇧⌘B</span>
           </button>
           <button
+            type="button"
             onClick={() => setGrid((g) => !g)}
-            title="grid overlay (or press C)"
-            className={`rounded-[4px] border px-2 py-1 text-[10px] transition-colors ${
-              grid
-                ? 'border-[rgba(var(--acc-rgb),0.45)] text-acc bg-[var(--acc-soft)]'
-                : 'border-line2x bg-[var(--panel)] text-dimx hover:text-acc hover:border-[rgba(var(--acc-rgb),0.4)]'
-            }`}
+            title="Grid overlay (C)"
+            aria-label="Toggle grid overlay"
+            aria-pressed={grid}
+            className={grid ? demoBtnOn : demoBtn}
           >
-            ⌃⌥⇧⌘C
+            <span className="sm:hidden">C</span>
+            <span className="hidden sm:inline">⌃⌥⇧⌘C</span>
           </button>
           <button
+            type="button"
             onClick={() => setNotes([])}
-            title="reset surface"
-            className="rounded-[4px] border border-line2x bg-[var(--panel)] px-2 py-1 text-[10px] text-faintx hover:text-[var(--red)] hover:border-[rgba(255,122,110,0.4)] transition-colors"
+            title="Reset surface"
+            aria-label="Reset demo"
+            className="rounded-[4px] border border-line2x bg-[var(--panel)] px-2 py-1 text-[10px] text-faintx hover:text-[var(--text)] hover:border-[rgba(var(--acc-rgb),0.35)] transition-colors"
           >
             reset
           </button>
         </div>
       </div>
 
-      {/* surface */}
+      {/* surface — premium layered desktop */}
       <div
         ref={ref}
+        data-grid={grid ? 'true' : undefined}
         onPointerEnter={() => (hoverRef.current = true)}
         onPointerLeave={() => (hoverRef.current = false)}
         onPointerMove={onSurfaceMove}
@@ -204,43 +230,46 @@ export default function SpatialDemo() {
             spawn(e.clientX - ref.current!.getBoundingClientRect().left, e.clientY - ref.current!.getBoundingClientRect().top)
           }
         }}
-        className="relative h-[380px] md:h-[460px] overflow-hidden rounded-b-[8px] border border-linex cursor-crosshair"
-        style={{
-          background: grid
-            ? 'linear-gradient(rgba(var(--acc-rgb),0.07) 1px, transparent 1px), linear-gradient(90deg, rgba(var(--acc-rgb),0.07) 1px, transparent 1px), radial-gradient(ellipse 80% 60% at 50% 30%, rgba(var(--acc-rgb),0.09), transparent 70%), var(--demo-surface)'
-            : 'radial-gradient(ellipse 80% 60% at 50% 30%, rgba(var(--acc-rgb),0.09), transparent 70%), var(--demo-surface)',
-          backgroundSize: grid ? '40px 40px, 40px 40px, 100% 100%, 100% 100%' : '100% 100%, 100% 100%',
-        }}
+        className="demo-desktop relative h-[340px] sm:h-[380px] md:h-[420px] overflow-hidden rounded-b-[8px] border border-linex cursor-crosshair"
       >
-        <div className="scanline" />
-
+        {/* soft ambient wash — extra depth without color noise */}
+        <div
+          className="pointer-events-none absolute inset-0"
+          aria-hidden
+          style={{
+            background:
+              'radial-gradient(ellipse 55% 40% at 72% 28%, rgba(255,255,255,0.12), transparent 70%), radial-gradient(ellipse 40% 50% at 18% 70%, rgba(0,0,0,0.06), transparent 65%)',
+          }}
+        />
         {/* grid rulers */}
         {grid && (
           <div data-surface="grid" className="absolute inset-0 pointer-events-none">
             {[80, 160, 240, 320, 400].map((x) => (
-              <span key={x} className="absolute top-1 text-[9px] text-[rgba(var(--acc-rgb),0.45)]" style={{ left: x + 3 }}>
+              <span key={x} className="absolute top-1 text-[9px] text-faintx/80" style={{ left: x + 3 }}>
                 {x}
               </span>
             ))}
             {[80, 160, 240, 320].map((y) => (
-              <span key={y} className="absolute left-1.5 text-[9px] text-[rgba(var(--acc-rgb),0.45)]" style={{ top: y + 3 }}>
+              <span key={y} className="absolute left-1.5 text-[9px] text-faintx/80" style={{ top: y + 3 }}>
                 {y}
               </span>
             ))}
           </div>
         )}
 
-        {/* empty state hint */}
-        {notes.length === 0 && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 pointer-events-none">
-            <div className="flex items-center gap-2 text-faintx text-[12px]">
-              <Chord keys={['⌃', '⌥', '⇧', '⌘', 'N']} />
-            </div>
-            <p className="text-[11px] text-faintx">
-              click anywhere — or press <span className="text-acc">N</span> — to drop a note in space
-            </p>
+        {/* empty state hint — fades away once the scene has notes */}
+        <div
+          className={`absolute inset-0 flex flex-col items-center justify-center gap-2.5 px-4 pointer-events-none pb-8 transition-opacity duration-500 ${
+            notes.length === 0 ? 'opacity-100' : 'opacity-0'
+          }`}
+        >
+          <div className="flex items-center gap-2 text-faintx text-[12px]">
+            <Chord keys={['⌃', '⌥', '⇧', '⌘', 'N']} />
           </div>
-        )}
+          <p className="text-[11px] text-faintx text-center max-w-[18rem] leading-relaxed">
+            click anywhere — or press <span className="text-acc">N</span> — to drop a note
+          </p>
+        </div>
 
         {/* notes */}
         {notes.map((n) => (
@@ -259,11 +288,11 @@ export default function SpatialDemo() {
               transition: 'opacity 0.22s ease, transform 0.22s ease',
             }}
           >
-            <div className="flex items-center justify-between border-b border-[rgba(214,204,184,0.14)] px-2.5 py-1.5">
-              <span className="text-[10px] text-[rgba(216,216,220,0.75)]">{n.title}</span>
-              <span className="text-[9px] text-[rgba(150,150,158,0.7)]">
+            <div className="flex items-center justify-between border-b border-[rgba(255,248,236,0.1)] px-2.5 py-1.5">
+              <span className="text-[10px] font-medium text-[rgba(245,242,236,0.82)]">{n.title}</span>
+              <span className="text-[9px] tabular-nums text-[rgba(200,196,188,0.55)]">
                 {dragInfo?.id === n.id ? (
-                  <span className="text-acc">
+                  <span className="text-[rgba(245,242,236,0.9)]">
                     x:{String(dragInfo.x).padStart(3, '0')} y:{String(dragInfo.y).padStart(3, '0')}
                   </span>
                 ) : (
@@ -276,7 +305,9 @@ export default function SpatialDemo() {
                 <div
                   key={i}
                   className={`text-[10px] leading-[1.5] whitespace-nowrap overflow-hidden ${
-                    l.startsWith('##') ? 'text-[rgba(216,216,220,0.9)] font-semibold' : 'text-[rgba(150,150,158,0.9)]'
+                    l.startsWith('##')
+                      ? 'font-semibold text-[rgba(245,242,236,0.92)]'
+                      : 'text-[rgba(200,196,188,0.78)]'
                   }`}
                 >
                   {l}
@@ -289,7 +320,7 @@ export default function SpatialDemo() {
         {/* bottom-left readout */}
         <div className="absolute bottom-2 left-3 text-[9px] text-faintx pointer-events-none">
           panels: {notes.filter((n) => !n.hidden).length}/{notes.length}
-          {allHidden && <span className="text-amberx"> · blinked out — ⌃⌥⇧⌘B to recall</span>}
+          {allHidden && <span className="text-acc"> · blinked out — ⌃⌥⇧⌘B to recall</span>}
         </div>
         <div className="absolute bottom-2 right-3 text-[9px] text-faintx pointer-events-none hidden sm:block">
           drag panels · state persists (x, y, w, h)

--- a/landing/components/homepage/ThemeSwitcher.tsx
+++ b/landing/components/homepage/ThemeSwitcher.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from 'react'
 
 /** Cream (default :root) or black. */
 const THEMES = [
-  { id: 'cream', bg: '#e8e2d4', acc: '#1a1612', label: 'cream' },
-  { id: 'black', bg: '#0a0a0b', acc: '#f0ece4', label: 'black' },
+  { id: 'cream', bg: '#e8e2d4', acc: '#0a0806', label: 'cream' },
+  { id: 'black', bg: '#000000', acc: '#ffffff', label: 'black' },
 ] as const
 
 type ThemeId = (typeof THEMES)[number]['id']

--- a/landing/components/homepage/ThemeSwitcher.tsx
+++ b/landing/components/homepage/ThemeSwitcher.tsx
@@ -2,32 +2,37 @@
 
 import { useEffect, useState } from 'react'
 
-/** Full-palette themes. `amber` is the default (:root), so it clears the attribute.
- *  Each swatch shows the theme's background (fill) + accent (ring). */
+/** Cream (default :root) or black. */
 const THEMES = [
-  { id: 'amber', bg: '#0a0a0b', acc: '#f0b45a' },
-  { id: 'green', bg: '#060907', acc: '#6ee787' },
-  { id: 'blue', bg: '#070a10', acc: '#7cc7e8' },
-  { id: 'violet', bg: '#0a0810', acc: '#c792ea' },
-  { id: 'paper', bg: '#e8e2d4', acc: '#9c5a16' },
+  { id: 'cream', bg: '#e8e2d4', acc: '#1a1612', label: 'cream' },
+  { id: 'black', bg: '#0a0a0b', acc: '#f0ece4', label: 'black' },
 ] as const
 
-function applyTheme(id: string) {
+type ThemeId = (typeof THEMES)[number]['id']
+
+function applyTheme(id: ThemeId) {
   const root = document.documentElement
-  if (id === 'amber') root.removeAttribute('data-theme')
-  else root.setAttribute('data-theme', id)
+  if (id === 'cream') root.removeAttribute('data-theme')
+  else root.setAttribute('data-theme', 'black')
+}
+
+function normalize(raw: string | null): ThemeId {
+  if (raw === 'black') return 'black'
+  // Migrate old multi-theme ids → cream default (except explicit black)
+  return 'cream'
 }
 
 export function ThemeSwitcher() {
-  const [active, setActive] = useState('amber')
+  const [active, setActive] = useState<ThemeId>('cream')
 
-  // Adopt whatever the no-FOUC script (or a prior visit) already set.
   useEffect(() => {
-    const saved = document.documentElement.getAttribute('data-theme') || 'amber'
+    const attr = document.documentElement.getAttribute('data-theme')
+    const saved = normalize(attr || localStorage.getItem('blink-theme'))
     setActive(saved)
+    applyTheme(saved)
   }, [])
 
-  const pick = (id: string) => {
+  const pick = (id: ThemeId) => {
     setActive(id)
     applyTheme(id)
     try {
@@ -36,26 +41,31 @@ export function ThemeSwitcher() {
   }
 
   return (
-    <div className="flex items-center gap-[7px]" role="radiogroup" aria-label="accent theme">
+    <div className="flex items-center" role="radiogroup" aria-label="color theme">
       {THEMES.map((t) => {
         const on = active === t.id
         return (
           <button
             key={t.id}
+            type="button"
             role="radio"
             aria-checked={on}
-            aria-label={`${t.id} theme`}
-            title={t.id}
+            aria-label={`${t.label} theme`}
+            title={t.label}
             onClick={() => pick(t.id)}
-            className="h-[12px] w-[12px] rounded-full transition-transform hover:scale-110"
-            style={{
-              backgroundColor: t.bg,
-              opacity: on ? 1 : 0.5,
-              boxShadow: on
-                ? `inset 0 0 0 1px ${t.acc}, 0 0 0 2px var(--bg), 0 0 0 3px ${t.acc}`
-                : `inset 0 0 0 1px ${t.acc}`,
-            }}
-          />
+            className="inline-flex h-8 w-7 items-center justify-center rounded-sm transition-transform hover:scale-105"
+          >
+            <span
+              className="block h-[12px] w-[12px] rounded-full"
+              style={{
+                backgroundColor: t.bg,
+                opacity: on ? 1 : 0.55,
+                boxShadow: on
+                  ? `inset 0 0 0 1px ${t.acc}, 0 0 0 2px var(--bg), 0 0 0 3px ${t.acc}`
+                  : `inset 0 0 0 1px ${t.acc}`,
+              }}
+            />
+          </button>
         )
       })}
     </div>

--- a/landing/components/homepage/shared.tsx
+++ b/landing/components/homepage/shared.tsx
@@ -1,4 +1,50 @@
-import type { ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+
+/* ------------------------------ scroll reveal ----------------------------- */
+
+/** Fades/rises content in when it enters the viewport (once). SSR renders it
+ *  fully visible — the hidden state is only armed on the client, so no-JS and
+ *  first paint are never blank. Reduced motion is handled by the global CSS. */
+export function Reveal({
+  children,
+  className = '',
+  delay = 0,
+}: {
+  children: ReactNode
+  className?: string
+  delay?: number
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [armed, setArmed] = useState(false)
+  const [inView, setInView] = useState(false)
+
+  useEffect(() => {
+    setArmed(true)
+    const el = ref.current
+    if (!el) return
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true)
+          io.disconnect()
+        }
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -6% 0px' },
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      className={`${armed ? 'reveal' : ''} ${inView ? 'reveal-in' : ''} ${className}`}
+      style={delay ? { transitionDelay: `${delay}ms` } : undefined}
+    >
+      {children}
+    </div>
+  )
+}
 
 /* ---------------------------------- kbd ---------------------------------- */
 
@@ -30,31 +76,30 @@ export function Chord({ keys }: { keys: string[] }) {
 /* ------------------------------ section header ---------------------------- */
 
 export function SectionHeader({
-  index,
   tag,
   title,
   sub,
 }: {
-  index: string
-  tag: string
+  tag?: string
   title: ReactNode
   sub?: ReactNode
 }) {
   return (
-    <div className="mb-12 md:mb-16">
-      <div className="label-x mb-5 flex items-center gap-3">
-        <span className="text-acc">{'//'}</span>
-        <span>
-          {index} — {tag}
-        </span>
-        <span className="h-px flex-1 bg-[var(--line)]" />
-        <span className="hidden sm:inline text-[var(--ghost)]">blink(1)</span>
-      </div>
-      <h2 className="text-[26px] md:text-[38px] font-bold leading-[1.12] tracking-[-0.02em] text-[var(--text)] max-w-3xl">
+    <div className="mb-10 md:mb-12">
+      {tag && (
+        <div className="label-x mb-4 flex items-center gap-3">
+          <span className="text-acc" aria-hidden>
+            {'//'}
+          </span>
+          <span>{tag}</span>
+          <span className="h-px flex-1 bg-[var(--line)]" aria-hidden />
+        </div>
+      )}
+      <h2 className="text-[24px] md:text-[32px] font-bold leading-[1.15] tracking-[-0.02em] text-[var(--text)] max-w-2xl text-balance">
         {title}
       </h2>
       {sub && (
-        <p className="mt-4 max-w-2xl text-[13px] md:text-[14px] leading-[1.75] text-dimx">{sub}</p>
+        <div className="mt-3 max-w-xl text-[13px] md:text-[14px] leading-[1.7] text-dimx">{sub}</div>
       )}
     </div>
   )
@@ -74,7 +119,7 @@ export function PrimaryButton({
       href={href}
       target="_blank"
       rel="noreferrer"
-      className="group inline-flex h-11 items-center gap-2.5 rounded-[6px] bg-[var(--acc)] px-5 text-[13px] font-bold text-[var(--on-acc)] transition-all hover:brightness-110 hover:shadow-[0_0_28px_rgba(var(--acc-rgb),0.35)]"
+      className="group inline-flex h-11 items-center gap-2.5 rounded-[6px] bg-[var(--acc)] px-5 text-[13px] font-bold text-[var(--on-acc)] transition-[filter,box-shadow,transform] duration-150 hover:brightness-110 hover:shadow-[0_10px_28px_-8px_rgba(var(--acc-rgb),0.55)] active:translate-y-px"
     >
       {children}
     </a>
@@ -93,7 +138,7 @@ export function GhostButton({
       href={href}
       target="_blank"
       rel="noreferrer"
-      className="inline-flex h-11 items-center gap-2.5 rounded-[6px] border border-line2x bg-[var(--panel)] px-5 text-[13px] font-medium text-dimx transition-all hover:border-[#3f3f48] hover:text-[var(--text)]"
+      className="inline-flex h-11 items-center gap-2.5 rounded-[6px] border border-line2x bg-[var(--panel)] px-5 text-[13px] font-medium text-dimx transition-colors duration-150 hover:border-[var(--line-2)] hover:bg-panel2x hover:text-[var(--text)] active:translate-y-px"
     >
       {children}
     </a>
@@ -106,7 +151,7 @@ export function Chip({ children, tone = 'default' }: { children: ReactNode; tone
   const tones = {
     default: 'border-line2x text-dimx',
     acc: 'border-[rgba(var(--acc-rgb),0.35)] text-acc bg-[var(--acc-soft)]',
-    amber: 'border-[rgba(255,195,95,0.35)] text-amberx bg-[rgba(255,195,95,0.08)]',
+    amber: 'border-[rgba(var(--acc-rgb),0.35)] text-acc bg-[var(--acc-soft)]',
   }
   return (
     <span className={`inline-flex items-center gap-1.5 rounded-[4px] border px-2 py-[3px] text-[11px] ${tones[tone]}`}>


### PR DESCRIPTION
## Summary
- Landing polish after 2.0.4: cream/black theme contrast, Hero cleanup, agent case study (last-24h desk narrative with quiet tools)
- Calmer board motion and fixed dual-pane desktop height
- Wire arach.dev GA (`G-GSHDZPFRZG`) on the static landing so blink.arach.dev shows in the same property

## Test plan
- [ ] `cd landing && bun run build` succeeds (static export)
- [ ] Cream and black themes both readable (tools, chrome, notes)
- [ ] Agent case study runs without layout jump; reduced-motion ok
- [ ] After deploy, Network shows `gtag/js?id=G-GSHDZPFRZG` and Realtime hits appear in arach.dev GA