### PR TITLE
✨ Add workspace-scoped live desk controls

### DIFF
--- a/Sources/BlinkApp/AppDelegate.swift
+++ b/Sources/BlinkApp/AppDelegate.swift
@@ -33,6 +33,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         store = NoteStore(fileStore: NoteFileStore(directory: Self.notesDirectory()))
         panelManager = PanelManager(store: store)
         model = AppModel(store: store, panelManager: panelManager)
+        panelManager.onWorkspaceScopeRequested = { [weak self] scope in
+            self?.model.selectWorkspace(scope)
+        }
         panelManager.startObservingStore()
         configureDiscovery()
         commandRequestObserver = NotificationCenter.default.addObserver(
@@ -44,6 +47,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 self?.toggleCommandPalette(from: nil)
             }
         }
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(receiveDeskCommand(_:)),
+            name: BlinkDeskCommand.notificationName,
+            object: nil
+        )
 
         // The filesystem is the API: external writers (the blink CLI, agents)
         // touch the Notes directory; reconcile diffs disk against memory and
@@ -256,7 +265,162 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         if let commandRequestObserver {
             NotificationCenter.default.removeObserver(commandRequestObserver)
         }
+        DistributedNotificationCenter.default().removeObserver(
+            self,
+            name: BlinkDeskCommand.notificationName,
+            object: nil
+        )
     }
