### PR TITLE
✨ Ship Blink 2.0.5 canvas and utility polish

### DIFF
--- a/Sources/BlinkApp/AppDelegate.swift
+++ b/Sources/BlinkApp/AppDelegate.swift
@@ -129,7 +129,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
 
         appItem("Commands…", action: #selector(menuCommands), keyEquivalent: "k")
-        appItem("Blink Guide", action: #selector(menuGuide), keyEquivalent: "?", modifiers: [.command])
+        appItem(
+            "Help & Shortcuts",
+            action: #selector(menuGuide),
+            keyEquivalent: "?",
+            modifiers: [.command]
+        )
         appMenu.addItem(.separator())
         appItem("Settings…", action: #selector(menuSettings), keyEquivalent: ",")
         appMenu.addItem(.separator())
@@ -497,10 +502,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     private func openGuide() {
         guard let activities = activityCatalog?.activities else { return }
+        // Blink owns one durable utility surface at a time. Commands remains a
+        // transient interstitial; Help and Settings replace one another instead
+        // of accumulating as unrelated document windows on the desktop.
+        commandPaletteController?.dismiss()
+        settingsWindow?.orderOut(nil)
         if guideWindow == nil {
             let host = NSHostingController(rootView: BlinkGuideView(activities: activities))
             let window = NSWindow(contentViewController: host)
-            window.title = "Blink Guide"
+            window.title = "Blink Help & Shortcuts"
             window.styleMask = [.titled, .closable, .resizable]
             window.setContentSize(NSSize(width: 780, height: 610))
             window.contentMinSize = NSSize(width: 720, height: 520)
@@ -514,6 +524,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     private func openSettings() {
+        commandPaletteController?.dismiss()
+        guideWindow?.orderOut(nil)
         if settingsWindow == nil {
             let host = NSHostingController(
                 rootView: SettingsView(store: .shared, notesDirectory: Self.notesDirectory())

--- a/Sources/BlinkApp/BlinkActivityCatalog.swift
+++ b/Sources/BlinkApp/BlinkActivityCatalog.swift
@@ -48,8 +48,8 @@ enum BlinkActivityID: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
-/// Educational grouping used by the Guide. The order of `allCases` is the
-/// intended presentation order.
+/// Capability grouping used by command search and reference metadata. The
+/// order of `allCases` is the intended presentation order.
 enum BlinkActivityGroup: String, CaseIterable, Identifiable {
     case capture = "Capture"
     case findAndOpen = "Find & Open"
@@ -359,13 +359,13 @@ private extension BlinkActivityCatalog {
             ),
             BlinkActivity(
                 id: .openGuide,
-                title: "Blink Guide",
-                description: "See every activity, gesture, and keyboard action.",
+                title: "Help & Shortcuts",
+                description: "Learn Blink's workspace model and review every shortcut.",
                 symbolName: "questionmark.circle",
                 group: .findAndOpen,
                 scope: .application,
                 keywords: ["help", "hints", "shortcuts", "learn"],
-                shortcut: fixed("?"),
+                shortcut: fixed("⌘?"),
                 availability: actionAvailability(h.openGuide),
                 execution: h.openGuide
             ),

--- a/Sources/BlinkApp/BlinkCommandPalette.swift
+++ b/Sources/BlinkApp/BlinkCommandPalette.swift
@@ -1,5 +1,5 @@
 // THESIS: Command-K is Blink's fastest path from intent to a note or action.
-// OWN-WORLD: A compact terminal-like graphite/paper panel with one warm signal color.
+// OWN-WORLD: A compact terminal-like graphite/paper panel with one cool signal color.
 // STORY: Type freely, scan Notes and Actions, then run the highlighted result with Return.
 // FIRST VIEWPORT: Live-state strip, decisive search field, grouped results, terse key legend.
 // FORM: A dedicated centered key panel, native to Blink's menubar and floating-panel architecture.

--- a/Sources/BlinkApp/BlinkConfig.swift
+++ b/Sources/BlinkApp/BlinkConfig.swift
@@ -360,10 +360,10 @@ struct BlinkConfig: Codable, Equatable {
             vars["--blink-text"] = "rgba(28,26,24,0.86)"
             vars["--blink-text-strong"] = "rgba(18,17,16,0.98)"
             vars["--blink-text-muted"] = "rgba(60,56,52,0.55)"
-            vars["--blink-accent"] = "#c2410c"  // deepened amber; reads on light
+            vars["--blink-accent"] = "#2d5daf"
             vars["--blink-code-bg"] = "rgba(20,18,16,0.06)"
-            vars["--blink-caret"] = "#c2410c"
-            vars["--blink-selection"] = "rgba(194,65,12,0.22)"
+            vars["--blink-caret"] = "#2d5daf"
+            vars["--blink-selection"] = "rgba(45,93,175,0.20)"
         }
         if let v = editor.fontFamily { vars["--blink-font-family"] = v }
         if let v = editor.monoFamily { vars["--blink-mono-family"] = v }

--- a/Sources/BlinkApp/BlinkGuideView.swift
+++ b/Sources/BlinkApp/BlinkGuideView.swift
@@ -1,37 +1,36 @@
-// THESIS: Blink's Guide is a field manual for a spatial tool, not a settings appendix.
-// OWN-WORLD: A quiet graphite/paper surface, fine spatial grid, warm signal-orange, mono labels.
-// STORY: Learn the things Blink can do, then scan every key by the place where it works.
-// FIRST VIEWPORT: A narrow navigator anchors two dense, legible reference pages.
+// THESIS: Blink Help explains the workspace model; Commands executes and Settings configures.
+// OWN-WORLD: A quiet graphite/paper surface, fine spatial grid, cool signal-blue, mono labels.
+// STORY: Understand capture → place → recall, then scan every key by where it works.
+// FIRST VIEWPORT: A narrow navigator anchors orientation and shortcut reference pages.
 // FORM: An established-world extension of Blink's terminal canvas and Hudson's native tokens.
 
 import SwiftUI
 import HudsonUI
 
-/// Blink's educational surface. The catalog supplies live names, shortcuts, and
-/// scopes; the small interaction field manual supplies gestures that are not
-/// executable commands and therefore do not belong in the palette.
+/// Blink's educational surface. Commands owns executable discovery; this view
+/// explains the spatial model and keeps live shortcuts and gestures readable.
 @MainActor
 struct BlinkGuideView: View {
     enum Page: String, CaseIterable, Identifiable {
-        case activities
+        case basics
         case shortcuts
 
         var id: Self { self }
         var title: String {
             switch self {
-            case .activities: "Activities"
+            case .basics: "Start Here"
             case .shortcuts: "All Shortcuts"
             }
         }
         var subtitle: String {
             switch self {
-            case .activities: "What Blink can do"
+            case .basics: "How Blink fits together"
             case .shortcuts: "Keys grouped by scope"
             }
         }
         var symbolName: String {
             switch self {
-            case .activities: "sparkles"
+            case .basics: "rectangle.3.group"
             case .shortcuts: "command"
             }
         }
@@ -39,7 +38,7 @@ struct BlinkGuideView: View {
 
     let activities: [BlinkActivity]
 
-    @State private var page: Page = .activities
+    @State private var page: Page = .basics
     @ObservedObject private var appearance = AppearanceManager.shared
 
     private var palette: BlinkDiscoveryPalette {
@@ -57,7 +56,7 @@ struct BlinkGuideView: View {
         .background(BlinkDiscoveryBackdrop(palette: palette))
         .preferredColorScheme(appearance.scheme == .dark ? .dark : .light)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Blink Guide")
+        .accessibilityLabel("Blink Help and Shortcuts")
     }
 
     private var navigator: some View {
@@ -71,13 +70,13 @@ struct BlinkGuideView: View {
                         .background(palette.accentSoft)
                         .clipShape(RoundedRectangle(cornerRadius: HudRadius.standard))
 
-                    Text("BLINK GUIDE")
+                    Text("BLINK HELP")
                         .font(HudFont.mono(HudTextSize.xs, weight: .semibold))
                         .tracking(HudTracking.wider)
                         .foregroundStyle(palette.ink)
                 }
 
-                Text("A field manual for your note desk.")
+                Text("Learn the workspace, then keep its keys close.")
                     .font(HudFont.ui(HudTextSize.xs))
                     .foregroundStyle(palette.muted)
                     .fixedSize(horizontal: false, vertical: true)
@@ -139,28 +138,23 @@ struct BlinkGuideView: View {
     @ViewBuilder
     private var detail: some View {
         switch page {
-        case .activities:
-            activitiesPage
+        case .basics:
+            basicsPage
         case .shortcuts:
             shortcutsPage
         }
     }
 
-    private var activitiesPage: some View {
+    private var basicsPage: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: HudSpacing.huge) {
                 pageHeader(
-                    title: "Activities",
-                    subtitle: "Everything Blink lets you capture, find, arrange, and shape."
+                    title: "How Blink Works",
+                    subtitle: "The note is the window, and the desktop is the workspace."
                 )
 
-                ForEach(BlinkActivityGroup.allCases) { group in
-                    let entries = activities.filter { $0.group == group }
-                    if !entries.isEmpty {
-                        activitySection(group: group, entries: entries)
-                    }
-                }
-
+                conceptSection(title: "THE CORE LOOP", rows: coreLoop)
+                conceptSection(title: "CHOOSE THE RIGHT SURFACE", rows: utilitySurfaces)
             }
             .padding(.horizontal, HudSpacing.huge)
             .padding(.vertical, HudSpacing.xxxl)
@@ -169,16 +163,69 @@ struct BlinkGuideView: View {
         .scrollIndicators(.automatic)
     }
 
-    private func activitySection(group: BlinkActivityGroup, entries: [BlinkActivity]) -> some View {
+    private var coreLoop: [GuideConcept] {
+        [
+            GuideConcept(
+                id: "capture",
+                symbolName: "plus.rectangle.on.rectangle",
+                title: "Capture",
+                detail: "Create or find a note from the menubar popover, Commands, or the global new-note shortcut."
+            ),
+            GuideConcept(
+                id: "place",
+                symbolName: "macwindow.on.rectangle",
+                title: "Place",
+                detail: "A note opens as its one floating panel. Move, resize, shade, or focus it directly on the desktop."
+            ),
+            GuideConcept(
+                id: "recall",
+                symbolName: "arrow.uturn.forward",
+                title: "Recall",
+                detail: "Reopening a note focuses the same panel, and Blink restores its position on this Mac."
+            ),
+        ]
+    }
+
+    private var utilitySurfaces: [GuideConcept] {
+        [
+            GuideConcept(
+                id: "commands",
+                symbolName: "command",
+                title: "Commands — do",
+                detail: "Find a note or run one available action. The launcher closes after your choice.",
+                shortcut: shortcut(for: .commandPalette)
+            ),
+            GuideConcept(
+                id: "help",
+                symbolName: "questionmark.circle",
+                title: "Help & Shortcuts — learn",
+                detail: "Keep the workspace model, gestures, and current keyboard map open as a reference.",
+                shortcut: shortcut(for: .openGuide)
+            ),
+            GuideConcept(
+                id: "settings",
+                symbolName: "gearshape",
+                title: "Settings — configure",
+                detail: "Change Blink's behavior and appearance. Controls stay open while you tune them.",
+                shortcut: shortcut(for: .openSettings)
+            ),
+        ]
+    }
+
+    private func shortcut(for id: BlinkActivityID) -> String? {
+        activities.first(where: { $0.id == id })?.shortcutDisplay
+    }
+
+    private func conceptSection(title: String, rows: [GuideConcept]) -> some View {
         VStack(alignment: .leading, spacing: HudSpacing.md) {
-            HudSectionLabel(group.displayTitle, tint: palette.dim)
+            HudSectionLabel(title, tint: palette.dim)
 
             VStack(spacing: 0) {
-                ForEach(entries) { activity in
-                    activityRow(activity)
-                    if activity.id != entries.last?.id {
+                ForEach(rows) { row in
+                    conceptRow(row)
+                    if row.id != rows.last?.id {
                         HudDivider(color: palette.rule.opacity(0.72))
-                            .padding(.leading, 42)
+                            .padding(.leading, 48)
                     }
                 }
             }
@@ -191,9 +238,9 @@ struct BlinkGuideView: View {
         }
     }
 
-    private func activityRow(_ activity: BlinkActivity) -> some View {
+    private func conceptRow(_ concept: GuideConcept) -> some View {
         HStack(alignment: .top, spacing: HudSpacing.xl) {
-            Image(systemName: activity.symbolName)
+            Image(systemName: concept.symbolName)
                 .font(HudFont.ui(HudTextSize.base, weight: .medium))
                 .foregroundStyle(palette.accent)
                 .frame(width: 24, height: 24)
@@ -203,17 +250,16 @@ struct BlinkGuideView: View {
 
             VStack(alignment: .leading, spacing: HudSpacing.xs) {
                 HStack(alignment: .firstTextBaseline, spacing: HudSpacing.md) {
-                    Text(activity.title)
+                    Text(concept.title)
                         .font(HudFont.ui(HudTextSize.base, weight: .semibold))
                         .foregroundStyle(palette.ink)
-                    scopeLabel(activity.scope)
                     Spacer(minLength: 0)
-                    if let shortcut = activity.shortcutDisplay {
+                    if let shortcut = concept.shortcut {
                         BlinkKeyChip(shortcut, palette: palette)
                     }
                 }
 
-                Text(activity.description)
+                Text(concept.detail)
                     .font(HudFont.ui(HudTextSize.sm))
                     .foregroundStyle(palette.muted)
                     .fixedSize(horizontal: false, vertical: true)
@@ -299,13 +345,6 @@ struct BlinkGuideView: View {
         .accessibilityElement(children: .combine)
     }
 
-    private func scopeLabel(_ scope: BlinkActivityScope) -> some View {
-        Text(scope.displayTitle.uppercased())
-            .font(HudFont.mono(HudTextSize.micro, weight: .medium))
-            .tracking(HudTracking.wide)
-            .foregroundStyle(palette.dim)
-    }
-
     private func shortcutRows(for scope: BlinkActivityScope) -> [GuideShortcut] {
         var rows = activities
             .filter { $0.scope == scope }
@@ -332,6 +371,28 @@ struct BlinkGuideView: View {
             }
         }
         return rows
+    }
+}
+
+private struct GuideConcept: Identifiable {
+    let id: String
+    let symbolName: String
+    let title: String
+    let detail: String
+    var shortcut: String?
+
+    init(
+        id: String,
+        symbolName: String,
+        title: String,
+        detail: String,
+        shortcut: String? = nil
+    ) {
+        self.id = id
+        self.symbolName = symbolName
+        self.title = title
+        self.detail = detail
+        self.shortcut = shortcut
     }
 }
 
@@ -434,7 +495,7 @@ private struct GuideShortcut: Identifiable {
 }
 
 /// Shared discovery-surface colors. Hudson owns spacing, type, motion, and
-/// component geometry; Blink supplies the app-specific graphite/orange world.
+/// component geometry; Blink supplies the app-specific graphite/blue world.
 struct BlinkDiscoveryPalette {
     let bg: Color
     let chrome: Color
@@ -459,9 +520,9 @@ struct BlinkDiscoveryPalette {
                 muted: Color(red: 0.650, green: 0.665, blue: 0.665),
                 dim: Color(red: 0.455, green: 0.475, blue: 0.480),
                 rule: Color.white.opacity(0.10),
-                accent: Color(red: 1.0, green: 0.345, blue: 0.133),
+                accent: Color(red: 0.365, green: 0.620, blue: 0.980),
                 live: Color(red: 0.353, green: 0.820, blue: 0.608),
-                selection: Color(red: 1.0, green: 0.345, blue: 0.133).opacity(0.13)
+                selection: Color(red: 0.365, green: 0.620, blue: 0.980).opacity(0.14)
             )
         }
         return .init(
@@ -472,9 +533,9 @@ struct BlinkDiscoveryPalette {
             muted: Color(red: 0.360, green: 0.335, blue: 0.310),
             dim: Color(red: 0.485, green: 0.455, blue: 0.420),
             rule: Color.black.opacity(0.12),
-            accent: Color(red: 0.820, green: 0.235, blue: 0.060),
+            accent: Color(red: 0.176, green: 0.365, blue: 0.690),
             live: Color(red: 0.106, green: 0.580, blue: 0.404),
-            selection: Color(red: 0.820, green: 0.235, blue: 0.060).opacity(0.11)
+            selection: Color(red: 0.176, green: 0.365, blue: 0.690).opacity(0.11)
         )
     }
 }

--- a/Sources/BlinkApp/BlinkIcon.swift
+++ b/Sources/BlinkApp/BlinkIcon.swift
@@ -2,18 +2,18 @@ import AppKit
 
 /// Blink's shared mark: a framed spatial surface with two diagonally placed notes.
 /// The idle menubar image is a template so macOS owns its contrast; the armed
-/// image uses Blink amber without changing any geometry.
+/// image uses Blink's signal blue without changing any geometry.
 enum BlinkIcon {
-    static let amber = NSColor(
-        srgbRed: 240.0 / 255.0,
-        green: 180.0 / 255.0,
-        blue: 90.0 / 255.0,
+    static let accent = NSColor(
+        srgbRed: 93.0 / 255.0,
+        green: 158.0 / 255.0,
+        blue: 250.0 / 255.0,
         alpha: 1
     )
 
     static func menuBar(armed: Bool) -> NSImage {
         let size = NSSize(width: 18, height: 18)
-        let color = armed ? amber : NSColor.black
+        let color = armed ? accent : NSColor.black
         let image = NSImage(size: size, flipped: false) { rect in
             NSGraphicsContext.current?.shouldAntialias = true
             drawMark(in: rect, color: color)

--- a/Sources/BlinkApp/CapturePopoverView.swift
+++ b/Sources/BlinkApp/CapturePopoverView.swift
@@ -2,8 +2,9 @@ import AppKit
 import BlinkCore
 import SwiftUI
 
-/// The menubar popover is Blink's compact workspace: capture/search on top,
-/// recents on the left, and a spatial overview of the same notes on the right.
+/// The menubar popover is Blink's compact workspace: capture/search spans the
+/// whole workspace, with recents on the left and a spatial overview on the
+/// right.
 /// Selecting is deliberately separate from opening so the canvas can act as a
 /// quiet browser; Return or the preview card's Open action realizes the panel.
 struct CapturePopoverView: View {
@@ -27,16 +28,18 @@ struct CapturePopoverView: View {
     @State private var canvasExpanded = false
     @FocusState private var fieldFocused: Bool
 
-    /// The resolved palette for the current app scheme (from "Capture
-    /// Window.dc.html"; accent is Talkie's #ff5822). Follows a light/dark flip
-    /// live because `appearance` is observed.
+    /// The resolved palette for the current app scheme. Its cool signal-blue
+    /// distinguishes Blink from Talkie's coral while preserving the graphite /
+    /// paper world. Follows a light/dark flip live because `appearance` is observed.
     private var pal: PopoverPalette { .forScheme(appearance.scheme) }
-    private var amber: Color { pal.accent }
-    private var amberBright: Color { pal.accentBright }
-    private var live: Color { pal.live }
+    private var accent: Color { pal.accent }
+    private var accentBright: Color { pal.accentBright }
     private var blinkShortcut: String {
         KeyChord.parse(configStore.config.hotkeys.blink)?.display
             ?? configStore.config.hotkeys.blink
+    }
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "dev"
     }
 
     /// The design is set in IBM Plex Mono weight 200. SF Mono at a light weight
@@ -70,12 +73,13 @@ struct CapturePopoverView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            searchHeader
+            captureHeader
             hairline
             HStack(spacing: 0) {
                 if !canvasExpanded {
                     recentSidebar
                         .frame(width: 262)
+                        .background(pal.navigationFill)
                     verticalHairline
                 }
                 canvasPane
@@ -119,8 +123,8 @@ struct CapturePopoverView: View {
         }
     }
 
-    private var searchHeader: some View {
-        HStack(spacing: 13) {
+    private var captureHeader: some View {
+        HStack(spacing: 10) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 15, weight: .light))
                 .foregroundStyle(pal.inkMuted)  // #6b7072
@@ -129,39 +133,32 @@ struct CapturePopoverView: View {
                 .textFieldStyle(.plain)
                 .font(mono(15, .light))
                 .foregroundStyle(pal.inkBright)  // #e6e8e6
-                .tint(amber)
+                .tint(accent)
                 .focused($fieldFocused)
                 .onSubmit { openFirstOrCreate() }
 
-            HStack(spacing: 6) {
-                Circle()
-                    .fill(live)
-                    .frame(width: 6, height: 6)
-                    .shadow(color: live.opacity(0.8), radius: 4)
-                Text("LIVE")
-                    .font(mono(10.5))
-                    .tracking(1.6)
-                    .foregroundStyle(live)
-            }
-            .padding(.trailing, 4)
-
-            Button(action: showCommands) {
-                KeyBadge(text: "⌘K")
-            }
-            .buttonStyle(.plain)
-            .help("Commands and notes")
-            .accessibilityLabel("Open commands")
+            toolbarSeparator
 
             Button(action: startSystemDictation) {
                 Image(systemName: "mic.fill")
                     .font(.system(size: 14, weight: .light))
-                    .foregroundStyle(amberBright)
-                    .frame(width: 30, height: 30)
-                    .background(amber.opacity(0.18))
-                    .overlay(Rectangle().stroke(amber.opacity(0.65), lineWidth: 1))
+                    .foregroundStyle(accentBright)
+                    .frame(width: 32, height: 32)
+                    .background(accent.opacity(0.07))
+                    .overlay(Rectangle().stroke(accent.opacity(0.22), lineWidth: 1))
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .help("Dictate into capture")
+            .accessibilityLabel("Dictate into capture")
+
+            NewNoteButton(
+                title: trimmedQuery.isEmpty ? "New note" : "Create note",
+                help: trimmedQuery.isEmpty
+                    ? "Create a new note (⌘↩)"
+                    : "Create a note from this capture (⌘↩)",
+                action: createFromQuery
+            )
         }
         .padding(.horizontal, 18)
         .frame(height: 56)
@@ -230,7 +227,7 @@ struct CapturePopoverView: View {
         RecentNoteRow(
             index: item.index,
             note: item.note,
-            amber: amber,
+            accent: accent,
             selected: item.note.id == selectedNote?.id,
             earlier: earlier,
             onSelect: { selectedNoteID = item.note.id },
@@ -248,22 +245,17 @@ struct CapturePopoverView: View {
 
     private var canvasPane: some View {
         VStack(spacing: 0) {
-            HStack {
-                (
-                    Text("CANVAS ")
-                        .foregroundColor(pal.inkMid)  // #7f8587
-                    + Text("/ ")
-                        .foregroundColor(pal.inkGhost)  // #3d4143
-                    + Text("\(String(format: "%02d", filtered.count)) NODES")
-                        .foregroundColor(amberBright)
-                )
-                .font(mono(10)).tracking(1.6)
+            HStack(spacing: 8) {
+                Text("CANVAS")
+                    .font(mono(10))
+                    .tracking(1.6)
+                    .foregroundStyle(pal.inkMid)
 
                 Spacer()
 
-                CanvasModePicker(selection: $canvasMode, amber: amber)
+                CanvasModePicker(selection: $canvasMode, accent: accent)
 
-                Rectangle().fill(pal.strokeBase.opacity(0.1)).frame(width: 1, height: 14).padding(.horizontal, 4)
+                toolbarSeparator
 
                 Button {
                     withAnimation(.easeInOut(duration: 0.18)) { canvasExpanded.toggle() }
@@ -279,7 +271,9 @@ struct CapturePopoverView: View {
                 .accessibilityLabel(canvasExpanded ? "Show recents" : "Expand canvas")
             }
             .padding(.horizontal, 20)
-            .frame(height: 42)
+            .frame(height: 44)
+
+            hairline
 
             Group {
                 if filtered.isEmpty {
@@ -298,7 +292,7 @@ struct CapturePopoverView: View {
                         NoteConstellation(
                             notes: filtered,
                             selectedNoteID: selectedNote?.id,
-                            amber: amber,
+                            accent: accent,
                             onSelect: { selectedNoteID = $0.id },
                             onOpen: open
                         )
@@ -318,6 +312,13 @@ struct CapturePopoverView: View {
         }
     }
 
+    private var toolbarSeparator: some View {
+        Rectangle()
+            .fill(pal.strokeBase.opacity(0.1))
+            .frame(width: 1, height: 16)
+            .padding(.horizontal, 3)
+    }
+
     private var emptyCanvas: some View {
         VStack(spacing: 10) {
             Image(systemName: "point.3.connected.trianglepath.dotted")
@@ -332,103 +333,68 @@ struct CapturePopoverView: View {
     }
 
     private var footer: some View {
-        HStack(spacing: 7) {
-            Button { createFromQuery() } label: {
-                HStack(spacing: 7) {
-                    KeyCap(symbol: "⌘")
-                    KeyCap(symbol: "↩")
-                    Text("New node")
-                        .font(mono(10.5)).tracking(1).textCase(.uppercase)
-                        .foregroundStyle(pal.inkMuted)
-                }
+        HStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Text("BLINK")
+                    .font(mono(10, .semibold))
+                    .tracking(1.4)
+                    .foregroundStyle(pal.ink)
+                Text("/")
+                    .font(mono(10))
+                    .foregroundStyle(pal.inkGhost)
+                Text("v\(appVersion)")
+                    .font(mono(9.5))
+                    .foregroundStyle(pal.inkMuted)
             }
-            .buttonStyle(.plain)
-            .help(trimmedQuery.isEmpty ? "New note" : "Create “\(trimmedQuery)”")
 
             Spacer()
 
-            Text("STATUS · READY")
-                .font(mono(10.5)).tracking(1)
-                .foregroundStyle(pal.inkFaint)
+            Text("READY")
+                .font(mono(9.5, .medium))
+                .tracking(1.2)
+                .foregroundStyle(pal.inkMuted)
 
-            Button(action: toggleBlink) {
-                HStack(spacing: 6) {
-                    Image(systemName: "eye")
-                        .font(.system(size: 12, weight: .light))
-                    Text(blinkShortcut)
-                        .font(mono(10))
-                        .padding(.horizontal, 5).padding(.vertical, 1)
-                        .overlay(Rectangle().stroke(pal.strokeBase.opacity(0.1), lineWidth: 1))
-                }
-                .foregroundStyle(pal.inkMid)  // #a6acae
-            }
-            .buttonStyle(.plain)
-            .help("Show or hide all notes (\(blinkShortcut))")
-            .accessibilityLabel("Show or hide all notes")
+            footerSeparator
 
-            footerIconButton(
+            FooterActionButton(
+                icon: "eye",
+                label: "Blink",
+                shortcut: blinkShortcut,
+                help: "Show or hide all notes (\(blinkShortcut))",
+                action: toggleBlink
+            )
+            FooterActionButton(
                 icon: "square.grid.3x3",
                 label: "Grid",
+                shortcut: nil,
                 help: "Show the spatial grid",
                 action: showGrid
             )
-
-            Button(action: showCommands) {
-                HStack(spacing: 5) {
-                    Image(systemName: "command")
-                    Text("K")
-                        .font(mono(10))
-                        .padding(.horizontal, 5).padding(.vertical, 1)
-                        .overlay(Rectangle().stroke(pal.strokeBase.opacity(0.1), lineWidth: 1))
-                }
-                .font(.system(size: 12, weight: .light))
-                .foregroundStyle(pal.inkMid)
-            }
-            .buttonStyle(.plain)
-            .help("Open commands and notes (⌘K)")
-            .accessibilityLabel("Open commands and notes")
-
-            footerIconButton(
-                icon: "questionmark.circle",
-                label: nil,
-                help: "Blink Guide — activities and shortcuts",
-                action: openGuide
+            FooterActionButton(
+                icon: "command",
+                label: "Commands",
+                shortcut: "⌘K",
+                help: "Open commands and notes (⌘K)",
+                action: showCommands
             )
 
-            footerIconButton(
-                icon: "gearshape",
-                label: nil,
-                help: "Settings (⌘,)",
-                action: openSettings
+            footerSeparator
+
+            FooterUtilitiesMenu(
+                openHelp: openGuide,
+                openSettings: openSettings
             )
         }
         .padding(.horizontal, 18)
-        .frame(height: 38)
+        .frame(height: 44)
+        .background(pal.footerFill)
     }
 
-    private func footerIconButton(
-        icon: String,
-        label: String?,
-        help: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            HStack(spacing: 5) {
-                Image(systemName: icon)
-                    .font(.system(size: 12, weight: .light))
-                if let label {
-                    Text(label.uppercased())
-                        .font(mono(9.5))
-                        .tracking(0.7)
-                }
-            }
-            .foregroundStyle(pal.inkMid)
-            .frame(minWidth: 24, minHeight: 24)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .help(help)
-        .accessibilityLabel(help)
+    private var footerSeparator: some View {
+        Rectangle()
+            .fill(pal.strokeBase.opacity(0.11))
+            .frame(width: 1, height: 20)
+            .padding(.horizontal, 8)
     }
 
     private var hairline: some View {
@@ -497,9 +463,145 @@ struct CapturePopoverView: View {
         }
         switch resolved.panel.sheet.lowercased() {
         case "card": return Color(red: 0.35, green: 0.82, blue: 0.61)
-        case "glass", "dotted": return amber
+        case "glass", "dotted": return accent
         default: return Color(red: 0.48, green: 0.52, blue: 0.59)
         }
+    }
+}
+
+private struct NewNoteButton: View {
+    @Environment(\.popoverPalette) private var pal
+    @State private var hovered = false
+
+    let title: String
+    let help: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 7) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(pal.accentBright)
+                Text(title.uppercased())
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .tracking(0.7)
+                    .foregroundStyle(pal.ink)
+                Text("⌘↩")
+                    .font(.system(size: 9.5, weight: .medium, design: .monospaced))
+                    .foregroundStyle(pal.inkMuted)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .overlay(Rectangle().stroke(pal.strokeBase.opacity(0.1), lineWidth: 1))
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 32)
+            .background(pal.strokeBase.opacity(hovered ? 0.07 : 0.025))
+            .overlay(Rectangle().stroke(pal.accent.opacity(hovered ? 0.42 : 0.20), lineWidth: 1))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered in
+            withAnimation(.easeOut(duration: 0.1)) { hovered = isHovered }
+        }
+        .help(help)
+        .accessibilityLabel(title)
+    }
+}
+
+private struct FooterActionButton: View {
+    @Environment(\.popoverPalette) private var pal
+    @State private var hovered = false
+
+    let icon: String
+    let label: String
+    let shortcut: String?
+    let help: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 11.5, weight: .light))
+                Text(label.uppercased())
+                    .font(.system(size: 9.5, weight: .medium, design: .monospaced))
+                    .tracking(0.55)
+                if let shortcut {
+                    Text(shortcut)
+                        .font(.system(size: 9, weight: .regular, design: .monospaced))
+                        .foregroundStyle(pal.inkMuted)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .overlay(Rectangle().stroke(pal.strokeBase.opacity(0.1), lineWidth: 1))
+                }
+            }
+            .foregroundStyle(hovered ? pal.ink : pal.inkMid)
+            .padding(.horizontal, 8)
+            .frame(height: 28)
+            .background(pal.strokeBase.opacity(hovered ? 0.07 : 0.025))
+            .overlay(Rectangle().stroke(pal.strokeBase.opacity(hovered ? 0.15 : 0.055), lineWidth: 1))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered in
+            withAnimation(.easeOut(duration: 0.1)) { hovered = isHovered }
+        }
+        .help(help)
+        .accessibilityLabel(help)
+    }
+}
+
+/// Help and configuration are durable utility windows, not immediate canvas
+/// actions. Keeping them behind one entry makes Commands the clear primary
+/// launcher while preserving both destinations.
+private struct FooterUtilitiesMenu: View {
+    @Environment(\.popoverPalette) private var pal
+    @State private var hovered = false
+
+    let openHelp: () -> Void
+    let openSettings: () -> Void
+
+    var body: some View {
+        Menu {
+            Button(action: openHelp) {
+                Label("Help & Shortcuts", systemImage: "questionmark.circle")
+            }
+            Divider()
+            Button(action: openSettings) {
+                Label("Settings…", systemImage: "gearshape")
+            }
+            .keyboardShortcut(",", modifiers: .command)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "ellipsis.circle")
+                    .font(.system(size: 11.5, weight: .light))
+                Text("MORE")
+                    .font(.system(size: 9.5, weight: .medium, design: .monospaced))
+                    .tracking(0.55)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 7, weight: .semibold))
+            }
+            .foregroundStyle(hovered ? pal.ink : pal.inkMid)
+            .padding(.horizontal, 8)
+            .frame(height: 28)
+            .background(pal.strokeBase.opacity(hovered ? 0.07 : 0.025))
+            .overlay(
+                Rectangle().stroke(
+                    pal.strokeBase.opacity(hovered ? 0.15 : 0.055),
+                    lineWidth: 1
+                )
+            )
+            .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .onHover { isHovered in
+            withAnimation(.easeOut(duration: 0.1)) { hovered = isHovered }
+        }
+        .help("Help, shortcuts, and settings")
+        .accessibilityLabel("More Blink options")
     }
 }
 
@@ -521,7 +623,7 @@ private enum CanvasMode: String, CaseIterable, Identifiable {
 private struct CanvasModePicker: View {
     @Environment(\.popoverPalette) private var pal
     @Binding var selection: CanvasMode
-    let amber: Color
+    let accent: Color
 
     var body: some View {
         HStack(spacing: 5) {
@@ -531,14 +633,14 @@ private struct CanvasModePicker: View {
                         .font(.system(size: 13, weight: .light))
                         .foregroundStyle(
                             selection == mode
-                                ? pal.accentBright         // #ff7a4d
+                                ? pal.accentBright
                                 : pal.ink        // #c4c8c6
                         )
                         .frame(width: 24, height: 24)
-                        .background(selection == mode ? amber.opacity(0.1) : .clear)  // sharp
+                        .background(selection == mode ? accent.opacity(0.1) : .clear)  // sharp
                         .overlay {
                             if selection == mode {
-                                Rectangle().stroke(amber.opacity(0.3), lineWidth: 1)
+                                Rectangle().stroke(accent.opacity(0.3), lineWidth: 1)
                             }
                         }
                         .contentShape(Rectangle())
@@ -555,7 +657,7 @@ private struct RecentNoteRow: View {
     @Environment(\.popoverPalette) private var pal
     let index: Int
     let note: Note
-    let amber: Color
+    let accent: Color
     let selected: Bool
     let earlier: Bool
     var onSelect: () -> Void
@@ -566,9 +668,9 @@ private struct RecentNoteRow: View {
 
     @State private var hovered = false
 
-    // Tiered ink: the active row is warm, today rows read clear, earlier ones recede.
+    // Tiered ink: the active row is cool, today rows read clear, earlier ones recede.
     private var numberColor: Color {
-        if selected { return pal.accentBright }   // #ff7a4d
+        if selected { return pal.accentBright }
         return earlier ? pal.inkGhost       // #3d4143
                        : pal.inkFaint       // #54595b
     }
@@ -578,7 +680,7 @@ private struct RecentNoteRow: View {
                        : pal.ink       // #d2d5d3
     }
     private var timeColor: Color {
-        if selected { return pal.warmSel } // #c8935f
+        if selected { return pal.selectedMeta }
         return earlier ? pal.inkFaint       // #54595b
                        : pal.inkMuted          // #6b7072
     }
@@ -606,11 +708,11 @@ private struct RecentNoteRow: View {
             .padding(.horizontal, 10)
             .frame(height: 32)
             .background(
-                selected ? amber.opacity(0.08) : (hovered ? pal.strokeBase.opacity(0.04) : .clear)
+                selected ? accent.opacity(0.08) : (hovered ? pal.strokeBase.opacity(0.04) : .clear)
             )
             .overlay(alignment: .leading) {
                 if selected {
-                    Rectangle().fill(amber).frame(width: 2)  // inset left bar
+                    Rectangle().fill(accent).frame(width: 2)  // inset left bar
                 }
             }
             .contentShape(Rectangle())
@@ -633,13 +735,30 @@ private struct NoteConstellation: View {
     @Environment(\.popoverPalette) private var pal
     let notes: [Note]
     let selectedNoteID: String?
-    let amber: Color
+    let accent: Color
     let onSelect: (Note) -> Void
     let onOpen: (Note) -> Void
 
+    /// Ephemeral overview placements for this popover session only. Intentionally
+    /// not written to `blink.slot` or panel frame autosave — the canvas is a
+    /// spatial browser, not the durable layout contract.
+    @State private var positionOverrides: [String: CGPoint] = [:]
+    @State private var activeDrag: OverviewDrag?
+    @State private var suppressOpenUntil: Date?
+
+    private struct OverviewDrag {
+        let noteID: String
+        let origin: CGPoint
+        var translation: CGSize = .zero
+        var didMove = false
+    }
+
     var body: some View {
         GeometryReader { geometry in
-            let points = ConstellationLayout.points(for: notes, in: geometry.size)
+            let size = geometry.size
+            let basePoints = ConstellationLayout.points(for: notes, in: size)
+            let points = resolvedPoints(base: basePoints, size: size)
+
             ZStack(alignment: .topLeading) {
                 CanvasSurface()
 
@@ -660,47 +779,145 @@ private struct NoteConstellation: View {
 
                 ForEach(Array(notes.enumerated()), id: \.element.id) { offset, note in
                     if let point = points[note.id] {
+                        let isDragging = activeDrag?.noteID == note.id
                         ConstellationNode(
                             index: offset + 1,
                             note: note,
-                            amber: amber,
+                            accent: accent,
                             selected: note.id == selectedNoteID,
+                            isDragging: isDragging,
                             onSelect: { onSelect(note) },
-                            onOpen: { onOpen(note) }
+                            onOpen: {
+                                guard !shouldSuppressOpen else { return }
+                                onOpen(note)
+                            },
+                            onDragChanged: { translation in
+                                beginOrUpdateDrag(
+                                    note: note,
+                                    base: basePoints[note.id] ?? point,
+                                    translation: translation
+                                )
+                            },
+                            onDragEnded: { translation in
+                                endDrag(
+                                    note: note,
+                                    base: basePoints[note.id] ?? point,
+                                    translation: translation,
+                                    size: size
+                                )
+                            }
                         )
                         .position(point)
+                        .zIndex(isDragging ? 100 : (note.id == selectedNoteID ? 10 : Double(notes.count - offset)))
                     }
                 }
             }
+            .coordinateSpace(name: "constellationCanvas")
             .clipShape(Rectangle())
+            .onChange(of: notes.map(\.id)) { _, ids in
+                let keep = Set(ids)
+                positionOverrides = positionOverrides.filter { keep.contains($0.key) }
+                if let drag = activeDrag, !keep.contains(drag.noteID) {
+                    activeDrag = nil
+                }
+            }
+            .onChange(of: size) { _, newSize in
+                positionOverrides = positionOverrides.mapValues {
+                    ConstellationLayout.clamp($0, in: newSize)
+                }
+            }
         }
+    }
+
+    private var shouldSuppressOpen: Bool {
+        if activeDrag?.didMove == true { return true }
+        if let until = suppressOpenUntil, Date() < until { return true }
+        return false
+    }
+
+    private func resolvedPoints(base: [String: CGPoint], size: CGSize) -> [String: CGPoint] {
+        var result = base
+        for (id, point) in positionOverrides where result[id] != nil {
+            result[id] = ConstellationLayout.clamp(point, in: size)
+        }
+        if let drag = activeDrag, result[drag.noteID] != nil {
+            result[drag.noteID] = ConstellationLayout.clamp(
+                CGPoint(
+                    x: drag.origin.x + drag.translation.width,
+                    y: drag.origin.y + drag.translation.height
+                ),
+                in: size
+            )
+        }
+        return result
+    }
+
+    private func beginOrUpdateDrag(note: Note, base: CGPoint, translation: CGSize) {
+        var drag: OverviewDrag
+        if let existing = activeDrag, existing.noteID == note.id {
+            drag = existing
+        } else {
+            drag = OverviewDrag(noteID: note.id, origin: positionOverrides[note.id] ?? base)
+            onSelect(note)
+        }
+        drag.translation = translation
+        if hypot(translation.width, translation.height) >= 4 {
+            drag.didMove = true
+        }
+        activeDrag = drag
+    }
+
+    private func endDrag(note: Note, base: CGPoint, translation: CGSize, size: CGSize) {
+        let origin: CGPoint
+        let didMove: Bool
+        if let drag = activeDrag, drag.noteID == note.id {
+            origin = drag.origin
+            didMove = drag.didMove || hypot(translation.width, translation.height) >= 4
+        } else {
+            origin = positionOverrides[note.id] ?? base
+            didMove = hypot(translation.width, translation.height) >= 4
+        }
+        if didMove {
+            positionOverrides[note.id] = ConstellationLayout.clamp(
+                CGPoint(x: origin.x + translation.width, y: origin.y + translation.height),
+                in: size
+            )
+            suppressOpenUntil = Date().addingTimeInterval(0.35)
+        }
+        activeDrag = nil
     }
 }
 
 private struct ConstellationNode: View {
     @Environment(\.popoverPalette) private var pal
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let index: Int
     let note: Note
-    let amber: Color
+    let accent: Color
     let selected: Bool
+    let isDragging: Bool
     let onSelect: () -> Void
     let onOpen: () -> Void
+    let onDragChanged: (CGSize) -> Void
+    let onDragEnded: (CGSize) -> Void
 
     @State private var hovered = false
 
     // Recency tier drives prominence: A (freshest) → B → C recede into the board.
+    // Selection and drag change chrome only — never padding, type size, or extra
+    // labels — so external geometry stays put.
     private var tier: Int { index <= 3 ? 0 : (index <= 6 ? 1 : 2) }
 
     private var bgColor: Color {
-        if selected { return pal.nodeSelBg }  // #121011
+        if selected || isDragging { return pal.nodeSelBg }
         switch tier {
-        case 0: return pal.nodeBg0          // paper card
+        case 0: return pal.nodeBg0
         case 1: return pal.nodeBg1
         default: return pal.nodeBg2
         }
     }
     private var borderColor: Color {
-        if selected { return amber.opacity(0.55) }
+        if selected || isDragging { return accent.opacity(0.55) }
         switch tier {
         case 0: return pal.strokeBase.opacity(hovered ? 0.25 : 0.11)
         case 1: return pal.strokeBase.opacity(hovered ? 0.18 : 0.08)
@@ -708,58 +925,69 @@ private struct ConstellationNode: View {
         }
     }
     private var titleColor: Color {
-        if selected { return pal.strokeBase }
+        if selected || isDragging { return pal.strokeBase }
         switch tier {
-        case 0: return pal.inkBright           // #e6e8e6
-        case 1: return pal.inkMid          // #83898b
-        default: return pal.inkFaint         // #54595b
+        case 0: return pal.inkBright
+        case 1: return pal.inkMid
+        default: return pal.inkFaint
         }
     }
     private var numberColor: Color {
-        if selected { return pal.accentBright }    // #ff7a4d
+        if selected || isDragging { return pal.accentBright }
         switch tier {
-        case 0: return pal.inkFaint          // #54595b
-        case 1: return pal.inkGhost          // #43484b
-        default: return pal.inkGhost            // #33383a
+        case 0: return pal.inkFaint
+        case 1: return pal.inkGhost
+        default: return pal.inkGhost
         }
     }
+
+    private var horizontalPadding: CGFloat { tier == 0 ? 12 : 10 }
+    private var verticalPadding: CGFloat { tier == 0 ? 8 : 6 }
+    private var numberSize: CGFloat { tier == 0 ? 10 : 9.5 }
+    private var titleSize: CGFloat { tier == 0 ? 11.5 : 11 }
 
     var body: some View {
         Button(action: onSelect) {
             HStack(spacing: 8) {
                 Text(String(format: "%02d", index))
-                    .font(.system(size: selected ? 10.5 : (tier == 0 ? 10 : 9.5), weight: .light, design: .monospaced))
+                    .font(.system(size: numberSize, weight: .light, design: .monospaced))
                     .foregroundStyle(numberColor)
                 Text(note.title)
-                    .font(.system(size: selected ? 12 : (tier == 0 ? 11.5 : 11), weight: .light, design: .monospaced))
+                    .font(.system(size: titleSize, weight: .light, design: .monospaced))
                     .foregroundStyle(titleColor)
                     .lineLimit(1)
-                if selected {
-                    Text(note.updatedAt.blinkCompactRelative)
-                        .font(.system(size: 10, weight: .light, design: .monospaced))
-                        .foregroundStyle(pal.inkMuted)
-                }
             }
-            .padding(.horizontal, selected ? 13 : (tier == 0 ? 12 : 11))
-            .padding(.vertical, selected ? 8 : (tier == 0 ? 7 : 6))
-            .background(bgColor)                                 // sharp corners
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(bgColor)
             .overlay(Rectangle().stroke(borderColor, lineWidth: 1))
-            .overlay { if selected { CornerTicks(color: amber) } }
+            .overlay { if selected || isDragging { CornerTicks(color: accent) } }
             .shadow(
-                color: selected ? amber.opacity(0.35) : .black.opacity(0.2),
-                radius: selected ? 14 : 4, x: 0, y: selected ? 6 : 2
+                color: isDragging ? accent.opacity(0.26) : .black.opacity(0.18),
+                radius: isDragging ? 10 : 4,
+                x: 0,
+                y: isDragging ? 5 : 2
             )
-            .offset(y: hovered && !selected ? -2 : 0)
+            .scaleEffect(isDragging && !reduceMotion ? 1.015 : 1)
+            .offset(y: hovered && !selected && !isDragging ? -1 : 0)
             .animation(.easeOut(duration: 0.12), value: hovered)
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: isDragging)
         }
         .buttonStyle(.plain)
         .onHover { hovered = $0 }
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 4, coordinateSpace: .named("constellationCanvas"))
+                .onChanged { value in onDragChanged(value.translation) }
+                .onEnded { value in onDragEnded(value.translation) }
+        )
         .simultaneousGesture(TapGesture(count: 2).onEnded(onOpen))
-        .help("Double-click to open \(note.title)")
+        .help("Drag to arrange · double-click to open \(note.title)")
+        .accessibilityAddTraits(selected ? .isSelected : [])
+        .accessibilityHint("Drag to reposition on the canvas. Double-click to open.")
     }
 }
 
-/// Amber L-brackets just outside a node's four corners — the "locked/active"
+/// Signal-blue L-brackets just outside a node's four corners — the "locked/active"
 /// framing from the design.
 private struct CornerTicks: View {
     let color: Color
@@ -790,43 +1018,57 @@ private struct NoteCardGrid: View {
     let onSelect: (Note) -> Void
     let onOpen: (Note) -> Void
 
-    private let columns = [GridItem(.adaptive(minimum: 170), spacing: 10)]
+    /// Compact adaptive cards on a 4pt rhythm; selection is stroke/fill only.
+    // Three readable columns beside Recents, four when the canvas is expanded.
+    // This uses the available height instead of compressing twelve notes into
+    // three rows above a large empty floor.
+    private let columns = [GridItem(.adaptive(minimum: 216, maximum: 260), spacing: 12)]
 
     var body: some View {
         ScrollView {
-            LazyVGrid(columns: columns, spacing: 10) {
+            LazyVGrid(columns: columns, spacing: 12) {
                 ForEach(notes, id: \.id) { note in
+                    let selected = note.id == selectedNoteID
                     Button { onSelect(note) } label: {
-                        VStack(alignment: .leading, spacing: 10) {
-                            HStack {
-                                Circle().fill(accent(note)).frame(width: 9, height: 9)
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack(spacing: 8) {
+                                Circle().fill(accent(note)).frame(width: 8, height: 8)
                                 Text(note.title)
-                                    .font(.system(size: 13, weight: .semibold))
-                                    .foregroundStyle(pal.strokeBase.opacity(0.84))
+                                    .font(.system(size: 12.5, weight: .semibold))
+                                    .foregroundStyle(pal.strokeBase.opacity(selected ? 0.90 : 0.82))
                                     .lineLimit(1)
-                                Spacer()
+                                Spacer(minLength: 4)
                                 Text(note.updatedAt.blinkCompactRelative)
                                     .font(.system(size: 10, design: .monospaced))
                                     .foregroundStyle(pal.strokeBase.opacity(0.28))
                             }
                             Text(note.blinkExcerpt)
                                 .font(.system(size: 11))
-                                .foregroundStyle(pal.strokeBase.opacity(0.43))
+                                .foregroundStyle(pal.strokeBase.opacity(0.42))
                                 .lineLimit(3)
-                                .frame(maxWidth: .infinity, minHeight: 46, alignment: .topLeading)
+                                .frame(maxWidth: .infinity, minHeight: 44, maxHeight: 44, alignment: .topLeading)
                         }
-                        .padding(14)
-                        .background(pal.strokeBase.opacity(note.id == selectedNoteID ? 0.075 : 0.035), in: RoundedRectangle(cornerRadius: 12))
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            selected ? pal.accent.opacity(0.055) : pal.strokeBase.opacity(0.03),
+                            in: RoundedRectangle(cornerRadius: 12)
+                        )
                         .overlay(
                             RoundedRectangle(cornerRadius: 12)
-                                .stroke(note.id == selectedNoteID ? accent(note).opacity(0.55) : pal.strokeBase.opacity(0.07), lineWidth: 1)
+                                .stroke(
+                                    selected ? pal.accent.opacity(0.50) : pal.strokeBase.opacity(0.07),
+                                    lineWidth: selected ? 1.5 : 1
+                                )
                         )
                     }
                     .buttonStyle(.plain)
                     .simultaneousGesture(TapGesture(count: 2).onEnded { onOpen(note) })
+                    .help("Double-click to open \(note.title)")
+                    .accessibilityAddTraits(selected ? .isSelected : [])
                 }
             }
-            .padding(14)
+            .padding(12)
         }
         .scrollIndicators(.hidden)
         .background(CanvasSurface())
@@ -843,38 +1085,51 @@ private struct CanvasNoteList: View {
 
     var body: some View {
         ScrollView {
-            LazyVStack(spacing: 6) {
+            LazyVStack(spacing: 4) {
                 ForEach(notes, id: \.id) { note in
+                    let selected = note.id == selectedNoteID
                     Button { onSelect(note) } label: {
                         HStack(spacing: 12) {
-                            Circle().fill(accent(note)).frame(width: 9, height: 9)
-                            VStack(alignment: .leading, spacing: 3) {
+                            Circle().fill(accent(note)).frame(width: 8, height: 8)
+                            VStack(alignment: .leading, spacing: 4) {
                                 Text(note.title)
-                                    .font(.system(size: 13, weight: .semibold))
-                                    .foregroundStyle(pal.strokeBase.opacity(0.82))
+                                    .font(.system(size: 12.5, weight: .semibold))
+                                    .foregroundStyle(pal.strokeBase.opacity(selected ? 0.90 : 0.80))
                                     .lineLimit(1)
                                 Text(note.blinkExcerpt)
                                     .font(.system(size: 10))
                                     .foregroundStyle(pal.strokeBase.opacity(0.35))
                                     .lineLimit(1)
                             }
-                            Spacer()
+                            Spacer(minLength: 8)
                             Text(note.updatedAt.blinkCompactRelative)
-                                .font(.system(size: 11, design: .monospaced))
+                                .font(.system(size: 10, design: .monospaced))
                                 .foregroundStyle(pal.strokeBase.opacity(0.28))
                             Image(systemName: "arrow.up.forward.app")
                                 .font(.system(size: 11))
-                                .foregroundStyle(pal.strokeBase.opacity(0.28))
+                                .foregroundStyle(pal.strokeBase.opacity(selected ? 0.40 : 0.24))
                         }
-                        .padding(.horizontal, 14)
-                        .frame(height: 50)
-                        .background(pal.strokeBase.opacity(note.id == selectedNoteID ? 0.07 : 0.025), in: RoundedRectangle(cornerRadius: 10))
+                        .padding(.horizontal, 12)
+                        .frame(height: 48)
+                        .background(
+                            selected ? pal.accent.opacity(0.05) : pal.strokeBase.opacity(0.02),
+                            in: RoundedRectangle(cornerRadius: 8)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(
+                                    selected ? pal.accent.opacity(0.46) : pal.strokeBase.opacity(0.05),
+                                    lineWidth: selected ? 1.5 : 1
+                                )
+                        )
                     }
                     .buttonStyle(.plain)
                     .simultaneousGesture(TapGesture(count: 2).onEnded { onOpen(note) })
+                    .help("Double-click to open \(note.title)")
+                    .accessibilityAddTraits(selected ? .isSelected : [])
                 }
             }
-            .padding(14)
+            .padding(12)
         }
         .scrollIndicators(.hidden)
         .background(CanvasSurface())
@@ -993,35 +1248,10 @@ private struct PopoutCorners: View {
     }
 }
 
-private struct KeyCap: View {
-    @Environment(\.popoverPalette) private var pal
-    let symbol: String
-
-    var body: some View {
-        Text(symbol)
-            .font(.system(size: 11, weight: .light, design: .monospaced))
-            .foregroundStyle(pal.ink)  // #d2d5d3
-            .frame(minWidth: 20, minHeight: 20)
-            .overlay(Rectangle().stroke(pal.strokeBase.opacity(0.1), lineWidth: 1))   // sharp
-    }
-}
-
-/// A bordered inline key hint (e.g. ⌘K) — sharp, thin, per the design.
-private struct KeyBadge: View {
-    @Environment(\.popoverPalette) private var pal
-    let text: String
-
-    var body: some View {
-        Text(text)
-            .font(.system(size: 10.5, weight: .light, design: .monospaced))
-            .foregroundStyle(pal.inkMuted)  // #6b7072
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .overlay(Rectangle().stroke(pal.strokeBase.opacity(0.1), lineWidth: 1))
-    }
-}
-
 private enum ConstellationLayout {
+    /// Inset so node centers stay fully inside the canvas surface.
+    private static let edgeInset = CGSize(width: 72, height: 22)
+
     private static let candidates: [CGPoint] = [
         CGPoint(x: 0.16, y: 0.20), CGPoint(x: 0.57, y: 0.13),
         CGPoint(x: 0.83, y: 0.32), CGPoint(x: 0.42, y: 0.43),
@@ -1033,6 +1263,17 @@ private enum ConstellationLayout {
         CGPoint(x: 0.10, y: 0.81), CGPoint(x: 0.49, y: 0.61),
         CGPoint(x: 0.25, y: 0.45), CGPoint(x: 0.72, y: 0.22),
     ]
+
+    static func clamp(_ point: CGPoint, in size: CGSize) -> CGPoint {
+        let minX = min(edgeInset.width, size.width / 2)
+        let maxX = max(minX, size.width - edgeInset.width)
+        let minY = min(edgeInset.height, size.height / 2)
+        let maxY = max(minY, size.height - edgeInset.height)
+        return CGPoint(
+            x: min(max(point.x, minX), maxX),
+            y: min(max(point.y, minY), maxY)
+        )
+    }
 
     static func points(for notes: [Note], in size: CGSize) -> [String: CGPoint] {
         var result: [String: CGPoint] = [:]
@@ -1057,7 +1298,10 @@ private enum ConstellationLayout {
             }
             occupied.insert(index)
             let normalized = candidates[index]
-            result[note.id] = CGPoint(x: normalized.x * size.width, y: normalized.y * size.height)
+            result[note.id] = clamp(
+                CGPoint(x: normalized.x * size.width, y: normalized.y * size.height),
+                in: size
+            )
         }
         return result
     }
@@ -1169,13 +1413,12 @@ private extension Color {
 /// terminal chrome — every hairline, border, dot, grid line, and hover fill is
 /// that color at some opacity, and it doubles as ink-on-surface text — so light
 /// mode is mostly "flip white → near-black." The opaque mono inks and the paper
-/// backgrounds carry explicit light values. Accents (amber, LIVE green) are
-/// shared: both read on paper as well as on black.
+/// backgrounds carry explicit light values. The translucent navigation rail
+/// and matte footer are separate semantic surfaces in both schemes.
 private struct PopoverPalette {
-    let accent = Color(red: 1.0, green: 0.345, blue: 0.133)        // #ff5822
-    let accentBright = Color(red: 1.0, green: 0.478, blue: 0.302)  // #ff7a4d
+    let accent: Color
+    let accentBright: Color
 
-    var live: Color
     /// White in dark, near-black in light: base for all opacity-based chrome
     /// and for ink-on-surface text.
     var strokeBase: Color
@@ -1188,13 +1431,15 @@ private struct PopoverPalette {
     var inkMuted: Color    // magnifier, section labels, key badges
     var inkFaint: Color    // row numbers, status line
     var inkGhost: Color    // counts, receded numbers, the "/" divider
-    var warmSel: Color     // a selected row's timestamp (warm tan)
+    var selectedMeta: Color // a selected row's timestamp
 
     // Opaque surfaces.
     var bgBase: Color
     var bgGrad1: Color
     var bgGrad2: Color
     var bgGrad3: Color
+    var navigationFill: Color
+    var footerFill: Color
     var canvasFill: Color
     var nodeSelBg: Color
     var nodeBg0: Color
@@ -1203,7 +1448,8 @@ private struct PopoverPalette {
     var popoutCorner: Color
 
     static let dark = PopoverPalette(
-        live: Color(red: 0.353, green: 0.820, blue: 0.608),        // #5ad19b
+        accent: Color(red: 0.365, green: 0.620, blue: 0.980),       // #5d9efa
+        accentBright: Color(red: 0.514, green: 0.706, blue: 1.000), // #83b4ff
         strokeBase: .white,
         inkStrong: Color(red: 0.984, green: 0.933, blue: 0.910),   // #fbeee8
         inkBright: Color(red: 0.902, green: 0.910, blue: 0.902),   // #e6e8e6
@@ -1212,11 +1458,13 @@ private struct PopoverPalette {
         inkMuted: Color(red: 0.420, green: 0.440, blue: 0.450),    // #6b7072
         inkFaint: Color(red: 0.329, green: 0.349, blue: 0.357),    // #54595b
         inkGhost: Color(red: 0.239, green: 0.255, blue: 0.263),    // #3d4143
-        warmSel: Color(red: 0.784, green: 0.576, blue: 0.373),     // #c8935f
+        selectedMeta: Color(red: 0.514, green: 0.706, blue: 1.000), // #83b4ff
         bgBase: Color(red: 0.039, green: 0.043, blue: 0.047),      // #0a0b0c
         bgGrad1: Color(red: 0.090, green: 0.098, blue: 0.110),     // #17191c
         bgGrad2: Color(red: 0.047, green: 0.055, blue: 0.063),     // #0c0e10
         bgGrad3: Color(red: 0.020, green: 0.024, blue: 0.027),     // #050607
+        navigationFill: Color(red: 0.028, green: 0.030, blue: 0.033).opacity(0.64),
+        footerFill: Color(red: 0.030, green: 0.029, blue: 0.030),  // matte #080708
         canvasFill: Color(red: 0.025, green: 0.031, blue: 0.041).opacity(0.93),
         nodeSelBg: Color(red: 0.071, green: 0.063, blue: 0.067),   // #121011
         nodeBg0: Color(red: 0.055, green: 0.059, blue: 0.067),     // #0e0f11
@@ -1226,7 +1474,8 @@ private struct PopoverPalette {
     )
 
     static let light = PopoverPalette(
-        live: Color(red: 0.106, green: 0.580, blue: 0.404),        // #1b9367
+        accent: Color(red: 0.176, green: 0.365, blue: 0.690),       // #2d5daf
+        accentBright: Color(red: 0.196, green: 0.408, blue: 0.741), // #3268bd
         strokeBase: Color(red: 0.086, green: 0.078, blue: 0.070),  // warm near-black
         inkStrong: Color(red: 0.090, green: 0.075, blue: 0.063),   // #17130f
         inkBright: Color(red: 0.130, green: 0.116, blue: 0.102),   // #211d1a
@@ -1235,11 +1484,13 @@ private struct PopoverPalette {
         inkMuted: Color(red: 0.460, green: 0.435, blue: 0.405),    // #756f67
         inkFaint: Color(red: 0.560, green: 0.535, blue: 0.505),    // #8f8880
         inkGhost: Color(red: 0.680, green: 0.655, blue: 0.622),    // #ada79e
-        warmSel: Color(red: 0.600, green: 0.380, blue: 0.180),     // #99612e
+        selectedMeta: Color(red: 0.196, green: 0.408, blue: 0.741), // #3268bd
         bgBase: Color(red: 0.949, green: 0.941, blue: 0.925),      // #f2f0ec paper
         bgGrad1: Color(red: 0.988, green: 0.980, blue: 0.965),     // #fcfaf6
         bgGrad2: Color(red: 0.949, green: 0.941, blue: 0.925),     // #f2f0ec
         bgGrad3: Color(red: 0.910, green: 0.898, blue: 0.874),     // #e8e5df
+        navigationFill: Color(red: 0.934, green: 0.928, blue: 0.914).opacity(0.60),
+        footerFill: Color(red: 0.890, green: 0.875, blue: 0.847),  // matte warm paper
         canvasFill: Color(red: 1.0, green: 0.996, blue: 0.988).opacity(0.72),
         nodeSelBg: Color(red: 1.0, green: 1.0, blue: 1.0),         // white card
         nodeBg0: Color(red: 0.988, green: 0.984, blue: 0.973),     // #fcfbf8

--- a/Sources/BlinkApp/SettingsView.swift
+++ b/Sources/BlinkApp/SettingsView.swift
@@ -152,11 +152,6 @@ struct SettingsView: View {
         )
     }
 
-    /// Pretty form of a config chord string ("hyper+n" -> "⌃⌥⇧⌘N").
-    private func chord(_ raw: String) -> String {
-        KeyChord.parse(raw)?.display ?? raw
-    }
-
     var body: some View {
         HStack(spacing: 0) {
             sidebar
@@ -275,7 +270,6 @@ struct SettingsView: View {
         case .general: generalPage
         case .notes: notesPage
         case .desktop: desktopPage
-        case .shortcuts: shortcutsPage
         }
     }
 
@@ -414,7 +408,7 @@ struct SettingsView: View {
             HudSettingsSection("Appearance", labelTint: settingsTheme.palette.muted) {
                 HudSettingsControlRow(
                     title: "Appearance",
-                    subtitle: "Auto follows macOS",
+                    subtitle: "Utilities only; notes may differ",
                     icon: "circle.lefthalf.filled"
                 ) {
                     Picker("Appearance", selection: appearance) {
@@ -523,108 +517,6 @@ struct SettingsView: View {
         }
     }
 
-    private var shortcutsPage: some View {
-        VStack(alignment: .leading, spacing: HudSpacing.xl) {
-            HudSettingsSection(
-                "Global — configurable in config.json",
-                labelTint: settingsTheme.palette.muted
-            ) {
-                ShortcutRow(
-                    icon: "plus.square",
-                    title: "New note",
-                    subtitle: "Works from any app",
-                    keys: chord(store.config.hotkeys.newNote)
-                )
-                SettingsDivider()
-                ShortcutRow(
-                    icon: "eye",
-                    title: "Blink all notes / none",
-                    subtitle: "Works from any app",
-                    keys: chord(store.config.hotkeys.blink)
-                )
-                SettingsDivider()
-                ShortcutRow(
-                    icon: "square.grid.3x3",
-                    title: "Grid overlay",
-                    subtitle: "Works from any app",
-                    keys: chord(store.config.hotkeys.grid)
-                )
-            }
-
-            HudSettingsSection(
-                "Panel — configurable in config.json",
-                labelTint: settingsTheme.palette.muted
-            ) {
-                ShortcutRow(
-                    icon: "book.closed",
-                    title: "Flip read / edit",
-                    keys: chord(store.config.hotkeys.toggleMode)
-                )
-                SettingsDivider()
-                ShortcutRow(
-                    icon: "circle.dashed",
-                    title: "Focus",
-                    keys: chord(store.config.hotkeys.focus)
-                )
-            }
-
-            HudSettingsSection("Panel — fixed", labelTint: settingsTheme.palette.muted) {
-                ShortcutRow(icon: "square.and.arrow.down", title: "Save note", keys: "⌘S")
-                SettingsDivider()
-                ShortcutRow(icon: "xmark.square", title: "Close panel", keys: "⌘W")
-                SettingsDivider()
-                ShortcutRow(
-                    icon: "escape",
-                    title: "Step back",
-                    subtitle: "Leave edit, then leave focus",
-                    keys: "⎋"
-                )
-            }
-
-            HudSettingsSection(
-                "Blink & Capture — fixed",
-                labelTint: settingsTheme.palette.muted
-            ) {
-                ShortcutRow(icon: "command", title: "Command palette", keys: "⌘K")
-                SettingsDivider()
-                ShortcutRow(icon: "gearshape", title: "Settings", keys: "⌘,")
-                SettingsDivider()
-                ShortcutRow(
-                    icon: "arrow.turn.down.left",
-                    title: "Open selected note",
-                    subtitle: "In the capture popover",
-                    keys: "↩"
-                )
-                SettingsDivider()
-                ShortcutRow(
-                    icon: "plus",
-                    title: "Create from typed text",
-                    subtitle: "In the capture popover",
-                    keys: "⌘↩"
-                )
-            }
-
-            HudSettingsSection("Grid — fixed", labelTint: settingsTheme.palette.muted) {
-                ShortcutRow(
-                    icon: "square.grid.3x3",
-                    title: "Place selected note",
-                    subtitle: "Nine positions follow the keyboard grid",
-                    keys: "Q–C"
-                )
-                SettingsDivider()
-                ShortcutRow(icon: "escape", title: "Cancel grid", keys: "⎋")
-            }
-
-            HudSettingsRow(
-                icon: "curlybraces",
-                title: "Rebind configurable shortcuts",
-                subtitle: "Edit the hotkeys section in config.json; Blink applies changes live",
-                onTap: openConfig
-            )
-            .accessibilityHint("Opens Blink's JSON configuration file")
-        }
-    }
-
     private func openConfig() {
         NSWorkspace.shared.open(store.fileURL)
     }
@@ -634,7 +526,6 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
     case general
     case notes
     case desktop
-    case shortcuts
 
     var id: String { rawValue }
 
@@ -643,7 +534,6 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
         case .general: "General"
         case .notes: "Notes"
         case .desktop: "Desktop"
-        case .shortcuts: "Shortcuts"
         }
     }
 
@@ -652,7 +542,6 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
         case .general: "Files, startup and session behavior"
         case .notes: "How new notes look and open"
         case .desktop: "Appearance, focus, movement and gestures"
-        case .shortcuts: "Keyboard actions grouped by where they work"
         }
     }
 
@@ -661,7 +550,6 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
         case .general: "gearshape"
         case .notes: "note.text"
         case .desktop: "display"
-        case .shortcuts: "keyboard"
         }
     }
 }
@@ -715,53 +603,5 @@ private struct SettingsDivider: View {
             .frame(height: HudStrokeWidth.thin)
             .padding(.leading, HudIconSize.medium + HudSpacing.xl + HudSpacing.md)
             .accessibilityHidden(true)
-    }
-}
-
-private struct ShortcutRow: View {
-    let icon: String
-    let title: String
-    var subtitle: String?
-    let keys: String
-
-    init(icon: String, title: String, subtitle: String? = nil, keys: String) {
-        self.icon = icon
-        self.title = title
-        self.subtitle = subtitle
-        self.keys = keys
-    }
-
-    var body: some View {
-        HudSettingsRow(
-            icon: icon,
-            title: title,
-            subtitle: subtitle,
-            badge: { KeyCap(keys) }
-        )
-    }
-}
-
-/// Small keycap chip for shortcut rows.
-private struct KeyCap: View {
-    let keys: String
-    @Environment(\.hudTheme) private var theme
-
-    init(_ keys: String) { self.keys = keys }
-
-    var body: some View {
-        Text(keys)
-            .font(.system(size: 11, weight: .medium, design: .monospaced))
-            .foregroundStyle(theme.palette.muted)
-            .padding(.horizontal, HudSpacing.sm)
-            .padding(.vertical, HudSpacing.xxs)
-            .background(
-                RoundedRectangle(cornerRadius: theme.radius.tight)
-                    .fill(theme.palette.chrome)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: theme.radius.tight)
-                    .stroke(theme.hairline.standard, lineWidth: HudStrokeWidth.thin)
-            )
-            .accessibilityLabel("Keyboard shortcut \(keys)")
     }
 }

--- a/Sources/BlinkCLI/BlinkCLI.swift
+++ b/Sources/BlinkCLI/BlinkCLI.swift
@@ -16,7 +16,7 @@ struct BlinkCommand: AsyncParsableCommand {
         else ~/Library/Application Support/Blink/Notes. Every command takes \
         --json for structured output.
         """,
-        version: "2.0.4",
+        version: "2.0.5",
         subcommands: [
             Ls.self, Cat.self, New.self, Present.self, Append.self, Type.self, Write.self,
             Search.self, Rm.self, PathCommand.self, WorkspaceCommand.self,

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arach/blink",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Spatial notes for macOS — native floating panels and an agent-first CLI over local Markdown.",
   "homepage": "https://blink.arach.dev",
   "bugs": {

--- a/web/editor/README.md
+++ b/web/editor/README.md
@@ -91,7 +91,7 @@ hard-coded values. Native code overrides them at runtime via
 | `--blink-code-bg` | `rgba(255,255,255,0.07)` | Code chip / block background. |
 | `--blink-code-text` | `rgba(255,255,255,0.8)` | Code text (inline + block). |
 | `--blink-caret` | `#ffffff` | Text caret / cursor. |
-| `--blink-selection` | `rgba(255,255,255,0.18)` | Editor and reader selection highlight (+ selection match); light mode supplies a stronger amber wash. |
+| `--blink-selection` | `rgba(255,255,255,0.18)` | Editor and reader selection highlight (+ selection match); light mode supplies a stronger blue wash. |
 | `--blink-h1-size` | `20px` | H1 size (reader). Editor derives `calc(… - 3px)` → 17px. |
 | `--blink-h2-size` | `17px` | H2 size (reader). Editor derives `calc(… - 3px)` → 14px. |
 | `--blink-h3-size` | `15px` | H3–H6 size (reader). Editor derives `calc(… - 3px)` → 12px. |


### PR DESCRIPTION
## Summary

- make constellation notes draggable within bounded canvas geometry while preserving stable selection sizing
- improve grid, card, and list presentation and clarify Commands, Help, and Settings roles
- replace the coral interaction palette with accessible cobalt across Blink discovery surfaces
- bump the CLI and npm package to 2.0.5 for the signed release

## Verification

- swift build
- swift test — 126 tests passed
- native visual verification of Commands and Help & Shortcuts
- Impeccable UI detector — no findings
- tools/release/ship.sh --dry-run — resolves v2.0.5 CLI and DMG assets

## Release

After merge, publish the canonical signed and notarized v2.0.5 GitHub release, then tag npm-v2.0.5 for npm provenance publishing.