### PR TITLE
🌓 Add system-aware landing themes

### DIFF
--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -5,6 +5,7 @@
 @layer base {
   /* Default: warm parchment with bottle-green interaction. Optional: forest dark. */
   :root {
+    color-scheme: light;
     --bg: #efe8d8;
     --bg-2: #f4eddf;
     --panel: #f8f3e8;
@@ -66,6 +67,7 @@
 
   /* Forest dark keeps the same parchment/botanical material world after sunset. */
   [data-theme="black"] {
+    color-scheme: dark;
     --bg: #07100b;
     --bg-2: #0b1710;
     --panel: #102118;

--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -18,6 +18,25 @@ const cormorantGaramond = Cormorant_Garamond({
   display: "swap",
 })
 
+const themeBootScript = `try{
+  var raw=new URLSearchParams(location.search).get('theme');
+  var normalize=function(value){
+    if(value==='light'||value==='cream')return 'light';
+    if(value==='dark'||value==='black')return 'dark';
+    if(value==='auto')return 'auto';
+    return null;
+  };
+  var query=normalize(raw);
+  var saved=null;
+  try{saved=normalize(localStorage.getItem('blink-theme'));}catch(e){}
+  var preference=query||saved||'auto';
+  if(query){try{localStorage.setItem('blink-theme',preference);}catch(e){}}
+  document.documentElement.setAttribute('data-theme-preference',preference);
+  var dark=preference==='dark'||(preference==='auto'&&window.matchMedia('(prefers-color-scheme: dark)').matches);
+  if(dark)document.documentElement.setAttribute('data-theme','black');
+  else document.documentElement.removeAttribute('data-theme');
+}catch(e){}`
+
 export const metadata: Metadata = {
   metadataBase: new URL("https://blink.arach.dev"),
   title: "Blink — Spatial notes for your Mac",
@@ -55,11 +74,10 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body>
-        {/* Apply cream (default) or black before paint — no flash. */}
+        {/* Resolve light, dark, or the macOS preference before paint — no flash. */}
         <script
           dangerouslySetInnerHTML={{
-            __html:
-              "try{var p=new URLSearchParams(location.search).get('theme');var t=p||localStorage.getItem('blink-theme');if(p){try{localStorage.setItem('blink-theme',p==='black'?'black':'cream')}catch(e){}}if(t==='black')document.documentElement.setAttribute('data-theme','black');else document.documentElement.removeAttribute('data-theme')}catch(e){}",
+            __html: themeBootScript,
           }}
         />
         {children}

--- a/landing/components/homepage/AgentGuide.tsx
+++ b/landing/components/homepage/AgentGuide.tsx
@@ -92,8 +92,8 @@ export default function AgentGuide() {
                 <span className="text-[11px] font-medium text-[var(--text)]">zero → spatial note</span>
                 <span className="text-[10px] text-faintx">macOS 14+ · arm64</span>
               </div>
-              <div className="overflow-x-auto p-4 md:p-5">
-                <pre className="min-w-[520px] text-[11.5px] leading-[1.9] text-dimx">
+              <div className="p-4 md:p-5">
+                <pre className="whitespace-pre-wrap break-words text-[11.5px] leading-[1.9] text-dimx">
                   <code>{`npm install -g @arach/blink
 blink app install
 blink app open

--- a/landing/components/homepage/Chrome.tsx
+++ b/landing/components/homepage/Chrome.tsx
@@ -39,12 +39,13 @@ export function TopBar() {
             href="https://github.com/arach/blink"
             target="_blank"
             rel="noreferrer"
-            className="inline-flex h-8 items-center gap-1.5 rounded-[5px] border border-line2x bg-panelx px-3 text-[11px] text-dimx hover:text-[var(--text)] hover:border-[var(--line-2)] hover:bg-panel2x transition-colors"
+            aria-label="GitHub"
+            className="inline-flex h-11 min-w-11 items-center justify-center gap-1.5 rounded-[5px] border border-line2x bg-panelx px-0 text-[11px] text-dimx hover:text-[var(--text)] hover:border-[var(--line-2)] hover:bg-panel2x transition-colors min-[360px]:px-3"
           >
             <svg viewBox="0 0 16 16" className="h-3.5 w-3.5 fill-current" aria-hidden>
               <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
             </svg>
-            github
+            <span className="hidden min-[360px]:inline">github</span>
           </a>
         </div>
       </div>

--- a/landing/components/homepage/ThemeSwitcher.tsx
+++ b/landing/components/homepage/ThemeSwitcher.tsx
@@ -1,70 +1,159 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
-/** Parchment light (default :root) or forest dark. IDs stay stable for saved preferences. */
 const THEMES = [
-  { id: 'cream', bg: '#efe8d8', acc: '#2f6447', label: 'parchment light' },
-  { id: 'black', bg: '#07100b', acc: '#93c6a2', label: 'forest dark' },
+  { id: 'light', label: 'Light', detail: 'Parchment light' },
+  { id: 'dark', label: 'Dark', detail: 'Forest dark' },
+  { id: 'auto', label: 'Auto', detail: 'Follow macOS' },
 ] as const
 
-type ThemeId = (typeof THEMES)[number]['id']
+type ThemePreference = (typeof THEMES)[number]['id']
 
-function applyTheme(id: ThemeId) {
+const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)'
+
+function normalize(raw: string | null): ThemePreference | null {
+  if (raw === 'light' || raw === 'cream') return 'light'
+  if (raw === 'dark' || raw === 'black') return 'dark'
+  if (raw === 'auto') return 'auto'
+  return null
+}
+
+function applyTheme(preference: ThemePreference, systemDark?: boolean) {
   const root = document.documentElement
-  if (id === 'cream') root.removeAttribute('data-theme')
-  else root.setAttribute('data-theme', 'black')
+  const dark =
+    preference === 'dark' ||
+    (preference === 'auto' &&
+      (systemDark ?? window.matchMedia(SYSTEM_DARK_QUERY).matches))
+
+  root.setAttribute('data-theme-preference', preference)
+  if (dark) root.setAttribute('data-theme', 'black')
+  else root.removeAttribute('data-theme')
 }
 
-function normalize(raw: string | null): ThemeId {
-  if (raw === 'black') return 'black'
-  // Migrate old multi-theme ids → cream default (except explicit black)
-  return 'cream'
-}
+function ThemeIcon({ id }: { id: ThemePreference }) {
+  if (id === 'light') {
+    return (
+      <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="1.25" aria-hidden>
+        <circle cx="8" cy="8" r="2.5" />
+        <path d="M8 1.25v1.5M8 13.25v1.5M1.25 8h1.5M13.25 8h1.5M3.23 3.23l1.06 1.06M11.71 11.71l1.06 1.06M12.77 3.23l-1.06 1.06M4.29 11.71l-1.06 1.06" />
+      </svg>
+    )
+  }
 
-export function ThemeSwitcher() {
-  const [active, setActive] = useState<ThemeId>('cream')
-
-  useEffect(() => {
-    const attr = document.documentElement.getAttribute('data-theme')
-    const saved = normalize(attr || localStorage.getItem('blink-theme'))
-    setActive(saved)
-    applyTheme(saved)
-  }, [])
-
-  const pick = (id: ThemeId) => {
-    setActive(id)
-    applyTheme(id)
-    try {
-      localStorage.setItem('blink-theme', id)
-    } catch {}
+  if (id === 'dark') {
+    return (
+      <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="1.25" aria-hidden>
+        <path d="M12.9 10.65A5.8 5.8 0 0 1 5.35 3.1 5.85 5.85 0 1 0 12.9 10.65Z" />
+      </svg>
+    )
   }
 
   return (
-    <div className="flex items-center" role="radiogroup" aria-label="color theme">
-      {THEMES.map((t) => {
-        const on = active === t.id
+    <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="1.25" aria-hidden>
+      <rect x="2.25" y="3" width="11.5" height="8.25" rx="1.25" />
+      <path d="M6 13.25h4M8 11.25v2" />
+    </svg>
+  )
+}
+
+export function ThemeSwitcher() {
+  const [active, setActive] = useState<ThemePreference>('auto')
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([])
+
+  useEffect(() => {
+    const query = normalize(new URLSearchParams(window.location.search).get('theme'))
+    const bootPreference = normalize(document.documentElement.getAttribute('data-theme-preference'))
+    let saved: ThemePreference | null = null
+
+    try {
+      saved = normalize(localStorage.getItem('blink-theme'))
+    } catch {}
+
+    const preference = query ?? bootPreference ?? saved ?? 'auto'
+    const media = window.matchMedia(SYSTEM_DARK_QUERY)
+
+    setActive(preference)
+    applyTheme(preference, media.matches)
+    try {
+      localStorage.setItem('blink-theme', preference)
+    } catch {}
+
+    const syncSystemTheme = (event: MediaQueryListEvent) => {
+      if (document.documentElement.getAttribute('data-theme-preference') === 'auto') {
+        applyTheme('auto', event.matches)
+      }
+    }
+    const syncSavedTheme = (event: StorageEvent) => {
+      if (event.key !== 'blink-theme') return
+      const next = normalize(event.newValue) ?? 'auto'
+      setActive(next)
+      applyTheme(next, media.matches)
+    }
+
+    media.addEventListener('change', syncSystemTheme)
+    window.addEventListener('storage', syncSavedTheme)
+    return () => {
+      media.removeEventListener('change', syncSystemTheme)
+      window.removeEventListener('storage', syncSavedTheme)
+    }
+  }, [])
+
+  const pick = (preference: ThemePreference) => {
+    setActive(preference)
+    applyTheme(preference)
+    try {
+      localStorage.setItem('blink-theme', preference)
+      const url = new URL(window.location.href)
+      url.searchParams.set('theme', preference)
+      window.history.replaceState(window.history.state, '', url)
+    } catch {}
+  }
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex = index
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') nextIndex = (index + 1) % THEMES.length
+    else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') nextIndex = (index - 1 + THEMES.length) % THEMES.length
+    else if (event.key === 'Home') nextIndex = 0
+    else if (event.key === 'End') nextIndex = THEMES.length - 1
+    else return
+
+    event.preventDefault()
+    const next = THEMES[nextIndex].id
+    pick(next)
+    optionRefs.current[nextIndex]?.focus()
+  }
+
+  return (
+    <div
+      className="inline-flex items-center rounded-[6px] border border-line2x bg-panelx p-0.5"
+      role="radiogroup"
+      aria-label="Color theme"
+    >
+      {THEMES.map((theme, index) => {
+        const selected = active === theme.id
         return (
           <button
-            key={t.id}
+            key={theme.id}
+            ref={(element) => {
+              optionRefs.current[index] = element
+            }}
             type="button"
             role="radio"
-            aria-checked={on}
-            aria-label={`${t.label} theme`}
-            title={t.label}
-            onClick={() => pick(t.id)}
-            className="inline-flex h-8 w-7 items-center justify-center rounded-sm transition-transform hover:scale-105"
+            aria-checked={selected}
+            aria-label={`${theme.label} theme`}
+            title={`${theme.label} — ${theme.detail}`}
+            tabIndex={selected ? 0 : -1}
+            onClick={() => pick(theme.id)}
+            onKeyDown={(event) => onKeyDown(event, index)}
+            className={[
+              'inline-flex h-11 w-11 items-center justify-center rounded-[4px] transition-[color,background-color,box-shadow] duration-150',
+              selected
+                ? 'bg-[var(--acc-soft)] text-acc shadow-[inset_0_0_0_1px_rgba(var(--acc-rgb),0.28)]'
+                : 'text-faintx hover:bg-[var(--acc-soft)] hover:text-[var(--text)]',
+            ].join(' ')}
           >
-            <span
-              className="block h-[12px] w-[12px] rounded-full"
-              style={{
-                backgroundColor: t.bg,
-                opacity: on ? 1 : 0.55,
-                boxShadow: on
-                  ? `inset 0 0 0 1px ${t.acc}, 0 0 0 2px var(--bg), 0 0 0 3px ${t.acc}`
-                  : `inset 0 0 0 1px ${t.acc}`,
-              }}
-            />
+            <ThemeIcon id={theme.id} />
           </button>
         )
       })}


### PR DESCRIPTION
## Summary

- add Light, Dark, and Auto preferences with pre-paint system resolution
- migrate legacy cream/black values and keep URL, localStorage, and cross-tab state aligned
- add accessible radio-keyboard behavior and 44px touch targets down to 320px
- wrap the agent install snippet instead of forcing horizontal scrolling

## Verification

- `cd landing && bunx tsc --noEmit`
- `cd landing && bun run build`
- agent-browser visual checks at 1440×1100 in light/dark and 390×844 plus 320×700 on mobile
- verified Light/Dark/Auto persistence, legacy `?theme=black` migration, roving Arrow-key focus, and zero horizontal overflow
- `git diff --check`