+
+    /// Realize the CLI's narrow live-desk verbs through AppModel and
+    /// PanelManager. Content never crosses this channel; files remain the
+    /// durable API and PanelManager remains the sole panel lifecycle owner.
+    @objc
+    private func receiveDeskCommand(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let requestID = userInfo[BlinkDeskCommand.Key.requestID] as? String,
+              let requestedHome = userInfo[BlinkDeskCommand.Key.home] as? String,
+              requestedHome == BlinkDeskCommand.canonicalHomePath()
+        else { return }
+
+        guard
+              let rawVerb = userInfo[BlinkDeskCommand.Key.verb] as? String,
+              let verb = BlinkDeskCommand.Verb(rawValue: rawVerb),
+              let noteID = userInfo[BlinkDeskCommand.Key.noteID] as? String
+        else {
+            log.error("[BLINK] ignored malformed desk command")
+            sendDeskResponse(
+                requestID: requestID,
+                success: false,
+                error: "Blink received a malformed desk command"
+            )
+            return
+        }
+
+        let request = DeskCommandRequest(
+            verb: verb,
+            noteID: noteID,
+            x: deskNumber(.x, in: userInfo),
+            y: deskNumber(.y, in: userInfo),
+            width: deskNumber(.width, in: userInfo),
+            height: deskNumber(.height, in: userInfo),
+            display: (userInfo[BlinkDeskCommand.Key.display] as? NSNumber)?.intValue,
+            animated: (userInfo[BlinkDeskCommand.Key.animated] as? NSNumber)?.boolValue ?? true
+        )
+        Task {
+            let result = await handleDeskCommand(request)
+            sendDeskResponse(
+                requestID: requestID,
+                success: result.success,
+                error: result.error
+            )
+        }
+    }
+
+    private func handleDeskCommand(_ request: DeskCommandRequest) async -> DeskCommandResult {
+        let verb = request.verb
+        let noteID = request.noteID
+        let applied: Bool
+
+        switch verb {
+        case .open:
+            applied = await model.openNote(
+                id: noteID,
+                deskFrame: request.hasFrame ? request.deskFrame : nil
+            )
+        case .move:
+            guard await model.openNote(id: noteID) else {
+                return .failure("Note “\(noteID)” was not found")
+            }
+            applied = panelManager.applyDeskFrame(
+                noteID: noteID,
+                x: request.x,
+                y: request.y,
+                width: request.width,
+                height: request.height,
+                display: request.display,
+                animated: request.animated
+            )
+        case .focus:
+            applied = await model.openNote(id: noteID)
+        case .close:
+            applied = panelManager.closePanel(noteID: noteID)
+        }
+
+        guard applied else {
+            return .failure("Blink could not \(verb.rawValue) note “\(noteID)”")
+        }
+
+        log.info(
+            "[BLINK] desk command applied",
+            metadata: ["verb": verb.rawValue, "id": noteID]
+        )
+        return .success
+    }
+
+    private func sendDeskResponse(requestID: String, success: Bool, error: String?) {
+        var userInfo: [AnyHashable: Any] = [
+            BlinkDeskCommand.Key.requestID: requestID,
+            BlinkDeskCommand.Key.success: success,
+        ]
+        if let error { userInfo[BlinkDeskCommand.Key.error] = error }
+        DistributedNotificationCenter.default().post(
+            name: BlinkDeskCommand.responseNotificationName,
+            object: nil,
+            userInfo: userInfo
+        )
+    }
+
+    private enum DeskNumberKey {
+        case x, y, width, height
+
+        var rawValue: String {
+            switch self {
+            case .x: BlinkDeskCommand.Key.x
+            case .y: BlinkDeskCommand.Key.y
+            case .width: BlinkDeskCommand.Key.width
+            case .height: BlinkDeskCommand.Key.height
+            }
+        }
+    }
+
+    private struct DeskCommandRequest: Sendable {
+        let verb: BlinkDeskCommand.Verb
+        let noteID: String
+        let x: CGFloat?
+        let y: CGFloat?
+        let width: CGFloat?
+        let height: CGFloat?
+        let display: Int?
+        let animated: Bool
+
+        var hasFrame: Bool {
+            x != nil || y != nil || width != nil || height != nil || display != nil
+        }
+
+        var deskFrame: DeskFrameRequest {
+            DeskFrameRequest(x: x, y: y, width: width, height: height, display: display)
+        }
+    }
+
+    private struct DeskCommandResult {
+        let success: Bool
+        let error: String?
+
+        static let success = DeskCommandResult(success: true, error: nil)
+
+        static func failure(_ error: String) -> DeskCommandResult {
+            DeskCommandResult(success: false, error: error)
+        }
+    }
+
+    private func deskNumber(
+        _ key: DeskNumberKey,
+        in userInfo: [AnyHashable: Any]
+    ) -> CGFloat? {
+        (userInfo[key.rawValue] as? NSNumber).map { CGFloat($0.doubleValue) }
+    }
+
 
     private func newNote() {
         log.info("[BLINK] new-note requested", metadata: ["source": "hotkey"])

--- a/Sources/BlinkApp/AppModel.swift
+++ b/Sources/BlinkApp/AppModel.swift
@@ -3,6 +3,55 @@ import Foundation
 import HudsonObservability
 import SwiftUI
 
+/// The live desktop boundary. Durable membership remains in each note's
+/// frontmatter; this device-local selection only decides which group the
+/// popover browses and which already-open panels are visible right now.
+enum WorkspaceScope: Hashable {
+    case all
+    case unfiled
+    case workspace(String)
+
+    private static let allKey = "scope:all"
+    private static let unfiledKey = "scope:unfiled"
+
+    init(storageValue: String?) {
+        switch storageValue {
+        case Self.unfiledKey:
+            self = .unfiled
+        case let value? where value.hasPrefix("workspace:"):
+            let id = String(value.dropFirst("workspace:".count))
+            self = id.isEmpty ? .all : .workspace(id)
+        default:
+            self = .all
+        }
+    }
+
+    var storageValue: String {
+        switch self {
+        case .all: Self.allKey
+        case .unfiled: Self.unfiledKey
+        case .workspace(let id): "workspace:\(id)"
+        }
+    }
+
+    var workspaceIDForNewNote: String? {
+        guard case .workspace(let id) = self else { return nil }
+        return id
+    }
+
+    func includes(workspace: String?) -> Bool {
+        switch self {
+        case .all: true
+        case .unfiled: workspace == nil
+        case .workspace(let id): workspace == id
+        }
+    }
+
+    static func containing(workspace: String?) -> WorkspaceScope {
+        workspace.map(Self.workspace) ?? .unfiled
+    }
+}
+
 /// The single observable source of truth for every UI surface (popover, panels,
 /// future palette). Mirrors the `NoteStore` actor into a @Published snapshot,
 /// refreshed on every store notification — so any surface that mutates notes
@@ -10,6 +59,7 @@ import SwiftUI
 @MainActor
 final class AppModel: ObservableObject {
     @Published private(set) var notes: [Note] = []
+    @Published private(set) var workspaceScope: WorkspaceScope
 
     private let store: NoteStore
     private let panelManager: PanelManager
@@ -19,6 +69,10 @@ final class AppModel: ObservableObject {
     init(store: NoteStore, panelManager: PanelManager) {
         self.store = store
         self.panelManager = panelManager
+        workspaceScope = WorkspaceScope(
+            storageValue: UserDefaults.standard.string(forKey: ConfigKeys.activeWorkspaceScope)
+        )
+        panelManager.configureWorkspaceScope(workspaceScope)
     }
 
     /// Register for store notifications and take the initial snapshot.
@@ -37,13 +91,26 @@ final class AppModel: ObservableObject {
     }
 
     func refresh() async {
-        notes = await store.all()
+        let snapshot = await store.all()
+        notes = snapshot
+        panelManager.applyWorkspaceScope(workspaceScope, notes: snapshot, animated: false)
+    }
+
+    /// Activate a device-local workspace view. Panels outside the selection are
+    /// hidden, never closed, so their pending text, exact frames, and open-set
+    /// membership remain untouched for the next switch.
+    func selectWorkspace(_ scope: WorkspaceScope) {
+        workspaceScope = scope
+        UserDefaults.standard.set(scope.storageValue, forKey: ConfigKeys.activeWorkspaceScope)
+        panelManager.applyWorkspaceScope(scope, notes: notes, animated: true, activate: true)
     }
 
     /// Create a note (optionally seeded with captured text) and open its panel.
     func createNote(content: String = "") async {
         do {
-            let note = try await store.create(content: content)
+            var presentation = NotePresentation()
+            presentation.workspace = workspaceScope.workspaceIDForNewNote
+            let note = try await store.create(content: content, presentation: presentation)
             // New notes always open in edit — you just created it to type.
             panelManager.openPanel(for: note, initialMode: "edit")
         } catch {
@@ -52,9 +119,26 @@ final class AppModel: ObservableObject {
     }
 
     /// Open (or focus) the panel for an existing note.
-    func openNote(id: String) async {
-        guard let note = await store.note(id: id) else { return }
-        panelManager.openPanel(for: note)
+    @discardableResult
+    func openNote(id: String, deskFrame: DeskFrameRequest? = nil) async -> Bool {
+        var note = await store.note(id: id)
+        if note == nil {
+            // A CLI can create and open in immediate succession, beating the
+            // directory watcher's coalesced event by a few milliseconds.
+            // Reconcile once at this explicit boundary rather than making the
+            // caller guess a sleep duration.
+            _ = await store.reconcile()
+            note = await store.note(id: id)
+        }
+        guard let note else {
+            log.error("[BLINK] open failed", metadata: ["id": id, "error": "note not found"])
+            return false
+        }
+        if !workspaceScope.includes(workspace: note.presentation.workspace) {
+            selectWorkspace(.containing(workspace: note.presentation.workspace))
+        }
+        panelManager.openPanel(for: note, deskFrame: deskFrame)
+        return true
     }
 
     /// Delete a note: close its panel (discarding pending edits for it) and

--- a/Sources/BlinkApp/CapturePopoverView.swift
+++ b/Sources/BlinkApp/CapturePopoverView.swift
@@ -2,6 +2,12 @@ import AppKit
 import BlinkCore
 import SwiftUI
 
+private struct WorkspaceMenuEntry: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let noteCount: Int
+}
+
 /// The menubar popover is Blink's compact workspace: capture/search spans the
 /// whole workspace, with recents on the left and a spatial overview on the
 /// right.
@@ -52,11 +58,34 @@ struct CapturePopoverView: View {
         query.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Definitions make empty workspaces selectable; note membership keeps an
+    /// unknown/removed definition browseable rather than orphaning its notes.
+    private var workspaceEntries: [WorkspaceMenuEntry] {
+        let configured = configStore.config.workspaces ?? [:]
+        let ids = Set(configured.keys).union(
+            model.notes.compactMap(\.presentation.workspace)
+        )
+        return ids.map { id in
+            let configuredTitle = configured[id]?.title?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let title = configuredTitle.flatMap { $0.isEmpty ? nil : $0 } ?? id
+            let count = model.notes.filter { $0.presentation.workspace == id }.count
+            return WorkspaceMenuEntry(id: id, title: title, noteCount: count)
+        }
+        .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+    }
+
+    private var scopedNotes: [Note] {
+        model.notes.filter {
+            model.workspaceScope.includes(workspace: $0.presentation.workspace)
+        }
+    }
+
     private var filtered: [Note] {
-        guard !trimmedQuery.isEmpty else { return Array(model.notes.prefix(12)) }
+        guard !trimmedQuery.isEmpty else { return Array(scopedNotes.prefix(12)) }
         let needle = trimmedQuery.lowercased()
         return Array(
-            model.notes
+            scopedNotes
                 .filter {
                     $0.title.lowercased().contains(needle)
                         || $0.content.lowercased().contains(needle)
@@ -69,6 +98,21 @@ struct CapturePopoverView: View {
     private var selectedNote: Note? {
         guard let selectedNoteID else { return nil }
         return filtered.first(where: { $0.id == selectedNoteID })
+    }
+
+    private var activeWorkspaceTitle: String {
+        switch model.workspaceScope {
+        case .all: "All notes"
+        case .unfiled: "Unfiled"
+        case .workspace(let id): workspaceEntries.first { $0.id == id }?.title ?? id
+        }
+    }
+
+    private var capturePlaceholder: String {
+        switch model.workspaceScope {
+        case .all: "Search or capture…"
+        default: "Search or capture in \(activeWorkspaceTitle)…"
+        }
     }
 
     var body: some View {
@@ -98,7 +142,11 @@ struct CapturePopoverView: View {
                 .opacity(0)
         )
         .onAppear {
+            normalizeWorkspaceScope()
             fieldFocused = true
+        }
+        .onChange(of: workspaceEntries.map(\.id)) { _, _ in
+            normalizeWorkspaceScope()
         }
         .onChange(of: filtered.map(\.id)) { _, ids in
             if let selectedNoteID, ids.contains(selectedNoteID) { return }
@@ -129,13 +177,26 @@ struct CapturePopoverView: View {
                 .font(.system(size: 15, weight: .light))
                 .foregroundStyle(pal.inkMuted)  // #6b7072
 
-            TextField("Search or capture…", text: $query)
+            TextField(capturePlaceholder, text: $query)
                 .textFieldStyle(.plain)
                 .font(mono(15, .light))
                 .foregroundStyle(pal.inkBright)  // #e6e8e6
                 .tint(accent)
                 .focused($fieldFocused)
                 .onSubmit { openFirstOrCreate() }
+
+            WorkspaceScopeMenu(
+                selection: model.workspaceScope,
+                title: activeWorkspaceTitle,
+                count: scopedNotes.count,
+                allCount: model.notes.count,
+                unfiledCount: model.notes.filter { $0.presentation.workspace == nil }.count,
+                workspaces: workspaceEntries
+            ) { scope in
+                query = ""
+                selectedNoteID = nil
+                model.selectWorkspace(scope)
+            }
 
             toolbarSeparator
 
@@ -189,8 +250,8 @@ struct CapturePopoverView: View {
             .padding(.top, 15)
             .padding(.bottom, 10)
 
-            if model.notes.isEmpty {
-                emptyState("No notes yet — create your first thought.")
+            if scopedNotes.isEmpty {
+                emptyState(sidebarEmptyMessage)
             } else if filtered.isEmpty {
                 emptyState("No matches — Return creates “\(trimmedQuery)”.")
             } else {
@@ -250,6 +311,18 @@ struct CapturePopoverView: View {
                     .font(mono(10))
                     .tracking(1.6)
                     .foregroundStyle(pal.inkMid)
+
+                if model.workspaceScope != .all {
+                    Text("/")
+                        .font(mono(10))
+                        .foregroundStyle(pal.inkGhost)
+                    Text(activeWorkspaceTitle.uppercased())
+                        .font(mono(9.5, .medium))
+                        .tracking(0.8)
+                        .foregroundStyle(accentBright)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
 
                 Spacer()
 
@@ -324,9 +397,14 @@ struct CapturePopoverView: View {
             Image(systemName: "point.3.connected.trianglepath.dotted")
                 .font(.system(size: 30, weight: .light))
                 .foregroundStyle(pal.strokeBase.opacity(0.18))
-            Text(trimmedQuery.isEmpty ? "Your notes will gather here" : "No notes on this canvas")
+            Text(emptyCanvasTitle)
                 .font(.system(size: 12))
                 .foregroundStyle(pal.strokeBase.opacity(0.36))
+            if trimmedQuery.isEmpty, model.workspaceScope != .all {
+                Text("New notes will land in this workspace.")
+                    .font(mono(10))
+                    .foregroundStyle(pal.strokeBase.opacity(0.26))
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(CanvasSurface())
@@ -416,6 +494,36 @@ struct CapturePopoverView: View {
 
     // MARK: - Actions
 
+    private var sidebarEmptyMessage: String {
+        guard trimmedQuery.isEmpty else {
+            return "No matches — Return creates “\(trimmedQuery)”."
+        }
+        switch model.workspaceScope {
+        case .all:
+            return "No notes yet — create your first thought."
+        case .unfiled:
+            return "No unfiled notes — new notes will land here."
+        case .workspace:
+            return "Blank slate — create the first note in \(activeWorkspaceTitle)."
+        }
+    }
+
+    private var emptyCanvasTitle: String {
+        if !trimmedQuery.isEmpty { return "No notes on this canvas" }
+        return switch model.workspaceScope {
+        case .all: "Your notes will gather here"
+        case .unfiled: "No unfiled notes"
+        case .workspace: "\(activeWorkspaceTitle) is a blank slate"
+        }
+    }
+
+    private func normalizeWorkspaceScope() {
+        guard case .workspace(let id) = model.workspaceScope,
+              !workspaceEntries.contains(where: { $0.id == id })
+        else { return }
+        model.selectWorkspace(.all)
+    }
+
     private func openFirstOrCreate() {
         if let selectedNote {
             open(selectedNote)
@@ -465,6 +573,76 @@ struct CapturePopoverView: View {
         case "card": return Color(red: 0.35, green: 0.82, blue: 0.61)
         case "glass", "dotted": return accent
         default: return Color(red: 0.48, green: 0.52, blue: 0.59)
+        }
+    }
+}
+
+private struct WorkspaceScopeMenu: View {
+    @Environment(\.popoverPalette) private var pal
+    @State private var hovered = false
+
+    let selection: WorkspaceScope
+    let title: String
+    let count: Int
+    let allCount: Int
+    let unfiledCount: Int
+    let workspaces: [WorkspaceMenuEntry]
+    let onSelect: (WorkspaceScope) -> Void
+
+    var body: some View {
+        Menu {
+            scopeButton(.all, title: "All notes", count: allCount)
+            scopeButton(.unfiled, title: "Unfiled", count: unfiledCount)
+
+            if !workspaces.isEmpty {
+                Divider()
+                ForEach(workspaces) { workspace in
+                    scopeButton(
+                        .workspace(workspace.id),
+                        title: workspace.title,
+                        count: workspace.noteCount
+                    )
+                }
+            }
+        } label: {
+            HStack(spacing: 7) {
+                Image(systemName: "square.stack.3d.up")
+                    .font(.system(size: 11, weight: .light))
+                Text(title.uppercased())
+                    .font(.system(size: 9.5, weight: .medium, design: .monospaced))
+                    .tracking(0.55)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: 132, alignment: .leading)
+                Text("\(count)")
+                    .font(.system(size: 9, weight: .regular, design: .monospaced))
+                    .foregroundStyle(pal.inkMuted)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 7, weight: .semibold))
+            }
+            .foregroundStyle(hovered ? pal.ink : pal.inkMid)
+            .padding(.horizontal, 9)
+            .frame(height: 30)
+            .background(pal.strokeBase.opacity(hovered ? 0.07 : 0.025))
+            .overlay(Rectangle().stroke(pal.strokeBase.opacity(hovered ? 0.15 : 0.07), lineWidth: 1))
+            .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .onHover { isHovered in
+            withAnimation(.easeOut(duration: 0.1)) { hovered = isHovered }
+        }
+        .help("Filter notes and panels by workspace")
+        .accessibilityLabel("Workspace \(title), \(count) notes")
+    }
+
+    private func scopeButton(_ scope: WorkspaceScope, title: String, count: Int) -> some View {
+        Button { onSelect(scope) } label: {
+            Label(
+                "\(title) · \(count)",
+                systemImage: selection == scope ? "checkmark" : "circle"
+            )
         }
     }
 }

--- a/Sources/BlinkApp/ConfigStore.swift
+++ b/Sources/BlinkApp/ConfigStore.swift
@@ -6,5 +6,6 @@ import Foundation
 enum ConfigKeys {
     static let restoreSession = "blink.restoreSession"  // legacy; migrated into config.json
     static let defaultMode = "blink.defaultMode"        // legacy; migrated into config.json
+    static let activeWorkspaceScope = "blink.activeWorkspaceScope"
     static func noteMode(_ id: String) -> String { "blink.noteMode.\(id)" }
 }

--- a/Sources/BlinkApp/PanelManager.swift
+++ b/Sources/BlinkApp/PanelManager.swift
@@ -2,6 +2,16 @@ import AppKit
 import BlinkCore
 import HudsonObservability
 
+/// A top-left, display-local panel frame requested by the live agent surface.
+/// It stays inside the app target because only PanelManager can realize it.
+struct DeskFrameRequest: Sendable {
+    let x: CGFloat?
+    let y: CGFloat?
+    let width: CGFloat?
+    let height: CGFloat?
+    let display: Int?
+}
+
 /// Owns every floating note panel: one panel per note (opening an open note
 /// focuses it), debounced saves with mandatory flushes on close and quit, and
 /// reopening the last session's panels on launch.
@@ -25,11 +35,19 @@ final class PanelManager: NSObject, NSWindowDelegate {
     private var revealOrderings: [String: RevealOrdering] = [:]
     private var isTerminating = false
     private var blinkHidden = false
+    private var workspaceScope: WorkspaceScope = .all
+    private var panelWorkspaces: [String: String] = [:]
+    private var workspaceSuppressedPanelIDs: Set<String> = []
     private lazy var focusOverlay = FocusOverlay()
     private lazy var drapeOverlay = DrapeOverlay()
     private var gridOverlay: GridOverlay?
     private var mostRecentKeyPanelID: String?
     private let log = HudLogger(category: "blink.panels")
+
+    /// Linked-note navigation originates inside a panel, below AppModel. Ask the
+    /// model to move the durable UI selection before realizing a cross-workspace
+    /// target, so every launcher converges on the same active scope.
+    var onWorkspaceScopeRequested: ((WorkspaceScope) -> Void)?
 
     private static let openNotesKey = "blink.openNotes"
     private static let saveDebounce: Duration = .seconds(1)
@@ -67,7 +85,11 @@ final class PanelManager: NSObject, NSWindowDelegate {
         for id in openIDs {
             if let note = await store.note(id: id),
                // Restore silently — the staggered reveal below owns the motion.
-               let panel = openPanel(for: note, playEntrance: false) {
+               let panel = openPanel(
+                    for: note,
+                    playEntrance: false,
+                    activateWorkspaceIfNeeded: false
+               ), panel.isVisible {
                 restored.append(panel)
             }
         }
@@ -152,6 +174,7 @@ final class PanelManager: NSObject, NSWindowDelegate {
     private func applyExternalUpdate(id: String) async {
         guard let panel = panels[id], pendingText[id] == nil else { return }
         guard let note = await store.note(id: id) else { return }
+        recordPanelWorkspace(note)
 
         // Presentation is part of the live note, not launch-only decoration.
         // Merge the legacy sheet alias exactly as openPanel does, then update
@@ -353,13 +376,36 @@ final class PanelManager: NSObject, NSWindowDelegate {
     /// `playEntrance` is `false` only for session restore, which runs its own
     /// staggered entrance across all reopened panels afterward.
     @discardableResult
-    func openPanel(for note: Note, initialMode: String? = nil, playEntrance: Bool = true) -> NotePanel? {
+    func openPanel(
+        for note: Note,
+        initialMode: String? = nil,
+        playEntrance: Bool = true,
+        activateWorkspaceIfNeeded: Bool = true,
+        deskFrame: DeskFrameRequest? = nil
+    ) -> NotePanel? {
+        recordPanelWorkspace(note)
+        if activateWorkspaceIfNeeded,
+           !workspaceScope.includes(workspace: note.presentation.workspace) {
+            onWorkspaceScopeRequested?(
+                .containing(workspace: note.presentation.workspace)
+            )
+        }
+        let shouldPresent = workspaceScope.includes(workspace: note.presentation.workspace)
         // Opening a note while blinked-away: the new panel is visible, so the
         // next Hyper+B should hide everything again.
-        blinkHidden = false
+        if shouldPresent { blinkHidden = false }
         if let existing = panels[note.id] {
-            mostRecentKeyPanelID = note.id
-            existing.makeKeyAndOrderFront(nil)
+            if let deskFrame {
+                applyDeskFrame(noteID: note.id, request: deskFrame, animated: false)
+            }
+            if shouldPresent {
+                workspaceSuppressedPanelIDs.remove(note.id)
+                mostRecentKeyPanelID = note.id
+                existing.makeKeyAndOrderFront(nil)
+            } else {
+                workspaceSuppressedPanelIDs.insert(note.id)
+                existing.orderOut(nil)
+            }
             return existing
         }
 
@@ -470,20 +516,30 @@ final class PanelManager: NSObject, NSWindowDelegate {
         if playEntrance, let slot = presentation.slot {
             placeInSlot(panel, slot: slot, animated: false)
         }
+        if let deskFrame {
+            // Apply before the entrance captures its home frame; otherwise a
+            // drop animation could restore the panel to its pre-command screen.
+            applyDeskFrame(noteID: note.id, request: deskFrame, animated: false)
+        }
 
         // Land the panel with its configured entrance (a new note, popover open,
         // or a reveal). Set alpha 0 BEFORE ordering front so the window never
         // flashes fully opaque for a frame; then order in and animate up.
-        let motion = BlinkConfigStore.shared.config.motion
-        if playEntrance {
-            panel.animateEntrance(motion: motion)
-        }
-        panel.makeKeyAndOrderFront(nil)
-        mostRecentKeyPanelID = note.id
-        if mode == "edit" {
-            // Give the webview native key focus so typing and shortcuts work
-            // immediately (JS focus alone doesn't set the first responder).
-            panel.makeFirstResponder(panel.editor.webView)
+        if shouldPresent {
+            workspaceSuppressedPanelIDs.remove(note.id)
+            let motion = BlinkConfigStore.shared.config.motion
+            if playEntrance {
+                panel.animateEntrance(motion: motion)
+            }
+            panel.makeKeyAndOrderFront(nil)
+            mostRecentKeyPanelID = note.id
+            if mode == "edit" {
+                // Give the webview native key focus so typing and shortcuts work
+                // immediately (JS focus alone doesn't set the first responder).
+                panel.makeFirstResponder(panel.editor.webView)
+            }
+        } else {
+            workspaceSuppressedPanelIDs.insert(note.id)
         }
         persistOpenList()
         updateFocusOverlay()
@@ -565,8 +621,11 @@ final class PanelManager: NSObject, NSWindowDelegate {
 
     // MARK: - Read surface for overlays (grid, constellation)
 
-    /// Snapshot of open panels by note id.
-    var openPanelsByID: [String: NotePanel] { panels }
+    /// Snapshot of open panels in the active workspace by note id. The grid is
+    /// a live view of the current desktop, not a way to leak suppressed groups.
+    var openPanelsByID: [String: NotePanel] {
+        panels.filter { panelMatchesWorkspace(noteID: $0.key) }
+    }
 
     /// The panel that currently has key focus, if any.
     var keyNotePanel: NotePanel? { panels.values.first { $0.isKeyWindow } }
@@ -576,10 +635,175 @@ final class PanelManager: NSObject, NSWindowDelegate {
     /// recently focused note instead of losing their target during presentation.
     var commandNotePanel: NotePanel? {
         keyNotePanel
-            ?? mostRecentKeyPanelID.flatMap { panels[$0] }
-            ?? NSApp.orderedWindows.compactMap { $0 as? NotePanel }.first { panel in
-                panels[panel.noteID] === panel
+            ?? mostRecentKeyPanelID.flatMap { id in
+                panelMatchesWorkspace(noteID: id) ? panels[id] : nil
             }
+            ?? NSApp.orderedWindows.compactMap { $0 as? NotePanel }.first { panel in
+                panels[panel.noteID] === panel && panelMatchesWorkspace(noteID: panel.noteID)
+            }
+    }
+
+    /// Apply a top-left, display-local frame from the agent-facing CLI. The
+    /// panel's current display is the coordinate space; omitted values preserve
+    /// the existing geometry. Programmatic moves use the same lock animation
+    /// and autosave path as grid placement.
+    @discardableResult
+    func applyDeskFrame(
+        noteID: String,
+        x: CGFloat?,
+        y: CGFloat?,
+        width: CGFloat?,
+        height: CGFloat?,
+        display: Int?,
+        animated: Bool
+    ) -> Bool {
+        applyDeskFrame(
+            noteID: noteID,
+            request: DeskFrameRequest(
+                x: x, y: y, width: width, height: height, display: display
+            ),
+            animated: animated
+        )
+    }
+
+    @discardableResult
+    private func applyDeskFrame(
+        noteID: String,
+        request: DeskFrameRequest,
+        animated: Bool
+    ) -> Bool {
+        guard let panel = panels[noteID] else { return false }
+        let priorScreen = panel.screen ?? NSScreen.main
+        let screen: NSScreen?
+        if let display = request.display {
+            guard NSScreen.screens.indices.contains(display - 1) else { return false }
+            screen = NSScreen.screens[display - 1]
+        } else {
+            screen = priorScreen
+        }
+        guard let screen else { return false }
+
+        let visible = screen.visibleFrame
+        let prior = panel.frame
+        let priorVisible = priorScreen?.visibleFrame ?? visible
+        let priorLocalX = prior.minX - priorVisible.minX
+        let priorLocalY = priorVisible.maxY - prior.maxY
+        var target = prior
+        target.size.width = min(
+            max(request.width ?? prior.width, panel.minSize.width), visible.width
+        )
+        target.size.height = min(
+            max(request.height ?? prior.height, panel.minSize.height), visible.height
+        )
+
+        // Omitted coordinates preserve the panel's display-local top-left
+        // offset, including when moving it to another display.
+        target.origin.x = visible.minX + (request.x ?? priorLocalX)
+        target.origin.y = visible.maxY - (request.y ?? priorLocalY) - target.height
+
+        target.origin.x = min(max(target.minX, visible.minX), visible.maxX - target.width)
+        target.origin.y = min(max(target.minY, visible.minY), visible.maxY - target.height)
+
+        if animated, !target.equalTo(prior) {
+            panel.animateLock(to: target)
+        } else {
+            panel.setFrame(target, display: true)
+            panel.saveFrame(usingName: "blink.note.\(noteID)")
+        }
+        updateFocusOverlay()
+        gridOverlay?.refresh()
+        return true
+    }
+
+    /// Close through the panel's normal delegate path so pending text still
+    /// flushes before the live window disappears.
+    @discardableResult
+    func closePanel(noteID: String) -> Bool {
+        guard let panel = panels[noteID] else { return false }
+        panel.close()
+        return true
+    }
+
+    // MARK: - Workspace plane
+
+    /// Set before session restore so off-scope panels can be rebuilt in memory
+    /// without flashing onto the desktop.
+    func configureWorkspaceScope(_ scope: WorkspaceScope) {
+        workspaceScope = scope
+    }
+
+    /// Switch the live desktop boundary without closing a panel. Every panel
+    /// keeps its editor, pending save, exact frame, and membership in the open
+    /// set; only AppKit visibility changes. Activating a scope is an explicit
+    /// recall action, so it also clears a previous global blink-away state.
+    func applyWorkspaceScope(
+        _ scope: WorkspaceScope,
+        notes: [Note],
+        animated: Bool,
+        activate: Bool = false
+    ) {
+        for note in notes { recordPanelWorkspace(note) }
+        workspaceScope = scope
+
+        if activate {
+            blinkHidden = false
+            blinkGeneration += 1
+            for task in blinkRevealTasks { task.cancel() }
+            blinkRevealTasks.removeAll()
+        }
+
+        let matching = panels.filter { panelMatchesWorkspace(noteID: $0.key) }
+        let outgoing = panels.filter { !panelMatchesWorkspace(noteID: $0.key) }
+        for (id, panel) in outgoing where panel.isVisible {
+            workspaceSuppressedPanelIDs.insert(id)
+            panel.orderOut(nil)
+        }
+
+        guard !blinkHidden else {
+            for panel in matching.values where panel.isVisible { panel.orderOut(nil) }
+            updateFocusOverlay()
+            gridOverlay?.refresh()
+            return
+        }
+
+        let incoming = matching.filter { id, panel in
+            !panel.isVisible && (activate || workspaceSuppressedPanelIDs.contains(id))
+        }
+        let motion = BlinkConfigStore.shared.config.motion
+        let shouldAnimate = animated && motion.enabled && !NotePanel.reduceMotion
+        for (id, panel) in incoming {
+            workspaceSuppressedPanelIDs.remove(id)
+            if shouldAnimate { panel.alphaValue = 0 }
+            panel.orderFrontRegardless()
+        }
+        if shouldAnimate {
+            staggerReveal(Array(incoming.values), motion: motion)
+        } else {
+            for panel in incoming.values { panel.alphaValue = 1 }
+        }
+
+        log.info(
+            "[BLINK] workspace scope applied",
+            metadata: [
+                "scope": scope.storageValue,
+                "visible": "\(matching.values.filter(\.isVisible).count)",
+                "suppressed": "\(outgoing.count)",
+            ]
+        )
+        updateFocusOverlay()
+        gridOverlay?.refresh()
+    }
+
+    private func recordPanelWorkspace(_ note: Note) {
+        if let workspace = note.presentation.workspace {
+            panelWorkspaces[note.id] = workspace
+        } else {
+            panelWorkspaces.removeValue(forKey: note.id)
+        }
+    }
+
+    private func panelMatchesWorkspace(noteID: String) -> Bool {
+        workspaceScope.includes(workspace: panelWorkspaces[noteID])
     }
 
     var hasCommandNotePanel: Bool { commandNotePanel != nil }
@@ -672,7 +896,8 @@ final class PanelManager: NSObject, NSWindowDelegate {
     /// State flips instantly; motion is garnish. Rapid toggles cancel any
     /// in-flight motion so a panel is always left fully visible or fully hidden.
     func toggleBlink() {
-        guard !panels.isEmpty else { return }
+        let all = panels.filter { panelMatchesWorkspace(noteID: $0.key) }.map(\.value)
+        guard !all.isEmpty else { return }
         blinkHidden.toggle()
         blinkGeneration += 1
         let generation = blinkGeneration
@@ -684,8 +909,6 @@ final class PanelManager: NSObject, NSWindowDelegate {
 
         let motion = BlinkConfigStore.shared.config.motion
         let animate = motion.enabled && !NotePanel.reduceMotion
-        let all = Array(panels.values)
-
         if blinkHidden {
             if animate {
                 // Synchronized exhale: every panel fades + drifts 6px outward
@@ -823,6 +1046,8 @@ final class PanelManager: NSObject, NSWindowDelegate {
         panels[id] = nil
         panelContent[id] = nil
         panelSlot[id] = nil
+        panelWorkspaces[id] = nil
+        workspaceSuppressedPanelIDs.remove(id)
         if mostRecentKeyPanelID == id {
             mostRecentKeyPanelID = nil
         }

--- a/Sources/BlinkCLI/BlinkCLI.swift
+++ b/Sources/BlinkCLI/BlinkCLI.swift
@@ -19,7 +19,7 @@ struct BlinkCommand: AsyncParsableCommand {
         version: "2.0.5",
         subcommands: [
             Ls.self, Cat.self, New.self, Present.self, Append.self, Type.self, Write.self,
-            Search.self, Rm.self, PathCommand.self, WorkspaceCommand.self,
+            Search.self, Rm.self, PathCommand.self, WorkspaceCommand.self, DeskCommand.self,
         ]
     )
 }
@@ -79,13 +79,11 @@ struct New: AsyncParsableCommand {
                 decoding: FileHandle.standardInput.readDataToEndOfFile(), as: UTF8.self
             )
         }
-        var note = try await loadedStore().create(content: text)
-        // Membership is a second write rather than a create parameter: the store
-        // owns slug assignment, and this keeps `create` a single-purpose verb.
+        var presentation = NotePresentation()
         if let workspace {
-            note.presentation.workspace = try WorkspaceStore.normalize(workspace)
-            try fileStore().save(note)
+            presentation.workspace = try WorkspaceStore.normalize(workspace)
         }
+        let note = try await loadedStore().create(content: text, presentation: presentation)
         if json {
             try printJSON(NoteJSON(note, full: false))
         } else {

--- a/Sources/BlinkCLI/DeskCommands.swift
+++ b/Sources/BlinkCLI/DeskCommands.swift
@@ -1,0 +1,302 @@
+import ArgumentParser
+import AppKit
+import BlinkCore
+import Foundation
+
+/// Live panel verbs for agents and scripts. Note content continues to use the
+/// file-backed commands; this narrow channel only asks the running app to
+/// realize a note on the desktop.
+struct DeskCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "desk",
+        abstract: "Open and arrange note panels in the running Blink app.",
+        subcommands: [
+            DeskOpen.self, DeskMove.self, DeskFocus.self, DeskClose.self, DeskScreens.self,
+        ]
+    )
+}
+
+struct DeskFrameOptions: ParsableArguments {
+    @Option(help: "Left edge in points from the display's visible left edge.")
+    var x: Double?
+
+    @Option(help: "Top edge in points from the display's visible top edge.")
+    var y: Double?
+
+    @Option(help: "Panel width in points (minimum 260).")
+    var width: Double?
+
+    @Option(help: "Panel height in points (minimum 120).")
+    var height: Double?
+
+    @Option(help: "One-based display number (defaults to the panel's current display).")
+    var display: Int?
+
+    var isEmpty: Bool {
+        x == nil && y == nil && width == nil && height == nil && display == nil
+    }
+
+    func validate() throws {
+        if let x, !x.isFinite {
+            throw ValidationError("--x must be a finite number")
+        }
+        if let y, !y.isFinite {
+            throw ValidationError("--y must be a finite number")
+        }
+        if let width, !width.isFinite {
+            throw ValidationError("--width must be a finite number")
+        }
+        if let height, !height.isFinite {
+            throw ValidationError("--height must be a finite number")
+        }
+        if let width, width <= 0 {
+            throw ValidationError("--width must be greater than zero")
+        }
+        if let height, height <= 0 {
+            throw ValidationError("--height must be greater than zero")
+        }
+        if let display, display < 1 {
+            throw ValidationError("--display must be one or greater")
+        }
+        if let display, display > NSScreen.screens.count {
+            throw ValidationError(
+                "--display \(display) does not exist (\(NSScreen.screens.count) available)"
+            )
+        }
+    }
+
+    func add(to userInfo: inout [AnyHashable: Any]) {
+        if let x { userInfo[BlinkDeskCommand.Key.x] = x }
+        if let y { userInfo[BlinkDeskCommand.Key.y] = y }
+        if let width { userInfo[BlinkDeskCommand.Key.width] = width }
+        if let height { userInfo[BlinkDeskCommand.Key.height] = height }
+        if let display { userInfo[BlinkDeskCommand.Key.display] = display }
+    }
+}
+
+struct DeskOpen: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "open",
+        abstract: "Open or focus a note, optionally at an exact frame."
+    )
+
+    @Argument(help: "The note id.") var id: String
+    @OptionGroup var frame: DeskFrameOptions
+
+    mutating func validate() throws { try frame.validate() }
+
+    func run() throws {
+        _ = try existingNote(id: id)
+        var userInfo = deskUserInfo(.open, id: id)
+        frame.add(to: &userInfo)
+        try postDeskCommand(userInfo)
+        print(id)
+    }
+}
+
+struct DeskMove: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "move",
+        abstract: "Move or resize an open note with a visible lock animation."
+    )
+
+    @Argument(help: "The note id.") var id: String
+    @OptionGroup var frame: DeskFrameOptions
+    @Flag(help: "Apply the frame immediately instead of animating it.") var instant = false
+
+    mutating func validate() throws {
+        try frame.validate()
+        if frame.isEmpty {
+            throw ValidationError(
+                "pass at least one of --x, --y, --width, --height, or --display"
+            )
+        }
+    }
+
+    func run() throws {
+        _ = try existingNote(id: id)
+        var userInfo = deskUserInfo(.move, id: id)
+        frame.add(to: &userInfo)
+        userInfo[BlinkDeskCommand.Key.animated] = !instant
+        try postDeskCommand(userInfo)
+        print(id)
+    }
+}
+
+struct DeskFocus: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "focus",
+        abstract: "Raise a note panel, opening it when needed."
+    )
+
+    @Argument(help: "The note id.") var id: String
+
+    func run() throws {
+        _ = try existingNote(id: id)
+        try postDeskCommand(deskUserInfo(.focus, id: id))
+        print(id)
+    }
+}
+
+struct DeskClose: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "close",
+        abstract: "Close a note panel without deleting its note."
+    )
+
+    @Argument(help: "The note id.") var id: String
+
+    func run() throws {
+        _ = try existingNote(id: id)
+        try postDeskCommand(deskUserInfo(.close, id: id))
+        print(id)
+    }
+}
+
+struct DeskScreens: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "screens",
+        abstract: "List display geometry for responsive desk scripts."
+    )
+
+    @Flag(help: "Structured output.") var json = false
+
+    func run() throws {
+        let screens = NSScreen.screens.enumerated().map { index, screen in
+            DeskScreenJSON(number: index + 1, screen: screen)
+        }
+        if json {
+            try printJSON(screens)
+        } else {
+            for screen in screens {
+                print(
+                    "\(screen.number)  \(Int(screen.visible.width))x\(Int(screen.visible.height))"
+                        + "  \(screen.name)"
+                )
+            }
+        }
+    }
+}
+
+private struct DeskScreenJSON: Encodable {
+    struct Frame: Encodable {
+        let x: Double
+        let y: Double
+        let width: Double
+        let height: Double
+
+        init(_ rect: NSRect) {
+            x = rect.origin.x
+            y = rect.origin.y
+            width = rect.width
+            height = rect.height
+        }
+    }
+
+    let number: Int
+    let name: String
+    let frame: Frame
+    let visible: Frame
+    let scale: Double
+
+    init(number: Int, screen: NSScreen) {
+        self.number = number
+        name = screen.localizedName
+        frame = Frame(screen.frame)
+        visible = Frame(screen.visibleFrame)
+        scale = screen.backingScaleFactor
+    }
+}
+
+private func deskUserInfo(
+    _ verb: BlinkDeskCommand.Verb,
+    id: String
+) -> [AnyHashable: Any] {
+    [
+        BlinkDeskCommand.Key.verb: verb.rawValue,
+        BlinkDeskCommand.Key.noteID: id,
+        BlinkDeskCommand.Key.home: BlinkDeskCommand.canonicalHomePath(),
+    ]
+}
+
+private func postDeskCommand(_ baseUserInfo: [AnyHashable: Any]) throws {
+    let requestID = UUID().uuidString.lowercased()
+    var userInfo = baseUserInfo
+    userInfo[BlinkDeskCommand.Key.requestID] = requestID
+
+    let waiter = DeskResponseWaiter(requestID: requestID)
+    let center = DistributedNotificationCenter.default()
+    center.addObserver(
+        waiter,
+        selector: #selector(DeskResponseWaiter.receive(_:)),
+        name: BlinkDeskCommand.responseNotificationName,
+        object: nil
+    )
+    defer { center.removeObserver(waiter) }
+
+    center.post(
+        name: BlinkDeskCommand.notificationName,
+        object: nil,
+        userInfo: userInfo
+    )
+    guard let response = waiter.wait(timeout: 2) else {
+        throw ValidationError(
+            "Blink did not acknowledge the desk command; make sure the app is running with the same BLINK_HOME"
+        )
+    }
+    guard response.success else {
+        throw ValidationError(response.error ?? "Blink could not apply the desk command")
+    }
+}
+
+private final class DeskResponseWaiter: NSObject {
+    struct Response {
+        let success: Bool
+        let error: String?
+    }
+
+    private let requestID: String
+    private let lock = NSLock()
+    private var response: Response?
+
+    init(requestID: String) {
+        self.requestID = requestID
+        super.init()
+    }
+
+    @objc func receive(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              userInfo[BlinkDeskCommand.Key.requestID] as? String == requestID,
+              let success = (userInfo[BlinkDeskCommand.Key.success] as? NSNumber)?.boolValue
+        else { return }
+
+        lock.lock()
+        response = Response(
+            success: success,
+            error: userInfo[BlinkDeskCommand.Key.error] as? String
+        )
+        lock.unlock()
+    }
+
+    func wait(timeout: TimeInterval) -> Response? {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while Date() < deadline {
+            lock.lock()
+            let current = response
+            lock.unlock()
+            if let current { return current }
+
+            // Distributed notifications may target this thread's run loop.
+            // Service it in short slices while still permitting delivery from
+            // the notification center's helper thread.
+            _ = RunLoop.current.run(
+                mode: .default,
+                before: min(deadline, Date(timeIntervalSinceNow: 0.05))
+            )
+        }
+
+        lock.lock()
+        defer { lock.unlock() }
+        return response
+    }
+}

--- a/Sources/BlinkCore/BlinkDeskCommand.swift
+++ b/Sources/BlinkCore/BlinkDeskCommand.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// The deliberately small cross-process command vocabulary for arranging the
+/// running Blink desk. Durable note content still travels through the files;
+/// these commands only address live panel state owned by the app.
+public enum BlinkDeskCommand {
+    public static let notificationName = Notification.Name("dev.arach.blink.desk-command")
+    public static let responseNotificationName = Notification.Name(
+        "dev.arach.blink.desk-command-response"
+    )
+
+    public enum Verb: String, Sendable {
+        case open
+        case move
+        case focus
+        case close
+    }
+
+    public enum Key {
+        public static let verb = "verb"
+        public static let noteID = "noteID"
+        public static let requestID = "requestID"
+        public static let home = "home"
+        public static let x = "x"
+        public static let y = "y"
+        public static let width = "width"
+        public static let height = "height"
+        public static let display = "display"
+        public static let animated = "animated"
+        public static let success = "success"
+        public static let error = "error"
+    }
+
+    public static func canonicalHomePath(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        BlinkPaths.home(environment: environment)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+    }
+}

--- a/Sources/BlinkCore/NoteStore.swift
+++ b/Sources/BlinkCore/NoteStore.swift
@@ -49,7 +49,10 @@ public actor NoteStore {
     /// Create a new note from raw markdown content. Assigns a unique slug id and
     /// stamps timestamps, then persists.
     @discardableResult
-    public func create(content: String) throws -> Note {
+    public func create(
+        content: String,
+        presentation: NotePresentation = NotePresentation()
+    ) async throws -> Note {
         let base = Slug.generate(from: Note.extractTitle(from: content))
         let id = Slug.unique(base, existing: Set(notes.keys))
         let now = clock()
@@ -60,7 +63,8 @@ public actor NoteStore {
                 createdAt: now,
                 updatedAt: now,
                 tags: [],
-                pinned: false
+                pinned: false,
+                presentation: presentation
             )
         )
         try fileStore.save(note)

--- a/Tests/BlinkCoreTests/NoteStoreTests.swift
+++ b/Tests/BlinkCoreTests/NoteStoreTests.swift
@@ -33,6 +33,23 @@ struct NoteStoreTests {
         #expect(c.id == "meeting-notes-3")
     }
 
+    @Test("create persists workspace membership atomically")
+    func createWithWorkspace() async throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        var presentation = NotePresentation()
+        presentation.workspace = "demo"
+        let created = try await store.create(
+            content: "# Demo note\nblank slate",
+            presentation: presentation
+        )
+
+        #expect(created.presentation.workspace == "demo")
+        let onDisk = try NoteFileStore(directory: dir).load(id: created.id)
+        #expect(onDisk.presentation.workspace == "demo")
+    }
+
     @Test("update bumps updatedAt and persists")
     func updatePersists() async throws {
         let (store, dir) = tempStore()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,8 +27,8 @@ cp .build/release/blink ~/bin/    # or anywhere on PATH
 
 ## Commands
 
-Every command takes `--json` for structured output. Errors go to stderr with
-exit code 1.
+Commands that expose structured output take `--json` where shown below. Errors
+go to stderr with a nonzero exit code.
 
 ```sh
 blink ls [--limit N] [--json]     # list notes, most recently updated first
@@ -42,6 +42,7 @@ blink search <query> [--json]     # case-insensitive substring over title + cont
 blink rm <id> [--json]            # delete a note
 blink path [<id>]                 # the notes directory, or a note's file path
 blink workspace <subcommand>      # named groups of notes + their brand
+blink desk <subcommand>           # open/focus/move/close live panels
 ```
 
 `workspace` is the grouping/branding verb set — see `docs/workspaces.md` for the
@@ -61,7 +62,9 @@ blink workspace rm <name> [--detach]                     # forget the definition
 `new` and `present` also take `--workspace <name>` so a note can be filed on
 creation. Membership is one `blink.workspace:` key in the note's frontmatter;
 the brand itself lives in `config.json`, so note markdown stays portable and
-free of presentation-only branding.
+free of presentation-only branding. In the running app, the capture popover's
+workspace selector filters the log/canvas and recalls only that workspace's
+open panels; notes created while a named workspace is active inherit it.
 
 `present` is the compound arrival verb: it sets a note's markdown **and** its
 `blink:` presentation (see `notes-representation.md`) in one write, get-or-create
@@ -76,6 +79,22 @@ app reveals it character by character (the visible hand); `write` replaces the
 whole body, so the panel updates in place with no animation. `append` is the
 established sibling of `type` (identical behavior). All three preserve presentation
 and foreign frontmatter.
+
+`desk` is the intentionally small live counterpart to the file API. It asks the
+running Blink app to realize an existing note as a panel while `PanelManager`
+continues to own one-panel-per-note identity, focus, save flushing, and geometry
+persistence. Coordinates are display-local AppKit points measured from the
+visible top-left corner; omitted frame values preserve the current value.
+`--display N` selects a one-based display (`1` is the main display); otherwise
+the panel stays on its current display.
+
+```sh
+blink desk open standup --display 1 --x 980 --y 90 --width 460 --height 260
+blink desk move standup --x 1130 --y 70     # visible lock-and-settle
+blink desk focus standup
+blink desk close standup                    # closes the panel, keeps the note
+blink desk screens --json                   # responsive-script display geometry
+```
 
 Examples:
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -196,13 +196,22 @@ blink present exception --workspace acme-docs --accent "#f7768e"
   removes the definition only; member notes keep their content and simply render
   unbranded. Add `--detach` to also clear membership from each member note.
 
-## What this is not
+## Durable group, live desktop
 
-`blink workspace` manages *durable* state — the files and the config. It does
-not open panels or move them on screen; that is the live plane, and it belongs
-to the running app (see `agent-api.md`, layer 2.5, still proposed). To reopen a
-workspace today, list it and open the notes:
+`blink workspace` manages *durable* state — the files and the config. The
+running app owns the live plane: choose a workspace from the capture popover to
+filter its log and canvas and recall only that workspace's already-open panels.
+Panels in other workspaces are hidden, never closed, so their pending text,
+exact frames, and session membership survive the switch. New notes inherit the
+active named workspace; **All notes** and **Unfiled** create unfiled notes.
+
+The file-backed `workspace` verbs do not mutate live panels. The `desk`
+companion sends acknowledged open, move, focus, and close requests to the
+running Blink instance with the same `BLINK_HOME`. An agent can inspect a group
+and explicitly present the notes it wants on that live desktop:
 
 ```sh
-blink workspace notes acme-docs --json | jq -r '.[].id'
+blink workspace notes acme-docs --json \
+  | jq -r '.[].id' \
+  | while read -r id; do blink desk open "$id"; done
 ```


### PR DESCRIPTION
## Summary
- add a device-local workspace selector that filters the popover and recalls matching open panels without closing them
- preserve user-hidden panels across background save refreshes while retaining explicit workspace recall
- make new notes inherit an active named workspace atomically
- add home-scoped, acknowledged `blink desk` open/move/focus/close/screens verbs while keeping lifecycle in `PanelManager`
- validate finite/display-safe geometry and preserve display-local offsets across screens
- document durable workspace membership versus live desktop state

## Verification
- `BLINK_HUDSON_SOURCE=git swift test` (127 tests, 15 suites)
- clean Swift package build including BlinkApp and `blink`
- end-to-end separate-process desk acknowledgement against an isolated `BLINK_HOME`
- mismatched `BLINK_HOME` correctly times out instead of controlling the running test instance
- non-finite frame rejection exits nonzero with a validation error
- `git diff --check origin/main...HEAD`

## Review fixes
- addressed all five findings from the independent Scout review: instance routing, hidden-panel preservation, display semantics, command acknowledgement, and documentation accuracy