### PR TITLE
✨ Add agent-ready web onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,83 +1,148 @@
 # AGENTS.md
 
-Blink v2 — native macOS spatial note-taking. Menubar-only app (LSUIElement):
-floating NSPanel notes + menubar popover + command palette. No main window.
-The v1 Tauri app remains at tag `v1-final` — port lessons, not code.
+## Blink in 60 seconds
 
-## Canonical references
+Blink is a native macOS spatial note-taking app. It is not a document library
+with detachable windows: **the note is the window, and the desktop is the
+workspace**.
 
-- Build plan (M0–M5): `docs/v2-plan.md` (local, untracked)
-- Feature spec / scope contract: `docs/functionality-v1.md` (local, untracked)
-- UI map: `docs/v2-ui-map.md` (local, untracked)
-- UI studies (visual spec): `design/studio` (local, untracked;
-  `bun dev` → localhost:3060/studio)
-- Config & theming (agent-first): `docs/config.md` — edit
-  `~/Library/Application Support/Blink/config.json` and Blink hot-applies it.
-  Agents configure the app through this file, not the GUI.
-- Notes representation (design conversation): `docs/notes-representation.md`
-  (local, untracked)
-- Notes CLI (agent-first): `docs/cli.md` — `blink ls/cat/new/search/rm/path`
-  over the same files; the app reconciles external writes live.
-- Notes Workspaces (agent-first): `docs/workspaces.md` — `blink workspace`
-  creates a named group of notes and brands it. Definition (title + brand) in
-  `config.json`; membership is one `blink.workspace` frontmatter key, so note
-  markdown stays portable. Brands are generic treatments — never hardcode a
-  specific product's identity into the app.
+The human loop is capture → place → recall:
+
+1. Create or find a note from the menubar popover, command palette, or global
+   new-note hotkey.
+2. The note opens as its one floating `NSPanel`; reopening it focuses that panel
+   rather than creating a duplicate.
+3. Move, resize, shade, or focus panels to arrange a working set. Blink restores
+   each note to the same place.
+4. Edit and read in the same panel. The menubar popover and command palette are
+   launchers, not alternate document windows.
+
+Blink is an `LSUIElement` menubar-only app: floating note panels + menubar
+popover + command palette, with no Dock icon and no main/library window. The v1
+Tauri app remains at tag `v1-final`; port lessons and behavior, never its code.
+
+When operating Blink rather than changing its code, use the `blink` CLI for
+notes and edit `config.json` for behavior/appearance. Drive the GUI only when a
+task specifically requires the live visual surface.
+
+## State model
+
+The markdown files are the durable truth for notes. Runtime note state
+converges through one path:
+
+```text
+panel edits / popover actions → PanelManager / AppModel → NoteStore → atomic .md
+CLI / external writes → same .md → directory watcher → NoteStore.reconcile()
+NoteStore notifications → AppModel snapshot → popover / palette / open panels
+```
+
+- Notes live at `~/Library/Application Support/Blink/Notes/<id>.md`, where `id`
+  is a unique title-derived slug. Body and metadata travel together in each
+  markdown file; metadata is YAML frontmatter. Unknown frontmatter must survive
+  round trips verbatim. UUIDv5 identity is derived only for v1 compatibility.
+- `NoteStore` owns note mutations and the in-memory index. `AppModel` mirrors it
+  for UI surfaces; it is not a second store.
+- `PanelManager` owns live windows, pending editor text, one-panel-per-note
+  identity, geometry, and save flushing. Do not bypass it for panel lifecycle.
+- Exact per-device panel frames (`NSWindow` frame autosave), the open-panel set,
+  and each note's read/edit mode live in `UserDefaults`. Portable
+  `blink.slot` frontmatter is placement intent; the autosaved frame is the
+  device-specific position. `NotePanel` suspends frame autosave while physics
+  owns a drag/fling/shade and persists the unshaded resting frame once settled.
+- External writers are first-class. The directory watcher calls
+  `NoteStore.reconcile()`, producing the same notifications as in-app edits.
+- `config.json` owns behavior and appearance and hot-applies independently of
+  note state. `BLINK_HOME` overrides the file-backed root (notes, config, and
+  attachments) for tests/agents; it does not redirect `UserDefaults`.
+
+## Source-of-truth order
+
+When documents disagree, use this order:
+
+1. Current code and tests describe shipped behavior.
+2. This file's hard requirements are non-regression constraints.
+3. `docs/cli.md`, `docs/config.md`, `docs/workspaces.md`, and `docs/release.md`
+   describe shipped agent-facing or release surfaces.
+4. `docs/placement.md` is mixed-status: the grid primitive is shipped; its
+   live-plane collision, scene, and tidy semantics are proposed.
+5. `docs/v2-plan.md`, `docs/v2-ui-map.md`, and
+   `docs/notes-representation.md` are local, untracked design references absent
+   from a fresh clone. They contain intent and history and may lag the code.
+6. `docs/agent-api.md` and `docs/agent-integration.md` are proposals, not
+   implemented surfaces.
+7. `docs/functionality-v1.md` is a local, untracked v1 inventory and
+   scope/lessons donor, not a description of the v2 codebase.
+
+Other useful references:
+
+- UI studies / visual spec: `design/studio` (local, untracked, and absent from
+  a fresh clone; `bun dev` → `localhost:3060/studio`).
+- The CLI operates on the same files as the app:
+  `blink ls/cat/new/present/type/write/search/rm/path/workspace`; see
+  `docs/cli.md`.
+- Agents configure Blink by editing
+  `~/Library/Application Support/Blink/config.json`, not by driving Settings;
+  see `docs/config.md`.
+- `blink workspace` defines a named treatment in `config.json`; membership is
+  one `blink.workspace` frontmatter key. See `docs/workspaces.md`. Brands are
+  generic treatments—never hardcode a specific product identity into Blink.
+
+## Where changes belong
+
+- `Sources/BlinkApp` — AppDelegate/status item/popover, command palette,
+  AppModel, PanelManager, NotePanel, config hot reload, and WebBridge.
+- `Sources/BlinkCore` — pure Swift with no AppKit: note model and identity,
+  frontmatter, atomic file storage, NoteStore, treatments, workspaces, and grid
+  math / panel physics.
+- `Sources/BlinkCLI` — `swift-argument-parser` CLI over BlinkCore. `BlinkPaths`
+  keeps the app and CLI on the same locations.
+- `Tests/BlinkCoreTests` — narrow tests for storage, frontmatter, identity,
+  workspaces, grid placement, and panel physics; run the matching suite for
+  domain changes.
+- `web/editor` — vanilla CodeMirror 6 (no React), bundled into one
+  `dist/editor.html` and hosted by each note panel. Load-bearing bridge contract:
+  `ready` / user-only `contentChanged` / `saveRequested` → native;
+  `setContent` / `getContent` / `focus` ← native.
+- Generic panel or web-bridge primitives should be shaped for eventual
+  HudsonKit upstreaming once proven here.
 
 ## Commands
 
 ```sh
 swift build                  # needs ../hudson checkout (BLINK_HUDSON_SOURCE=git for GitHub)
 swift test                   # BlinkCore tests
-swift build --product blink  # the notes CLI (docs/cli.md)
+swift build --product blink  # notes CLI (docs/cli.md)
 (cd web/editor && bun install && bun run build)   # editor bundle
 ./scripts/run-app.sh --debug --restart            # bundle dist/Blink.app + launch
 ```
 
-## Architecture
+## Hard requirements (inherited from v1 bugs)
 
-- `Sources/BlinkApp` — AppDelegate (NSStatusItem + NSPopover, Scout pattern),
-  HotkeyManager (Carbon, no accessibility permission needed), AppModel (the
-  single observable source of truth over NoteStore — every surface reads it),
-  PanelManager (one panel per note, save policy), NotePanel (glass NSPanel),
-  WebBridge (WKScriptMessageHandler ↔ editor bundle).
-- `Sources/BlinkCore` — pure Swift, no AppKit: Note model, slug + UUIDv5
-  identity (v1-compatible), minimal YAML frontmatter codec (preserves foreign
-  keys verbatim), atomic file store, NoteStore actor posting NotificationCenter
-  events (created/updated/deleted) + `reconcile()` for external writers.
-- `Sources/BlinkCLI` — the `blink` CLI (swift-argument-parser) over BlinkCore;
-  `BlinkPaths` (BLINK_HOME override) keeps app and CLI agreeing on locations.
-- `web/editor` — vanilla CodeMirror 6 (no React), single-file dist/editor.html,
-  four-message bridge: ready · contentChanged (user events ONLY) ·
-  saveRequested → native; setContent/getContent/focus ← native.
-- PanelKit and WebBridge are designed to be upstreamed to HudsonKit once proven.
-
-## Hard requirements (inherited from v1's bugs — do not regress)
-
-- Flush pending saves on note-switch, panel-close, and quit. Never trust a debounce alone.
-- All note writes are atomic: temp file + fsync + rename.
-- Note metadata lives in the markdown file's frontmatter, never only in a side index.
-- One panel per note — opening an open note focuses it.
-- Panel geometry persists per note and restores exactly; never scramble a layout.
-- Cross-surface sync is bidirectional: all mutations flow through NoteStore →
-  notifications → AppModel; never mutate UI state directly.
-- `contentChanged` fires on user edits only — programmatic setContent must never
-  echo (v1's cross-note corruption bug).
+- Flush pending saves on note-switch, panel-close, and quit. Never trust a
+  debounce alone.
+- All note writes are atomic: temp file + `fsync` + rename.
+- Note metadata lives in the markdown file's frontmatter, never only in a side
+  index. Preserve foreign frontmatter verbatim.
+- One panel per note—opening an open note focuses it.
+- Panel geometry persists per note and restores exactly; never scramble a
+  layout.
+- Note mutations flow through `NoteStore` → notifications → `AppModel`; never
+  mutate one UI surface as the source of truth.
+- `contentChanged` fires on user edits only. Programmatic `setContent` must
+  never echo (the v1 cross-note corruption bug).
 
 ## Conventions
 
-- **For larger initiatives/features, survey the ecosystem first**: check
-  HudsonKit (`../hudson/packages/native/apple/HudsonKit`) for primitives to
-  reuse, and lattices / talkie / scout (`../lattices`, `../talkie`,
-  `../openscout`) for working patterns to transplant. Blink hand-rolls only
-  what none of them have — and anything generic built here should be shaped
-  for upstreaming to HudsonKit. Small widgets/tweaks don't need the survey.
-  (Precedent: HotkeyManager came from Scout via Lattices; settings use
-  HudSettingsSection/Row; glass, palette, and observability are all Hudson.)
-
+- `AGENTS.md` and `CLAUDE.md` mirror the same instructions (apart from their
+  title); keep them in sync.
+- For larger initiatives/features, survey the ecosystem first: check HudsonKit
+  (`../hudson/packages/native/apple/HudsonKit`) for reusable primitives and
+  lattices / talkie / scout (`../lattices`, `../talkie`, `../openscout`) for
+  proven patterns. Small widgets/tweaks do not need the survey.
 - Log prefix `[BLINK]` via HudLogger (HudsonObservability).
-- Hyper = ⌃⌥⇧⌘. Global hotkeys via Carbon RegisterEventHotKey.
+- Hyper = ⌃⌥⇧⌘. Global hotkeys use Carbon `RegisterEventHotKey` and do not
+  require Accessibility permission.
 - User-visible name is "Blink".
 - GUI verification: LSUIElement apps are invisible to System Events' "visible
-  processes"; synthesized keystrokes go to the frontmost app — `tell
-  application "Blink" to activate` first, and use AXRaise for restored panels.
+  processes." Activate Blink before synthesized keystrokes, and use `AXRaise`
+  for restored panels.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,83 +1,148 @@
 # CLAUDE.md
 
-Blink v2 — native macOS spatial note-taking. Menubar-only app (LSUIElement):
-floating NSPanel notes + menubar popover + command palette. No main window.
-The v1 Tauri app remains at tag `v1-final` — port lessons, not code.
+## Blink in 60 seconds
 
-## Canonical references
+Blink is a native macOS spatial note-taking app. It is not a document library
+with detachable windows: **the note is the window, and the desktop is the
+workspace**.
 
-- Build plan (M0–M5): `docs/v2-plan.md` (local, untracked)
-- Feature spec / scope contract: `docs/functionality-v1.md` (local, untracked)
-- UI map: `docs/v2-ui-map.md` (local, untracked)
-- UI studies (visual spec): `design/studio` (local, untracked;
-  `bun dev` → localhost:3060/studio)
-- Config & theming (agent-first): `docs/config.md` — edit
-  `~/Library/Application Support/Blink/config.json` and Blink hot-applies it.
-  Agents configure the app through this file, not the GUI.
-- Notes representation (design conversation): `docs/notes-representation.md`
-  (local, untracked)
-- Notes CLI (agent-first): `docs/cli.md` — `blink ls/cat/new/search/rm/path`
-  over the same files; the app reconciles external writes live.
-- Notes Workspaces (agent-first): `docs/workspaces.md` — `blink workspace`
-  creates a named group of notes and brands it. Definition (title + brand) in
-  `config.json`; membership is one `blink.workspace` frontmatter key, so note
-  markdown stays portable. Brands are generic treatments — never hardcode a
-  specific product's identity into the app.
+The human loop is capture → place → recall:
+
+1. Create or find a note from the menubar popover, command palette, or global
+   new-note hotkey.
+2. The note opens as its one floating `NSPanel`; reopening it focuses that panel
+   rather than creating a duplicate.
+3. Move, resize, shade, or focus panels to arrange a working set. Blink restores
+   each note to the same place.
+4. Edit and read in the same panel. The menubar popover and command palette are
+   launchers, not alternate document windows.
+
+Blink is an `LSUIElement` menubar-only app: floating note panels + menubar
+popover + command palette, with no Dock icon and no main/library window. The v1
+Tauri app remains at tag `v1-final`; port lessons and behavior, never its code.
+
+When operating Blink rather than changing its code, use the `blink` CLI for
+notes and edit `config.json` for behavior/appearance. Drive the GUI only when a
+task specifically requires the live visual surface.
+
+## State model
+
+The markdown files are the durable truth for notes. Runtime note state
+converges through one path:
+
+```text
+panel edits / popover actions → PanelManager / AppModel → NoteStore → atomic .md
+CLI / external writes → same .md → directory watcher → NoteStore.reconcile()
+NoteStore notifications → AppModel snapshot → popover / palette / open panels
+```
+
+- Notes live at `~/Library/Application Support/Blink/Notes/<id>.md`, where `id`
+  is a unique title-derived slug. Body and metadata travel together in each
+  markdown file; metadata is YAML frontmatter. Unknown frontmatter must survive
+  round trips verbatim. UUIDv5 identity is derived only for v1 compatibility.
+- `NoteStore` owns note mutations and the in-memory index. `AppModel` mirrors it
+  for UI surfaces; it is not a second store.
+- `PanelManager` owns live windows, pending editor text, one-panel-per-note
+  identity, geometry, and save flushing. Do not bypass it for panel lifecycle.
+- Exact per-device panel frames (`NSWindow` frame autosave), the open-panel set,
+  and each note's read/edit mode live in `UserDefaults`. Portable
+  `blink.slot` frontmatter is placement intent; the autosaved frame is the
+  device-specific position. `NotePanel` suspends frame autosave while physics
+  owns a drag/fling/shade and persists the unshaded resting frame once settled.
+- External writers are first-class. The directory watcher calls
+  `NoteStore.reconcile()`, producing the same notifications as in-app edits.
+- `config.json` owns behavior and appearance and hot-applies independently of
+  note state. `BLINK_HOME` overrides the file-backed root (notes, config, and
+  attachments) for tests/agents; it does not redirect `UserDefaults`.
+
+## Source-of-truth order
+
+When documents disagree, use this order:
+
+1. Current code and tests describe shipped behavior.
+2. This file's hard requirements are non-regression constraints.
+3. `docs/cli.md`, `docs/config.md`, `docs/workspaces.md`, and `docs/release.md`
+   describe shipped agent-facing or release surfaces.
+4. `docs/placement.md` is mixed-status: the grid primitive is shipped; its
+   live-plane collision, scene, and tidy semantics are proposed.
+5. `docs/v2-plan.md`, `docs/v2-ui-map.md`, and
+   `docs/notes-representation.md` are local, untracked design references absent
+   from a fresh clone. They contain intent and history and may lag the code.
+6. `docs/agent-api.md` and `docs/agent-integration.md` are proposals, not
+   implemented surfaces.
+7. `docs/functionality-v1.md` is a local, untracked v1 inventory and
+   scope/lessons donor, not a description of the v2 codebase.
+
+Other useful references:
+
+- UI studies / visual spec: `design/studio` (local, untracked, and absent from
+  a fresh clone; `bun dev` → `localhost:3060/studio`).
+- The CLI operates on the same files as the app:
+  `blink ls/cat/new/present/type/write/search/rm/path/workspace`; see
+  `docs/cli.md`.
+- Agents configure Blink by editing
+  `~/Library/Application Support/Blink/config.json`, not by driving Settings;
+  see `docs/config.md`.
+- `blink workspace` defines a named treatment in `config.json`; membership is
+  one `blink.workspace` frontmatter key. See `docs/workspaces.md`. Brands are
+  generic treatments—never hardcode a specific product identity into Blink.
+
+## Where changes belong
+
+- `Sources/BlinkApp` — AppDelegate/status item/popover, command palette,
+  AppModel, PanelManager, NotePanel, config hot reload, and WebBridge.
+- `Sources/BlinkCore` — pure Swift with no AppKit: note model and identity,
+  frontmatter, atomic file storage, NoteStore, treatments, workspaces, and grid
+  math / panel physics.
+- `Sources/BlinkCLI` — `swift-argument-parser` CLI over BlinkCore. `BlinkPaths`
+  keeps the app and CLI on the same locations.
+- `Tests/BlinkCoreTests` — narrow tests for storage, frontmatter, identity,
+  workspaces, grid placement, and panel physics; run the matching suite for
+  domain changes.
+- `web/editor` — vanilla CodeMirror 6 (no React), bundled into one
+  `dist/editor.html` and hosted by each note panel. Load-bearing bridge contract:
+  `ready` / user-only `contentChanged` / `saveRequested` → native;
+  `setContent` / `getContent` / `focus` ← native.
+- Generic panel or web-bridge primitives should be shaped for eventual
+  HudsonKit upstreaming once proven here.
 
 ## Commands
 
 ```sh
 swift build                  # needs ../hudson checkout (BLINK_HUDSON_SOURCE=git for GitHub)
 swift test                   # BlinkCore tests
-swift build --product blink  # the notes CLI (docs/cli.md)
+swift build --product blink  # notes CLI (docs/cli.md)
 (cd web/editor && bun install && bun run build)   # editor bundle
 ./scripts/run-app.sh --debug --restart            # bundle dist/Blink.app + launch
 ```
 
-## Architecture
+## Hard requirements (inherited from v1 bugs)
 
-- `Sources/BlinkApp` — AppDelegate (NSStatusItem + NSPopover, Scout pattern),
-  HotkeyManager (Carbon, no accessibility permission needed), AppModel (the
-  single observable source of truth over NoteStore — every surface reads it),
-  PanelManager (one panel per note, save policy), NotePanel (glass NSPanel),
-  WebBridge (WKScriptMessageHandler ↔ editor bundle).
-- `Sources/BlinkCore` — pure Swift, no AppKit: Note model, slug + UUIDv5
-  identity (v1-compatible), minimal YAML frontmatter codec (preserves foreign
-  keys verbatim), atomic file store, NoteStore actor posting NotificationCenter
-  events (created/updated/deleted) + `reconcile()` for external writers.
-- `Sources/BlinkCLI` — the `blink` CLI (swift-argument-parser) over BlinkCore;
-  `BlinkPaths` (BLINK_HOME override) keeps app and CLI agreeing on locations.
-- `web/editor` — vanilla CodeMirror 6 (no React), single-file dist/editor.html,
-  four-message bridge: ready · contentChanged (user events ONLY) ·
-  saveRequested → native; setContent/getContent/focus ← native.
-- PanelKit and WebBridge are designed to be upstreamed to HudsonKit once proven.
-
-## Hard requirements (inherited from v1's bugs — do not regress)
-
-- Flush pending saves on note-switch, panel-close, and quit. Never trust a debounce alone.
-- All note writes are atomic: temp file + fsync + rename.
-- Note metadata lives in the markdown file's frontmatter, never only in a side index.
-- One panel per note — opening an open note focuses it.
-- Panel geometry persists per note and restores exactly; never scramble a layout.
-- Cross-surface sync is bidirectional: all mutations flow through NoteStore →
-  notifications → AppModel; never mutate UI state directly.
-- `contentChanged` fires on user edits only — programmatic setContent must never
-  echo (v1's cross-note corruption bug).
+- Flush pending saves on note-switch, panel-close, and quit. Never trust a
+  debounce alone.
+- All note writes are atomic: temp file + `fsync` + rename.
+- Note metadata lives in the markdown file's frontmatter, never only in a side
+  index. Preserve foreign frontmatter verbatim.
+- One panel per note—opening an open note focuses it.
+- Panel geometry persists per note and restores exactly; never scramble a
+  layout.
+- Note mutations flow through `NoteStore` → notifications → `AppModel`; never
+  mutate one UI surface as the source of truth.
+- `contentChanged` fires on user edits only. Programmatic `setContent` must
+  never echo (the v1 cross-note corruption bug).
 
 ## Conventions
 
-- **For larger initiatives/features, survey the ecosystem first**: check
-  HudsonKit (`../hudson/packages/native/apple/HudsonKit`) for primitives to
-  reuse, and lattices / talkie / scout (`../lattices`, `../talkie`,
-  `../openscout`) for working patterns to transplant. Blink hand-rolls only
-  what none of them have — and anything generic built here should be shaped
-  for upstreaming to HudsonKit. Small widgets/tweaks don't need the survey.
-  (Precedent: HotkeyManager came from Scout via Lattices; settings use
-  HudSettingsSection/Row; glass, palette, and observability are all Hudson.)
-
+- `AGENTS.md` and `CLAUDE.md` mirror the same instructions (apart from their
+  title); keep them in sync.
+- For larger initiatives/features, survey the ecosystem first: check HudsonKit
+  (`../hudson/packages/native/apple/HudsonKit`) for reusable primitives and
+  lattices / talkie / scout (`../lattices`, `../talkie`, `../openscout`) for
+  proven patterns. Small widgets/tweaks do not need the survey.
 - Log prefix `[BLINK]` via HudLogger (HudsonObservability).
-- Hyper = ⌃⌥⇧⌘. Global hotkeys via Carbon RegisterEventHotKey.
+- Hyper = ⌃⌥⇧⌘. Global hotkeys use Carbon `RegisterEventHotKey` and do not
+  require Accessibility permission.
 - User-visible name is "Blink".
 - GUI verification: LSUIElement apps are invisible to System Events' "visible
-  processes"; synthesized keystrokes go to the frontmost app — `tell
-  application "Blink" to activate` first, and use AXRaise for restored panels.
+  processes." Activate Blink before synthesized keystrokes, and use `AXRaise`
+  for restored panels.

--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -12,12 +12,20 @@ const jetBrainsMono = JetBrains_Mono({
 })
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://blink.arach.dev"),
   title: "Blink — Spatial notes for your Mac",
   description:
     "A native macOS menubar app. Summon a borderless glass note anywhere with a keystroke, place it in space, and it stays. Plain markdown you own — open to your agents.",
   keywords:
     "macOS notes, menubar app, spatial notes, floating notes, markdown, keyboard-first, agent-first, native app",
   authors: [{ name: "Blink" }],
+  alternates: {
+    canonical: "/",
+    types: {
+      "text/plain": [{ url: "/llms.txt", title: "Blink for language models" }],
+      "text/markdown": [{ url: "/agents.md", title: "Blink agent instructions" }],
+    },
+  },
   openGraph: {
     title: "Blink — Spatial notes for your Mac",
     description:

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -5,6 +5,7 @@ import Hero from "@/components/homepage/Hero"
 import { SpecStrip } from "@/components/homepage/Architecture"
 import Sheets from "@/components/homepage/Sheets"
 import FilesystemAPI from "@/components/homepage/FilesystemAPI"
+import AgentGuide from "@/components/homepage/AgentGuide"
 import AgentCaseStudy from "@/components/homepage/AgentCaseStudy"
 import Keys from "@/components/homepage/Keys"
 import { Install, Footer } from "@/components/homepage/Install"
@@ -17,6 +18,7 @@ export default function Home() {
         <Hero />
         <SpecStrip />
         <FilesystemAPI />
+        <AgentGuide />
         <AgentCaseStudy />
         <Sheets />
         <Keys />

--- a/landing/components/homepage/AgentGuide.tsx
+++ b/landing/components/homepage/AgentGuide.tsx
@@ -1,0 +1,133 @@
+import { Reveal, SectionHeader } from './shared'
+
+const DOCS = [
+  {
+    href: '/llms.txt',
+    label: 'llms.txt',
+    detail: 'product map + canonical links',
+  },
+  {
+    href: '/agents.md',
+    label: 'agents.md',
+    detail: 'complete operating contract',
+  },
+  {
+    href: 'https://github.com/arach/blink/blob/main/docs/cli.md',
+    label: 'CLI reference',
+    detail: 'commands + JSON shapes',
+  },
+]
+
+const CONTRACT = [
+  {
+    term: 'Use the CLI',
+    detail: 'Prefer blink over GUI automation. It handles slugs, atomic writes, stdin, and structured output.',
+  },
+  {
+    term: 'Files are truth',
+    detail: 'Every note is one Markdown file. Metadata and portable placement intent travel in YAML frontmatter.',
+  },
+  {
+    term: 'Choose the verb',
+    detail: 'present creates or composes; type adds a visible update; write quietly replaces; cat and search read.',
+  },
+  {
+    term: 'App optional',
+    detail: 'Writes still land while Blink is closed. The app reconciles them when it is running or next opens.',
+  },
+  {
+    term: 'Configure by file',
+    detail: 'Edit ~/Library/Application Support/Blink/config.json for behavior, appearance, styles, and workspaces. Valid changes hot-apply.',
+  },
+]
+
+export default function AgentGuide() {
+  return (
+    <section id="agents" className="scroll-mt-16 border-t border-linex py-20 md:py-28">
+      <div className="mx-auto max-w-5xl px-4 md:px-6">
+        <SectionHeader
+          tag="FOR AGENTS"
+          title={
+            <>
+              The whole operating contract, <span className="text-acc">without the GUI.</span>
+            </>
+          }
+          sub="Install once, use predictable verbs, and drop to plain Markdown whenever the abstraction gets in the way. These are the stable entry points an agent can discover and act on."
+        />
+
+        <Reveal>
+          <nav
+            aria-label="Agent documentation"
+            className="grid border-y border-linex sm:grid-cols-3"
+          >
+            {DOCS.map((doc, index) => (
+              <a
+                key={doc.href}
+                href={doc.href}
+                target="_blank"
+                rel="noreferrer"
+                className={[
+                  'group flex min-w-0 items-center justify-between gap-4 py-4 transition-colors hover:bg-[var(--acc-soft)] focus-visible:bg-[var(--acc-soft)]',
+                  index > 0 ? 'border-t border-linex sm:border-l sm:border-t-0' : '',
+                  index === 0 ? 'sm:pr-5' : 'sm:px-5',
+                  index === DOCS.length - 1 ? 'sm:pr-0' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                <span className="min-w-0">
+                  <span className="block text-[12.5px] font-bold text-[var(--text)]">{doc.label}</span>
+                  <span className="mt-1 block text-[10.5px] leading-[1.5] text-faintx">{doc.detail}</span>
+                </span>
+                <span className="shrink-0 text-[14px] text-faintx transition-transform group-hover:translate-x-0.5" aria-hidden>
+                  ↗
+                </span>
+              </a>
+            ))}
+          </nav>
+
+          <div className="mt-8 grid items-start gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:gap-12">
+            <div className="overflow-hidden rounded-[8px] border border-linex bg-panelx">
+              <div className="flex items-center justify-between border-b border-linex bg-panel2x px-4 py-2.5">
+                <span className="text-[11px] font-medium text-[var(--text)]">zero → spatial note</span>
+                <span className="text-[10px] text-faintx">macOS 14+ · arm64</span>
+              </div>
+              <div className="overflow-x-auto p-4 md:p-5">
+                <pre className="min-w-[520px] text-[11.5px] leading-[1.9] text-dimx">
+                  <code>{`npm install -g @arach/blink
+blink app install
+blink app open
+
+blink present q3-plan $'# Q3 plan\\n\\nShip it.' \\
+  --slot 6 --style focus --json`}</code>
+                </pre>
+              </div>
+              <div className="border-t border-linex px-4 py-3 text-[10.5px] leading-[1.6] text-faintx md:px-5">
+                <span className="text-dimx">notes → </span>
+                <span className="break-all">~/Library/Application Support/Blink/Notes/</span>
+              </div>
+            </div>
+
+            <dl className="border-t border-linex">
+              {CONTRACT.map((item) => (
+                <div key={item.term} className="grid gap-1 border-b border-linex py-4 sm:grid-cols-[8.5rem_1fr] sm:gap-5">
+                  <dt className="text-[11.5px] font-bold text-[var(--text)]">{item.term}</dt>
+                  <dd className="text-[11px] leading-[1.65] text-dimx">{item.detail}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          <div className="mt-6 flex flex-col gap-2 text-[10.5px] leading-[1.65] text-faintx sm:flex-row sm:items-center sm:justify-between">
+            <span>
+              Core verbs: <span className="text-dimx">ls · cat · new · present · type · write · search · rm · path · workspace</span>
+            </span>
+            <span>
+              Sandbox with <span className="text-dimx">BLINK_HOME</span>
+            </span>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  )
+}

--- a/landing/components/homepage/Chrome.tsx
+++ b/landing/components/homepage/Chrome.tsx
@@ -3,6 +3,7 @@ import { BlinkMark } from './BlinkMark'
 
 const LINKS = [
   { href: '#how', label: 'how' },
+  { href: '#agents', label: 'agents' },
   { href: '#desk', label: 'desk' },
   { href: '#keys', label: 'keys' },
   { href: '#install', label: 'install' },

--- a/landing/components/homepage/Install.tsx
+++ b/landing/components/homepage/Install.tsx
@@ -60,6 +60,18 @@ export function Footer() {
           </div>
           <div className="flex items-center gap-5 text-[11px] text-dimx">
             <a
+              href="/agents.md"
+              className="hover:text-acc transition-colors"
+            >
+              agents.md
+            </a>
+            <a
+              href="/llms.txt"
+              className="hover:text-acc transition-colors"
+            >
+              llms.txt
+            </a>
+            <a
               href="https://github.com/arach/blink"
               target="_blank"
               rel="noreferrer"

--- a/landing/public/agents.md
+++ b/landing/public/agents.md
@@ -1,0 +1,183 @@
+# Blink — instructions for agents
+
+Blink is a native macOS spatial note-taking app. It is designed to be operated by humans and agents through the same local files.
+
+The product model is simple: **the note is the window, and the desktop is the workspace**. A note is one floating panel in the running app and one Markdown file on disk. Opening an already-open note focuses its existing panel rather than creating a duplicate.
+
+## Choose the right surface
+
+- Operating Blink: use the `blink` CLI for notes and `config.json` for behavior and appearance.
+- Reading or writing content: prefer CLI commands; plain file access is the lower-level escape hatch.
+- Verifying live appearance or placement: use the GUI only when the task requires the rendered visual surface.
+- Developing Blink itself: read the repository's `AGENTS.md` before changing code.
+
+Do not assume a Unix socket, MCP server, or live streaming API exists. Those surfaces are proposed, not shipped. The CLI and filesystem are the stable agent interfaces today.
+
+## Requirements and install
+
+- macOS 14 or newer
+- Apple Silicon
+- Node.js 18 or newer for the npm shims
+
+```sh
+npm install -g @arach/blink
+blink app install
+blink app open
+```
+
+The npm package includes the signed native CLI. `blink app install` fetches and validates the signed, notarized Blink app before installing it in `/Applications`.
+
+Check the installed CLI when version-sensitive behavior matters:
+
+```sh
+blink --version
+npm view @arach/blink version
+```
+
+## File layout
+
+Default file-backed root:
+
+```text
+~/Library/Application Support/Blink/
+├── Notes/
+│   └── <id>.md
+├── config.json
+└── attachments/
+```
+
+When `BLINK_HOME` is set, Blink uses `$BLINK_HOME/Notes`, `$BLINK_HOME/config.json`, and `$BLINK_HOME/attachments` instead. Use this for isolated tests and automation.
+
+`BLINK_HOME` does not redirect device-local `UserDefaults`. Exact panel frames, the open-panel set, and per-note read/edit mode remain Mac-local state.
+
+## Note model
+
+- One Markdown file is one note.
+- The filename stem and frontmatter `id` are a unique title-derived slug.
+- The title is derived from the first meaningful content line.
+- Note metadata and portable presentation live in YAML frontmatter.
+- Unknown or foreign frontmatter must survive round trips.
+- Portable placement intent such as `blink.slot` lives in frontmatter.
+- Exact pixel geometry is device-local and must never be substituted for portable placement intent.
+
+Example:
+
+```md
+---
+id: q3-plan
+blink:
+  style: focus
+  accent: "#7dd3fc"
+  slot: 6
+---
+# Q3 plan
+
+Ship something people love.
+```
+
+## Core commands
+
+```sh
+blink ls [--limit N] [--json]
+blink cat <id> [--json]
+blink new [text ...] [--json]
+blink present <id> [text ...] [presentation options] [--json]
+blink append <id> [text ...] [--json]
+blink type <id> [text ...] [--json]
+blink write <id> [text ...] [--json]
+blink search <query> [--json]
+blink rm <id> [--json]
+blink path [<id>]
+blink workspace <subcommand>
+```
+
+Commands accept stdin where content is optional. Prefer stdin when exact whitespace or multi-line Markdown matters.
+
+### Choose the correct write verb
+
+- `blink new`: create a note and let Blink assign a unique slug.
+- `blink present`: get or create a known id while changing content, presentation, and placement together. This is the default composition verb.
+- `blink type`: append a visible update. If the panel is open, Blink reveals the appended suffix as typed text.
+- `blink append`: the established sibling of `type`; it also appends a visible update.
+- `blink write`: quietly replace an existing note's body. Use only when full replacement is intended.
+- `blink rm`: delete a note. Use only when deletion is explicitly intended.
+
+## Common workflows
+
+Create and place a complete note:
+
+```sh
+blink present q3-plan $'# Q3 plan\n\nShip something people love.' \
+  --style focus --slot 6 --json
+```
+
+Read, search, and inspect paths:
+
+```sh
+blink ls --json
+blink cat q3-plan
+blink search "launch" --json
+blink path q3-plan
+```
+
+Add a visible update without replacing the note:
+
+```sh
+printf '%s\n' '- rollout is green' | blink type q3-plan --json
+```
+
+Quietly replace the body from a file:
+
+```sh
+blink write q3-plan < revised-q3-plan.md
+```
+
+Create and use a named workspace:
+
+```sh
+blink workspace init "Acme Docs"
+blink new --workspace acme-docs "# Q3 planning"
+blink workspace notes acme-docs --json
+```
+
+A workspace is a generic group plus treatment. Its definition lives in `config.json`; note membership is one `blink.workspace` frontmatter key.
+
+## Configuration
+
+Edit:
+
+```text
+~/Library/Application Support/Blink/config.json
+```
+
+Blink watches the file and hot-applies valid changes to behavior, hotkeys, panels, appearance, motion, editor styling, named styles, and workspaces. Prefer this file to driving the Settings UI.
+
+Full reference: https://github.com/arach/blink/blob/main/docs/config.md
+
+## Safety rules
+
+1. Prefer CLI mutations. Blink's write path is atomic: temporary file, `fsync`, rename.
+2. Preserve note content and frontmatter you do not own.
+3. Do not replace a full note when an append or presentation-only change is enough.
+4. If a user has unsaved text in an open panel, the user's text wins over an external edit.
+5. Never move or rewrite device-local panel geometry casually. Spatial memory is part of the product contract.
+6. Opening an open note should focus it, never create a duplicate.
+7. Use `BLINK_HOME` for isolated automation that must not touch the user's real note files.
+8. Treat workspaces as generic treatments; do not bake a third-party product identity into Blink.
+
+## Runtime behavior
+
+External writes are first-class. The running app watches the Notes directory, calls `NoteStore.reconcile()`, and emits the same created/updated/deleted notifications as in-app changes. The menubar, command palette, and open panels then update from the same runtime path.
+
+If Blink is closed, CLI writes still succeed. The note is available when the app next opens.
+
+## Canonical references
+
+- Website: https://blink.arach.dev/
+- LLM overview: https://blink.arach.dev/llms.txt
+- Repository: https://github.com/arach/blink
+- CLI: https://github.com/arach/blink/blob/main/docs/cli.md
+- Config: https://github.com/arach/blink/blob/main/docs/config.md
+- Workspaces: https://github.com/arach/blink/blob/main/docs/workspaces.md
+- Releases: https://github.com/arach/blink/releases/latest
+- Development instructions: https://github.com/arach/blink/blob/main/AGENTS.md

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -1,0 +1,72 @@
+# Blink
+
+> Native spatial notes for macOS. Each note is a floating panel on the desktop and a local Markdown file that humans and agents can safely share.
+
+Homepage: https://blink.arach.dev/
+Repository: https://github.com/arach/blink
+Releases: https://github.com/arach/blink/releases/latest
+Agent instructions: https://blink.arach.dev/agents.md
+CLI reference: https://github.com/arach/blink/blob/main/docs/cli.md
+Configuration reference: https://github.com/arach/blink/blob/main/docs/config.md
+Workspace reference: https://github.com/arach/blink/blob/main/docs/workspaces.md
+
+## Product model
+
+- Blink is a macOS 14+ Apple Silicon menubar app built with Swift and AppKit.
+- The note is the window; the desktop is the workspace.
+- There is no main library window, cloud account, side database, or Electron runtime.
+- One note equals one Markdown file with YAML frontmatter.
+- The app, CLI, and external writers converge on the same files.
+
+## Install
+
+```sh
+npm install -g @arach/blink
+blink app install
+blink app open
+```
+
+The npm package requires Node.js 18+ and includes the native `blink` CLI. `blink app install` installs the signed and notarized macOS app.
+
+## Agent entry points
+
+- Use the `blink` CLI for note operations. Prefer it to GUI automation.
+- Edit `~/Library/Application Support/Blink/config.json` for behavior and appearance; valid changes hot-apply.
+- Read `/agents.md` for the complete operating contract, examples, paths, and safety rules.
+- Set `BLINK_HOME` to isolate the file-backed Blink root for tests or automation.
+
+## Core CLI
+
+```text
+blink ls
+blink cat <id>
+blink new [text]
+blink present <id> [text] [--style ... --slot 1-9] [--json]
+blink type <id> [text]
+blink write <id> [text]
+blink search <query>
+blink rm <id>
+blink path [<id>]
+blink workspace <subcommand>
+```
+
+`present` composes content, presentation, and placement. `type` appends an update that an open panel reveals visibly. `write` quietly replaces the body. Use `--json` when structured output is available and stdin for exact multi-line content.
+
+## Paths and truth
+
+```text
+~/Library/Application Support/Blink/
+├── Notes/<id>.md       note content + YAML frontmatter
+├── config.json         behavior, appearance, styles, workspaces
+└── attachments/        note media and installed workspace marks
+```
+
+The Markdown files are note truth. Portable placement intent such as `blink.slot` lives in frontmatter. Exact panel frames, open-panel state, and per-note read/edit mode are device-local state, not part of `BLINK_HOME`.
+
+## Safety and current status
+
+- Prefer CLI writes because they are atomic and preserve Blink and foreign frontmatter.
+- External file edits reconcile live; if an open panel has unsaved user text, the user wins.
+- Use `blink rm` only when deletion is explicitly intended.
+- Workspaces are generic groups and treatments; never hardcode another product's brand into Blink.
+- A Unix socket, MCP server, and streaming live-plane API are proposals, not shipped interfaces. Use the CLI and files today.


### PR DESCRIPTION
## Summary

- front-load the Blink product and state mental model in AGENTS.md and CLAUDE.md
- publish `/llms.txt` and `/agents.md` with install, CLI, paths, safety rules, and canonical references
- add a responsive For Agents section plus navigation, footer, and metadata discovery links

## Verification

- `diff <(tail -n +2 AGENTS.md) <(tail -n +2 CLAUDE.md)`
- `bunx tsc --noEmit --incremental false`
- `bun run build`
- live browser checks at desktop and mobile widths in cream and black themes
- no runtime errors, horizontal overflow, or Impeccable detector findings
- static export contains byte-identical `agents.md` and `llms.txt`

## Release

This is a documentation and landing-site shipment; no app or npm version changes are required. Merge to `main` triggers the canonical GitHub Pages deployment.