### PR TITLE
🔐 Add encrypted peer snapshot foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,11 +10,15 @@ let hudsonDependency: Package.Dependency = hudsonSource == "git"
 
 let package = Package(
     name: "Blink",
-    platforms: [.macOS(.v14)],
+    platforms: [
+        .macOS(.v14),
+        .iOS(.v17),
+    ],
     products: [
         .executable(name: "BlinkApp", targets: ["BlinkApp"]),
         .executable(name: "blink", targets: ["BlinkCLI"]),
         .library(name: "BlinkCore", targets: ["BlinkCore"]),
+        .library(name: "BlinkPeer", targets: ["BlinkPeer"]),
     ],
     dependencies: [
         hudsonDependency,
@@ -43,10 +47,20 @@ let package = Package(
             name: "BlinkCore",
             path: "Sources/BlinkCore"
         ),
+        .target(
+            name: "BlinkPeer",
+            dependencies: ["BlinkCore"],
+            path: "Sources/BlinkPeer"
+        ),
         .testTarget(
             name: "BlinkCoreTests",
             dependencies: ["BlinkCore"],
             path: "Tests/BlinkCoreTests"
+        ),
+        .testTarget(
+            name: "BlinkPeerTests",
+            dependencies: ["BlinkCore", "BlinkPeer"],
+            path: "Tests/BlinkPeerTests"
         ),
     ]
 )

--- a/Sources/BlinkApp/AppDelegate.swift
+++ b/Sources/BlinkApp/AppDelegate.swift
@@ -30,7 +30,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         NSApp.setActivationPolicy(.accessory)
         installMainMenu()
 
-        store = NoteStore(fileStore: NoteFileStore(directory: Self.notesDirectory()))
+        store = NoteStore(
+            fileStore: NoteFileStore(directory: Self.notesDirectory()),
+            tombstoneStore: BlinkTombstoneStore(fileURL: BlinkPaths.tombstones())
+        )
         panelManager = PanelManager(store: store)
         model = AppModel(store: store, panelManager: panelManager)
         panelManager.onWorkspaceScopeRequested = { [weak self] scope in
@@ -69,6 +72,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                             "created": "\(diff.created.count)",
                             "updated": "\(diff.updated.count)",
                             "deleted": "\(diff.deleted.count)",
+                            "tombstoneFailures": "\(diff.tombstoneFailures.count)",
                         ]
                     )
                 }

--- a/Sources/BlinkCLI/BlinkCLI.swift
+++ b/Sources/BlinkCLI/BlinkCLI.swift
@@ -261,8 +261,9 @@ struct Rm: AsyncParsableCommand {
     @Argument(help: "The note id (slug).") var id: String
     @Flag(help: "Structured output.") var json = false
 
-    func run() throws {
+    func run() async throws {
         _ = try existingNote(id: id)
+        try await BlinkTombstoneStore(fileURL: BlinkPaths.tombstones()).recordDeletion(id: id)
         try fileStore().delete(id: id)
         if json {
             try printJSON(["deleted": id])
@@ -297,7 +298,10 @@ func fileStore() -> NoteFileStore {
 }
 
 func loadedStore() async throws -> NoteStore {
-    let store = NoteStore(fileStore: fileStore())
+    let store = NoteStore(
+        fileStore: fileStore(),
+        tombstoneStore: BlinkTombstoneStore(fileURL: BlinkPaths.tombstones())
+    )
     try await store.load()
     return store
 }

--- a/Sources/BlinkCore/BlinkPaths.swift
+++ b/Sources/BlinkCore/BlinkPaths.swift
@@ -32,6 +32,17 @@ public enum BlinkPaths {
         home(environment: environment).appendingPathComponent("config.json", isDirectory: false)
     }
 
+    /// Durable deletion evidence for peer replication. Full snapshots are
+    /// authoritative today; this journal preserves delete intent for later
+    /// incremental sync and multi-writer conflict handling.
+    public static func tombstones(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        home(environment: environment)
+            .appendingPathComponent("sync", isDirectory: true)
+            .appendingPathComponent("tombstones.json", isDirectory: false)
+    }
+
     /// Where note attachments live: `<home>/attachments`. A note can embed an
     /// image it owns via `![](blink://attachments/pic.png)`; the app serves this
     /// directory to the editor webview over the `blink://` scheme (see

--- a/Sources/BlinkCore/BlinkSnapshot.swift
+++ b/Sources/BlinkCore/BlinkSnapshot.swift
@@ -1,0 +1,369 @@
+import CryptoKit
+import Foundation
+
+/// One exact note payload in a coherent peer snapshot. `markdown` includes the
+/// complete frontmatter block so foreign metadata survives transport verbatim.
+public struct BlinkSnapshotNote: Codable, Equatable, Sendable {
+    public var id: String
+    public var revision: String
+    public var markdown: String
+    public var title: String
+    public var updatedAt: Date
+    public var tags: [String]
+    public var pinned: Bool
+    public var presentation: NotePresentation
+
+    public init(
+        id: String,
+        revision: String,
+        markdown: String,
+        title: String,
+        updatedAt: Date,
+        tags: [String],
+        pinned: Bool,
+        presentation: NotePresentation
+    ) {
+        self.id = id
+        self.revision = revision
+        self.markdown = markdown
+        self.title = title
+        self.updatedAt = updatedAt
+        self.tags = tags
+        self.pinned = pinned
+        self.presentation = presentation
+    }
+}
+
+/// Durable deletion evidence reserved for later incremental replication. Full
+/// snapshots remain authoritative today, but recording deletions now avoids an
+/// identity and conflict-model migration when writes arrive.
+public struct BlinkSnapshotTombstone: Codable, Equatable, Identifiable, Sendable {
+    public var id: String
+    public var deletedAt: Date
+    public var revision: String
+
+    public init(id: String, deletedAt: Date, revision: String) {
+        self.id = id
+        self.deletedAt = deletedAt
+        self.revision = revision
+    }
+}
+
+/// A file that was deliberately withheld from the snapshot. Quarantine is part
+/// of the wire contract so a malformed or identity-divergent note never becomes
+/// an accidental deletion on the phone.
+public struct BlinkSnapshotIssue: Codable, Equatable, Sendable {
+    public enum Code: String, Codable, Equatable, Sendable {
+        case unreadable
+        case invalidUTF8
+        case invalidFrontmatter
+        case identityMismatch
+    }
+
+    public var code: Code
+    public var fileName: String
+    public var expectedID: String?
+    public var claimedID: String?
+
+    public init(
+        code: Code,
+        fileName: String,
+        expectedID: String? = nil,
+        claimedID: String? = nil
+    ) {
+        self.code = code
+        self.fileName = fileName
+        self.expectedID = expectedID
+        self.claimedID = claimedID
+    }
+}
+
+/// An authoritative, replace-in-one-step view of Blink's file-backed truth.
+/// `etag` excludes `generatedAt`, so an unchanged note corpus produces 304s.
+public struct BlinkSnapshot: Codable, Equatable, Sendable {
+    public static let currentVersion = 1
+
+    public var version: Int
+    public var generatedAt: Date
+    public var etag: String
+    public var notes: [BlinkSnapshotNote]
+    public var tombstones: [BlinkSnapshotTombstone]
+    public var issues: [BlinkSnapshotIssue]
+
+    public init(
+        version: Int = BlinkSnapshot.currentVersion,
+        generatedAt: Date,
+        etag: String,
+        notes: [BlinkSnapshotNote],
+        tombstones: [BlinkSnapshotTombstone],
+        issues: [BlinkSnapshotIssue]
+    ) {
+        self.version = version
+        self.generatedAt = generatedAt
+        self.etag = etag
+        self.notes = notes
+        self.tombstones = tombstones
+        self.issues = issues
+    }
+}
+
+public enum BlinkSnapshotFetchResult: Codable, Equatable, Sendable {
+    case notModified(etag: String)
+    case snapshot(BlinkSnapshot)
+}
+
+/// The iOS surface depends on this app-level boundary, never on a concrete LAN,
+/// Tailscale, Noise, TLS, or managed-relay client.
+public protocol BlinkPeerTransport: Sendable {
+    func fetchSnapshot(ifNoneMatch etag: String?) async throws -> BlinkSnapshotFetchResult
+}
+
+public enum BlinkSnapshotBuilderError: Error, LocalizedError, Equatable, Sendable {
+    case unstableDirectory(attempts: Int)
+    case directoryReadFailed(String)
+    case revisionEncodingFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unstableDirectory(let attempts):
+            return "Blink notes changed during \(attempts) consecutive snapshot reads."
+        case .directoryReadFailed(let detail):
+            return "Blink could not read the notes directory: \(detail)"
+        case .revisionEncodingFailed(let detail):
+            return "Blink could not encode the snapshot revision: \(detail)"
+        }
+    }
+}
+
+/// Builds a stable full snapshot by requiring two identical consecutive reads.
+/// Atomic note writes guarantee each individual read is untorn; the second pass
+/// ensures the directory set did not move underneath the multi-file snapshot.
+public struct BlinkSnapshotBuilder: Sendable {
+    public let notesDirectory: URL
+    public let maxStabilityAttempts: Int
+    private let clock: @Sendable () -> Date
+
+    public init(
+        notesDirectory: URL,
+        maxStabilityAttempts: Int = 4,
+        clock: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.notesDirectory = notesDirectory
+        self.maxStabilityAttempts = max(2, maxStabilityAttempts)
+        self.clock = clock
+    }
+
+    public func build(
+        tombstones: [BlinkSnapshotTombstone] = []
+    ) throws -> BlinkSnapshot {
+        var previous: [RawSnapshotFile]?
+        var lastReadError: Error?
+
+        for _ in 0..<maxStabilityAttempts {
+            do {
+                let current = try captureFiles()
+                if current == previous {
+                    return try makeSnapshot(from: current, tombstones: tombstones)
+                }
+                previous = current
+                lastReadError = nil
+            } catch {
+                previous = nil
+                lastReadError = error
+            }
+        }
+
+        if let lastReadError {
+            throw BlinkSnapshotBuilderError.directoryReadFailed(lastReadError.localizedDescription)
+        }
+        throw BlinkSnapshotBuilderError.unstableDirectory(attempts: maxStabilityAttempts)
+    }
+
+    private func captureFiles() throws -> [RawSnapshotFile] {
+        guard FileManager.default.fileExists(atPath: notesDirectory.path) else {
+            return []
+        }
+        let entries = try FileManager.default.contentsOfDirectory(
+            at: notesDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+
+        return entries
+            .filter { url in
+                let name = url.lastPathComponent
+                return name.hasSuffix(".md") && !name.hasPrefix(".")
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            .map { url in
+                RawSnapshotFile(
+                    fileName: url.lastPathComponent,
+                    data: try? Data(contentsOf: url)
+                )
+            }
+    }
+
+    private func makeSnapshot(
+        from files: [RawSnapshotFile],
+        tombstones: [BlinkSnapshotTombstone]
+    ) throws -> BlinkSnapshot {
+        var notes: [BlinkSnapshotNote] = []
+        var issues: [BlinkSnapshotIssue] = []
+
+        for file in files {
+            let fileID = String(file.fileName.dropLast(3))
+            guard let data = file.data else {
+                issues.append(
+                    BlinkSnapshotIssue(
+                        code: .unreadable,
+                        fileName: file.fileName,
+                        expectedID: fileID
+                    )
+                )
+                continue
+            }
+            guard let markdown = String(data: data, encoding: .utf8) else {
+                issues.append(
+                    BlinkSnapshotIssue(
+                        code: .invalidUTF8,
+                        fileName: file.fileName,
+                        expectedID: fileID
+                    )
+                )
+                continue
+            }
+            guard let note = try? Frontmatter.decode(markdown) else {
+                issues.append(
+                    BlinkSnapshotIssue(
+                        code: .invalidFrontmatter,
+                        fileName: file.fileName,
+                        expectedID: fileID
+                    )
+                )
+                continue
+            }
+
+            guard !fileID.isEmpty, note.id == fileID else {
+                issues.append(
+                    BlinkSnapshotIssue(
+                        code: .identityMismatch,
+                        fileName: file.fileName,
+                        expectedID: fileID,
+                        claimedID: note.id
+                    )
+                )
+                continue
+            }
+
+            notes.append(
+                BlinkSnapshotNote(
+                    id: note.id,
+                    revision: Self.sha256Hex(data),
+                    markdown: markdown,
+                    title: note.title,
+                    updatedAt: note.updatedAt,
+                    tags: note.tags,
+                    pinned: note.pinned,
+                    presentation: note.presentation
+                )
+            )
+        }
+
+        notes.sort { $0.id < $1.id }
+        issues.sort {
+            if $0.fileName != $1.fileName { return $0.fileName < $1.fileName }
+            return $0.code.rawValue < $1.code.rawValue
+        }
+        // Any present source file suppresses an older deletion marker, even if
+        // that file is temporarily quarantined. Otherwise a failed tombstone
+        // cleanup plus a transient parse error could erase the cache's last
+        // known-good copy instead of preserving it.
+        let presentIDs = Set(notes.map(\.id)).union(issues.compactMap(\.expectedID))
+        let visibleTombstones = tombstones
+            .filter { !presentIDs.contains($0.id) }
+            .sorted {
+                if $0.deletedAt != $1.deletedAt { return $0.deletedAt < $1.deletedAt }
+                return $0.id < $1.id
+            }
+        let etag = try Self.snapshotETag(
+            notes: notes,
+            tombstones: visibleTombstones,
+            issues: issues
+        )
+
+        return BlinkSnapshot(
+            generatedAt: clock(),
+            etag: etag,
+            notes: notes,
+            tombstones: visibleTombstones,
+            issues: issues
+        )
+    }
+
+    private static func snapshotETag(
+        notes: [BlinkSnapshotNote],
+        tombstones: [BlinkSnapshotTombstone],
+        issues: [BlinkSnapshotIssue]
+    ) throws -> String {
+        let manifest = SnapshotRevisionManifest(
+            version: BlinkSnapshot.currentVersion,
+            notes: notes.map { SnapshotRevisionNote(id: $0.id, revision: $0.revision) },
+            tombstones: tombstones,
+            issues: issues
+        )
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .millisecondsSince1970
+            encoder.outputFormatting = [.sortedKeys]
+            let digest = sha256Hex(try encoder.encode(manifest))
+            return "\"sha256-\(digest)\""
+        } catch {
+            throw BlinkSnapshotBuilderError.revisionEncodingFailed(error.localizedDescription)
+        }
+    }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// Serializes peer fetches and turns an exact ETag match into an authenticated
+/// transport-level not-modified response.
+public actor BlinkSnapshotService {
+    private let builder: BlinkSnapshotBuilder
+    private let tombstoneStore: BlinkTombstoneStore?
+
+    public init(
+        builder: BlinkSnapshotBuilder,
+        tombstoneStore: BlinkTombstoneStore? = nil
+    ) {
+        self.builder = builder
+        self.tombstoneStore = tombstoneStore
+    }
+
+    public func fetchSnapshot(ifNoneMatch etag: String?) async throws -> BlinkSnapshotFetchResult {
+        let tombstones = try await tombstoneStore?.all() ?? []
+        let snapshot = try builder.build(tombstones: tombstones)
+        if etag == snapshot.etag {
+            return .notModified(etag: snapshot.etag)
+        }
+        return .snapshot(snapshot)
+    }
+}
+
+private struct RawSnapshotFile: Equatable {
+    var fileName: String
+    var data: Data?
+}
+
+private struct SnapshotRevisionNote: Codable {
+    var id: String
+    var revision: String
+}
+
+private struct SnapshotRevisionManifest: Codable {
+    var version: Int
+    var notes: [SnapshotRevisionNote]
+    var tombstones: [BlinkSnapshotTombstone]
+    var issues: [BlinkSnapshotIssue]
+}

--- a/Sources/BlinkCore/BlinkSnapshotCache.swift
+++ b/Sources/BlinkCore/BlinkSnapshotCache.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+public enum BlinkSnapshotCacheError: Error, LocalizedError, Equatable, Sendable {
+    case decodingFailed(String)
+    case encodingFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .decodingFailed(let detail):
+            return "Blink's offline notes could not be decoded: \(detail)"
+        case .encodingFailed(let detail):
+            return "Blink's offline notes could not be encoded: \(detail)"
+        }
+    }
+}
+
+/// A replaceable mobile cache for peer snapshots. The server's snapshot is
+/// authoritative except for quarantined IDs: when a source file is unreadable
+/// or identity-divergent, the last known-good note remains visible until the
+/// source recovers or a durable tombstone explicitly deletes it.
+public actor BlinkSnapshotCache {
+    public let fileURL: URL
+
+    public init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    public func load() throws -> BlinkSnapshot? {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+        do {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .millisecondsSince1970
+            return try decoder.decode(BlinkSnapshot.self, from: Data(contentsOf: fileURL))
+        } catch {
+            throw BlinkSnapshotCacheError.decodingFailed(error.localizedDescription)
+        }
+    }
+
+    @discardableResult
+    public func apply(_ incoming: BlinkSnapshot) throws -> BlinkSnapshot {
+        let previous = try load()
+        let deletedIDs = Set(incoming.tombstones.map(\.id))
+        let quarantinedIDs = Set(incoming.issues.compactMap(\.expectedID))
+        var notesByID = Dictionary(
+            incoming.notes.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+
+        if let previous {
+            for note in previous.notes
+                where quarantinedIDs.contains(note.id)
+                    && !deletedIDs.contains(note.id)
+                    && notesByID[note.id] == nil {
+                notesByID[note.id] = note
+            }
+        }
+        for id in deletedIDs {
+            notesByID[id] = nil
+        }
+
+        var cached = incoming
+        cached.notes = notesByID.values.sorted { $0.id < $1.id }
+        try persist(cached)
+        return cached
+    }
+
+    public func removeAll() throws {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
+        try FileManager.default.removeItem(at: fileURL)
+    }
+
+    private func persist(_ snapshot: BlinkSnapshot) throws {
+        let data: Data
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .millisecondsSince1970
+            encoder.outputFormatting = [.sortedKeys]
+            data = try encoder.encode(snapshot)
+        } catch {
+            throw BlinkSnapshotCacheError.encodingFailed(error.localizedDescription)
+        }
+
+        let directory = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let tempURL = directory.appendingPathComponent(
+            ".\(fileURL.lastPathComponent).\(UUID().uuidString).tmp"
+        )
+        FileManager.default.createFile(atPath: tempURL.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: tempURL)
+        do {
+            try handle.write(contentsOf: data)
+            try handle.synchronize()
+            try handle.close()
+        } catch {
+            try? handle.close()
+            try? FileManager.default.removeItem(at: tempURL)
+            throw error
+        }
+
+        do {
+            if FileManager.default.fileExists(atPath: fileURL.path) {
+                _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+            } else {
+                try FileManager.default.moveItem(at: tempURL, to: fileURL)
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: tempURL)
+            throw error
+        }
+    }
+}

--- a/Sources/BlinkCore/BlinkTombstoneStore.swift
+++ b/Sources/BlinkCore/BlinkTombstoneStore.swift
@@ -1,0 +1,166 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+public enum BlinkTombstoneStoreError: Error, LocalizedError, Equatable, Sendable {
+    case decodingFailed(String)
+    case encodingFailed(String)
+    case lockingFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .decodingFailed(let detail):
+            return "Blink tombstones could not be decoded: \(detail)"
+        case .encodingFailed(let detail):
+            return "Blink tombstones could not be encoded: \(detail)"
+        case .lockingFailed(let detail):
+            return "Blink tombstones could not be locked: \(detail)"
+        }
+    }
+}
+
+/// Atomic durable deletion journal. It is intentionally separate from note
+/// files because a deleted note can no longer carry its own replication state.
+public actor BlinkTombstoneStore {
+    private struct FileContents: Codable {
+        var version: Int = 1
+        var tombstones: [BlinkSnapshotTombstone]
+    }
+
+    public let fileURL: URL
+    private let clock: @Sendable () -> Date
+
+    public init(
+        fileURL: URL,
+        clock: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.fileURL = fileURL
+        self.clock = clock
+    }
+
+    @discardableResult
+    public func recordDeletion(id: String, at date: Date? = nil) throws -> BlinkSnapshotTombstone {
+        let deletedAt = date ?? clock()
+        let revisionMaterial = Data("\(id)\u{0}\(deletedAt.timeIntervalSince1970)".utf8)
+        let revision = SHA256.hash(data: revisionMaterial)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let tombstone = BlinkSnapshotTombstone(
+            id: id,
+            deletedAt: deletedAt,
+            revision: revision
+        )
+
+        try withFileLock(operation: LOCK_EX) {
+            var byID = Dictionary(
+                try loadUnlocked().map { ($0.id, $0) },
+                uniquingKeysWith: { _, latest in latest }
+            )
+            byID[id] = tombstone
+            try persist(Array(byID.values))
+        }
+        return tombstone
+    }
+
+    public func all() throws -> [BlinkSnapshotTombstone] {
+        try withFileLock(operation: LOCK_SH) {
+            try loadUnlocked().sorted {
+                if $0.deletedAt != $1.deletedAt { return $0.deletedAt < $1.deletedAt }
+                return $0.id < $1.id
+            }
+        }
+    }
+
+    public func remove(id: String) throws {
+        try withFileLock(operation: LOCK_EX) {
+            let remaining = try loadUnlocked().filter { $0.id != id }
+            try persist(remaining)
+        }
+    }
+
+    @discardableResult
+    public func prune(olderThan cutoff: Date) throws -> Int {
+        try withFileLock(operation: LOCK_EX) {
+            let existing = try loadUnlocked()
+            let remaining = existing.filter { $0.deletedAt >= cutoff }
+            try persist(remaining)
+            return existing.count - remaining.count
+        }
+    }
+
+    private func loadUnlocked() throws -> [BlinkSnapshotTombstone] {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return [] }
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .millisecondsSince1970
+            return try decoder.decode(FileContents.self, from: data).tombstones
+        } catch {
+            throw BlinkTombstoneStoreError.decodingFailed(error.localizedDescription)
+        }
+    }
+
+    private func withFileLock<T>(
+        operation: Int32,
+        _ body: () throws -> T
+    ) throws -> T {
+        let directory = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let lockURL = directory.appendingPathComponent(".\(fileURL.lastPathComponent).lock")
+        let descriptor = Darwin.open(lockURL.path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else {
+            throw BlinkTombstoneStoreError.lockingFailed(String(cString: strerror(errno)))
+        }
+        defer { Darwin.close(descriptor) }
+
+        guard flock(descriptor, operation) == 0 else {
+            throw BlinkTombstoneStoreError.lockingFailed(String(cString: strerror(errno)))
+        }
+        defer { _ = flock(descriptor, LOCK_UN) }
+        return try body()
+    }
+
+    private func persist(_ tombstones: [BlinkSnapshotTombstone]) throws {
+        let contents = FileContents(
+            tombstones: tombstones.sorted {
+                if $0.deletedAt != $1.deletedAt { return $0.deletedAt < $1.deletedAt }
+                return $0.id < $1.id
+            }
+        )
+        let data: Data
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .millisecondsSince1970
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            data = try encoder.encode(contents)
+        } catch {
+            throw BlinkTombstoneStoreError.encodingFailed(error.localizedDescription)
+        }
+
+        let directory = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let tempURL = directory.appendingPathComponent(".\(fileURL.lastPathComponent).\(UUID().uuidString).tmp")
+        FileManager.default.createFile(atPath: tempURL.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: tempURL)
+        do {
+            try handle.write(contentsOf: data)
+            try handle.synchronize()
+            try handle.close()
+        } catch {
+            try? handle.close()
+            try? FileManager.default.removeItem(at: tempURL)
+            throw error
+        }
+
+        do {
+            if FileManager.default.fileExists(atPath: fileURL.path) {
+                _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+            } else {
+                try FileManager.default.moveItem(at: tempURL, to: fileURL)
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: tempURL)
+            throw error
+        }
+    }
+}

--- a/Sources/BlinkCore/NoteStore.swift
+++ b/Sources/BlinkCore/NoteStore.swift
@@ -20,22 +20,30 @@ public actor NoteStore {
     private var notes: [String: Note] = [:]
     private let clock: @Sendable () -> Date
     private let notificationCenter: NotificationCenter
+    private let tombstoneStore: BlinkTombstoneStore?
 
-    public init(fileStore: NoteFileStore, notificationCenter: NotificationCenter = .default) {
+    public init(
+        fileStore: NoteFileStore,
+        notificationCenter: NotificationCenter = .default,
+        tombstoneStore: BlinkTombstoneStore? = nil
+    ) {
         self.fileStore = fileStore
         self.clock = { Date() }
         self.notificationCenter = notificationCenter
+        self.tombstoneStore = tombstoneStore
     }
 
     /// Testing hook: inject a clock so `createdAt`/`updatedAt` are controllable.
     init(
         fileStore: NoteFileStore,
         notificationCenter: NotificationCenter = .default,
+        tombstoneStore: BlinkTombstoneStore? = nil,
         clock: @escaping @Sendable () -> Date
     ) {
         self.fileStore = fileStore
         self.clock = clock
         self.notificationCenter = notificationCenter
+        self.tombstoneStore = tombstoneStore
     }
 
     /// Read the directory into memory. Returns all notes sorted `updatedAt` desc.
@@ -69,6 +77,7 @@ public actor NoteStore {
         )
         try fileStore.save(note)
         notes[id] = note
+        try? await tombstoneStore?.remove(id: id)
         post(.blinkNoteCreated, id: id)
         return note
     }
@@ -125,10 +134,14 @@ public actor NoteStore {
     }
 
     /// Delete a note by id. Throws if `id` is unknown.
-    public func delete(id: String) throws {
+    public func delete(id: String) async throws {
         guard notes[id] != nil else {
             throw NoteFileStoreError.noteNotFound(id: id)
         }
+        // Record first. If the file deletion then fails, full snapshots suppress
+        // the tombstone while the note still exists; a later successful delete
+        // already has durable evidence.
+        try await tombstoneStore?.recordDeletion(id: id, at: clock())
         try fileStore.delete(id: id)
         notes[id] = nil
         post(.blinkNoteDeleted, id: id)
@@ -140,7 +153,10 @@ public actor NoteStore {
         public var created: [String] = []
         public var updated: [String] = []
         public var deleted: [String] = []
-        public var isEmpty: Bool { created.isEmpty && updated.isEmpty && deleted.isEmpty }
+        public var tombstoneFailures: [String] = []
+        public var isEmpty: Bool {
+            created.isEmpty && updated.isEmpty && deleted.isEmpty && tombstoneFailures.isEmpty
+        }
     }
 
     /// Re-scan the directory and reconcile the in-memory index with it,
@@ -152,7 +168,7 @@ public actor NoteStore {
     /// Files that fail to decode are skipped, not treated as deletions — a
     /// malformed foreign file must never cascade into closing panels.
     @discardableResult
-    public func reconcile() -> ReconcileDiff {
+    public func reconcile() async -> ReconcileDiff {
         let onDisk = Dictionary(
             fileStore.loadAllLenient().map { ($0.id, $0) },
             uniquingKeysWith: { first, _ in first }
@@ -170,12 +186,36 @@ public actor NoteStore {
         }
         // Deleted = the file is gone. A present-but-undecodable file keeps its
         // in-memory version untouched (it may be foreign, or mid-rewrite).
-        diff.deleted = notes.keys.filter { !present.contains($0) }
-        for id in diff.deleted { notes[id] = nil }
+        let deletionCandidates = notes.keys.filter { !present.contains($0) }
+        for id in deletionCandidates {
+            do {
+                try await tombstoneStore?.recordDeletion(id: id, at: clock())
+                diff.deleted.append(id)
+                notes[id] = nil
+            } catch {
+                // Retain the known note so the next reconcile retries the
+                // journal write instead of silently losing delete evidence.
+                diff.tombstoneFailures.append(id)
+            }
+        }
+
+        // Retry stale tombstone cleanup for every present note, not only a
+        // newly discovered one. Independent CLI/app writers can transiently
+        // contend on the journal; reconciliation is the convergence loop.
+        for id in onDisk.keys {
+            do {
+                try await tombstoneStore?.remove(id: id)
+            } catch {
+                if !diff.tombstoneFailures.contains(id) {
+                    diff.tombstoneFailures.append(id)
+                }
+            }
+        }
 
         diff.created.sort()
         diff.updated.sort()
         diff.deleted.sort()
+        diff.tombstoneFailures.sort()
         for id in diff.created { post(.blinkNoteCreated, id: id) }
         for id in diff.updated { post(.blinkNoteUpdated, id: id) }
         for id in diff.deleted { post(.blinkNoteDeleted, id: id) }

--- a/Sources/BlinkPeer/BlinkLANPeerClient.swift
+++ b/Sources/BlinkPeer/BlinkLANPeerClient.swift
@@ -1,0 +1,474 @@
+@preconcurrency import MultipeerConnectivity
+
+import BlinkCore
+import CryptoKit
+import Foundation
+
+/// Discovers Blink Macs, completes the encrypted pairing handshake, and then
+/// exposes the app-level `BlinkPeerTransport` snapshot boundary.
+public final class BlinkLANPeerClient: NSObject, BlinkPeerTransport, @unchecked Sendable {
+    private struct PendingConnection {
+        var attemptID: UUID
+        var candidateID: String
+        var continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private struct DiscoveredPeer {
+        var peer: MCPeerID
+        var hostID: String
+        var hostPublicKey: Data
+    }
+
+    private let identity: BlinkPeerClientIdentity
+    private let peerID: MCPeerID
+    private var session: MCSession
+    private let browser: MCNearbyServiceBrowser
+    private let lock = NSLock()
+    private var peersByID: [String: DiscoveredPeer] = [:]
+    private var pendingConnection: PendingConnection?
+    private var activeAttemptID: UUID?
+    private var pendingResponses: [UUID: CheckedContinuation<BlinkPeerResponse, any Error>] = [:]
+    private var connectedPeer: MCPeerID?
+    private var connectionPrivateKey: Curve25519.KeyAgreement.PrivateKey?
+    private var connectionKey: SymmetricKey?
+    private var pairedHostStorage: BlinkPeerHost?
+    private var connectionObserver: (@Sendable (Bool) -> Void)?
+    private var browsingFailureStorage: String?
+
+    public var pairedHost: BlinkPeerHost? {
+        lock.withLock { pairedHostStorage }
+    }
+
+    public var browsingFailure: String? {
+        lock.withLock { browsingFailureStorage }
+    }
+
+    public init(identity: BlinkPeerClientIdentity) {
+        self.identity = identity
+        var displayName = identity.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if displayName.isEmpty { displayName = "iPhone" }
+        while displayName.utf8.count > 60 { displayName.removeLast() }
+        let peerID = MCPeerID(displayName: displayName)
+        self.peerID = peerID
+        self.session = MCSession(
+            peer: peerID,
+            securityIdentity: nil,
+            encryptionPreference: .required
+        )
+        self.browser = MCNearbyServiceBrowser(peer: peerID, serviceType: BlinkLANPeerServer.serviceType)
+        super.init()
+        session.delegate = self
+        browser.delegate = self
+    }
+
+    deinit {
+        browser.stopBrowsingForPeers()
+        session.disconnect()
+    }
+
+    public func startBrowsing() {
+        lock.withLock { browsingFailureStorage = nil }
+        browser.startBrowsingForPeers()
+    }
+
+    public func stopBrowsing() {
+        browser.stopBrowsingForPeers()
+    }
+
+    public func observeConnection(_ observer: @escaping @Sendable (Bool) -> Void) {
+        lock.withLock { connectionObserver = observer }
+    }
+
+    public func availablePeers() -> [BlinkLANPeerCandidate] {
+        lock.withLock {
+            peersByID.map {
+                BlinkLANPeerCandidate(
+                    id: $0.key,
+                    name: $0.value.peer.displayName,
+                    hostID: $0.value.hostID,
+                    publicKey: $0.value.hostPublicKey.base64EncodedString()
+                )
+            }
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        }
+    }
+
+    @discardableResult
+    public func connect(to candidateID: String) async throws -> BlinkPeerHost {
+        let discovered = try lock.withLock { () throws -> DiscoveredPeer in
+            guard let peer = peersByID[candidateID] else { throw BlinkPeerError.peerUnavailable }
+            return peer
+        }
+
+        failAllPending(with: BlinkPeerError.connectionFailed("A newer connection replaced this session."))
+        let attemptID = UUID()
+        let nextSession = MCSession(
+            peer: peerID,
+            securityIdentity: nil,
+            encryptionPreference: .required
+        )
+        nextSession.delegate = self
+        let previousSession = lock.withLock { () -> MCSession in
+            let previous = session
+            session = nextSession
+            activeAttemptID = attemptID
+            pairedHostStorage = nil
+            return previous
+        }
+        previousSession.disconnect()
+
+        let privateKey = Curve25519.KeyAgreement.PrivateKey()
+        let responseKey = try BlinkPeerCrypto.symmetricKey(
+            privateKey: privateKey,
+            peerPublicKey: discovered.hostPublicKey
+        )
+        let securedIdentity = BlinkPeerClientIdentity(
+            credential: BlinkPeerCrypto.credential(
+                seed: identity.credential,
+                hostPublicKey: discovered.hostPublicKey
+            ),
+            name: identity.name
+        )
+        let installed = lock.withLock { () -> Bool in
+            guard activeAttemptID == attemptID, session === nextSession else { return false }
+            connectionPrivateKey = privateKey
+            connectionKey = responseKey
+            return true
+        }
+        guard installed else {
+            nextSession.disconnect()
+            throw BlinkPeerError.connectionFailed("A newer connection replaced this attempt.")
+        }
+
+        do {
+            try await waitForConnection(
+                to: discovered.peer,
+                candidateID: candidateID,
+                attemptID: attemptID,
+                using: nextSession
+            )
+            let response = try await request(
+                .requestAccess(securedIdentity),
+                timeout: .seconds(90),
+                expectedAttemptID: attemptID,
+                expectedSession: nextSession
+            )
+            switch response {
+            case .accessGranted(let host):
+                guard host.id == discovered.hostID,
+                      host.publicKey == discovered.hostPublicKey.base64EncodedString()
+                else { throw BlinkPeerError.invalidResponse }
+                let stillCurrent = lock.withLock { () -> Bool in
+                    guard activeAttemptID == attemptID, session === nextSession else {
+                        return false
+                    }
+                    pairedHostStorage = host
+                    return true
+                }
+                guard stillCurrent else {
+                    throw BlinkPeerError.connectionFailed("A newer connection replaced this attempt.")
+                }
+                notifyConnectionObserver(isConnected: true)
+                return host
+            case .failure(let failure) where failure.code == "access-denied":
+                nextSession.disconnect()
+                throw BlinkPeerError.accessDenied
+            case .failure(let failure):
+                throw BlinkPeerError.remoteFailure(code: failure.code, message: failure.message)
+            case .snapshot:
+                throw BlinkPeerError.invalidResponse
+            }
+        } catch {
+            nextSession.disconnect()
+            throw error
+        }
+    }
+
+    public func disconnect() {
+        let currentSession = lock.withLock { () -> MCSession in
+            pairedHostStorage = nil
+            return session
+        }
+        failAllPending(with: BlinkPeerError.connectionFailed("The session disconnected."))
+        currentSession.disconnect()
+        notifyConnectionObserver(isConnected: false)
+    }
+
+    public func fetchSnapshot(ifNoneMatch etag: String?) async throws -> BlinkSnapshotFetchResult {
+        guard pairedHost != nil else { throw BlinkPeerError.unauthorized }
+        let response = try await request(.fetchSnapshot(ifNoneMatch: etag))
+        switch response {
+        case .snapshot(let result): return result
+        case .failure(let failure) where failure.code == "unauthorized":
+            throw BlinkPeerError.unauthorized
+        case .failure(let failure):
+            throw BlinkPeerError.remoteFailure(code: failure.code, message: failure.message)
+        case .accessGranted:
+            throw BlinkPeerError.invalidResponse
+        }
+    }
+
+    private func waitForConnection(
+        to peer: MCPeerID,
+        candidateID: String,
+        attemptID: UUID,
+        using session: MCSession
+    ) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            let registered = lock.withLock { () -> Bool in
+                guard activeAttemptID == attemptID, self.session === session else {
+                    return false
+                }
+                pendingConnection = PendingConnection(
+                    attemptID: attemptID,
+                    candidateID: candidateID,
+                    continuation: continuation
+                )
+                return true
+            }
+            guard registered else {
+                continuation.resume(
+                    throwing: BlinkPeerError.connectionFailed("A newer connection replaced this attempt.")
+                )
+                return
+            }
+            browser.invitePeer(peer, to: session, withContext: nil, timeout: 12)
+            Task { [weak self] in
+                try? await Task.sleep(for: .seconds(12))
+                self?.timeOutConnection(attemptID: attemptID)
+            }
+        }
+    }
+
+    private func request(
+        _ request: BlinkPeerRequest,
+        timeout: Duration = .seconds(12),
+        expectedAttemptID: UUID? = nil,
+        expectedSession: MCSession? = nil
+    ) async throws -> BlinkPeerResponse {
+        let connection = try lock.withLock { () throws -> (
+            MCPeerID?,
+            Curve25519.KeyAgreement.PrivateKey?,
+            SymmetricKey?,
+            MCSession
+        ) in
+            if let expectedAttemptID, activeAttemptID != expectedAttemptID {
+                throw BlinkPeerError.connectionFailed("A newer connection replaced this attempt.")
+            }
+            if let expectedSession, session !== expectedSession {
+                throw BlinkPeerError.connectionFailed("A newer connection replaced this session.")
+            }
+            return (connectedPeer, connectionPrivateKey, connectionKey, session)
+        }
+        guard let peer = connection.0,
+              let privateKey = connection.1,
+              let responseKey = connection.2
+        else {
+            throw BlinkPeerError.connectionFailed("The Mac is not connected.")
+        }
+        let id = UUID()
+        let sealedPayload = try BlinkPeerCrypto.seal(request, using: responseKey)
+        let data = try JSONEncoder().encode(
+            BlinkPeerRequestEnvelope(
+                id: id,
+                clientPublicKey: privateKey.publicKey.rawRepresentation,
+                sealedPayload: sealedPayload
+            )
+        )
+        return try await withCheckedThrowingContinuation { continuation in
+            let dispatchError = lock.withLock { () -> (any Error)? in
+                if let expectedAttemptID, activeAttemptID != expectedAttemptID {
+                    return BlinkPeerError.connectionFailed(
+                        "A newer connection replaced this attempt."
+                    )
+                }
+                if let expectedSession, session !== expectedSession {
+                    return BlinkPeerError.connectionFailed(
+                        "A newer connection replaced this session."
+                    )
+                }
+                guard session === connection.3, connectedPeer == peer else {
+                    return BlinkPeerError.connectionFailed("The Mac is no longer connected.")
+                }
+
+                pendingResponses[id] = continuation
+                do {
+                    try connection.3.send(data, toPeers: [peer], with: .reliable)
+                    return nil
+                } catch {
+                    pendingResponses[id] = nil
+                    return error
+                }
+            }
+            if let dispatchError {
+                continuation.resume(throwing: dispatchError)
+                return
+            }
+            Task { [weak self] in
+                try? await Task.sleep(for: timeout)
+                self?.finishResponse(id: id, result: .failure(BlinkPeerError.requestTimedOut))
+            }
+        }
+    }
+
+    private func timeOutConnection(attemptID: UUID) {
+        let continuation = lock.withLock { () -> CheckedContinuation<Void, any Error>? in
+            guard pendingConnection?.attemptID == attemptID else { return nil }
+            defer { pendingConnection = nil }
+            if activeAttemptID == attemptID {
+                activeAttemptID = nil
+                connectionPrivateKey = nil
+                connectionKey = nil
+            }
+            return pendingConnection?.continuation
+        }
+        continuation?.resume(throwing: BlinkPeerError.requestTimedOut)
+    }
+
+    private func finishResponse(
+        id: UUID,
+        result: Result<BlinkPeerResponse, any Error>
+    ) {
+        let continuation = lock.withLock { pendingResponses.removeValue(forKey: id) }
+        continuation?.resume(with: result)
+    }
+
+    private func failAllPending(with error: any Error) {
+        let pending = lock.withLock { () -> (
+            CheckedContinuation<Void, any Error>?,
+            [CheckedContinuation<BlinkPeerResponse, any Error>]
+        ) in
+            let connection = pendingConnection?.continuation
+            pendingConnection = nil
+            activeAttemptID = nil
+            let responses = Array(pendingResponses.values)
+            pendingResponses.removeAll()
+            connectedPeer = nil
+            connectionPrivateKey = nil
+            connectionKey = nil
+            return (connection, responses)
+        }
+        pending.0?.resume(throwing: error)
+        pending.1.forEach { $0.resume(throwing: error) }
+    }
+
+    private func candidateID(for peer: MCPeerID) -> String {
+        "\(peer.displayName)#\(peer.hash)"
+    }
+
+    private func notifyConnectionObserver(isConnected: Bool) {
+        let observer = lock.withLock { connectionObserver }
+        observer?(isConnected)
+    }
+}
+
+extension BlinkLANPeerClient: MCNearbyServiceBrowserDelegate {
+    public func browser(
+        _ browser: MCNearbyServiceBrowser,
+        foundPeer peerID: MCPeerID,
+        withDiscoveryInfo info: [String: String]?
+    ) {
+        guard info?["version"] == "3",
+              let hostID = info?["hostID"],
+              !hostID.isEmpty,
+              let encodedKey = info?["hostKey"],
+              let hostPublicKey = Data(base64Encoded: encodedKey),
+              (try? Curve25519.KeyAgreement.PublicKey(rawRepresentation: hostPublicKey)) != nil
+        else { return }
+        lock.withLock {
+            peersByID[candidateID(for: peerID)] = DiscoveredPeer(
+                peer: peerID,
+                hostID: hostID,
+                hostPublicKey: hostPublicKey
+            )
+        }
+    }
+
+    public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+        lock.withLock { peersByID[candidateID(for: peerID)] = nil }
+    }
+
+    public func browser(
+        _ browser: MCNearbyServiceBrowser,
+        didNotStartBrowsingForPeers error: any Error
+    ) {
+        lock.withLock { browsingFailureStorage = error.localizedDescription }
+    }
+}
+
+extension BlinkLANPeerClient: MCSessionDelegate {
+    public func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        guard lock.withLock({ self.session === session }) else { return }
+        switch state {
+        case .connected:
+            let id = candidateID(for: peerID)
+            let continuation = lock.withLock { () -> CheckedContinuation<Void, any Error>? in
+                guard pendingConnection?.candidateID == id,
+                      pendingConnection?.attemptID == activeAttemptID
+                else { return nil }
+                connectedPeer = peerID
+                defer { pendingConnection = nil }
+                return pendingConnection?.continuation
+            }
+            continuation?.resume()
+        case .notConnected:
+            let id = candidateID(for: peerID)
+            let wasCurrentSession = lock.withLock {
+                connectedPeer == peerID || pendingConnection?.candidateID == id
+            }
+            if wasCurrentSession {
+                lock.withLock { pairedHostStorage = nil }
+                failAllPending(with: BlinkPeerError.connectionFailed("The Mac ended the session."))
+                notifyConnectionObserver(isConnected: false)
+            }
+        case .connecting:
+            break
+        @unknown default:
+            break
+        }
+    }
+
+    public func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        guard lock.withLock({ self.session === session && connectedPeer == peerID }) else { return }
+        guard let envelope = try? JSONDecoder().decode(BlinkPeerResponseEnvelope.self, from: data),
+              envelope.version == 3,
+              let responseKey = lock.withLock({ connectionKey }),
+              let response = try? BlinkPeerCrypto.open(
+                  BlinkPeerResponse.self,
+                  from: envelope.sealedPayload,
+                  using: responseKey
+              )
+        else { return }
+        finishResponse(id: envelope.id, result: .success(response))
+    }
+
+    public func session(
+        _ session: MCSession,
+        didReceive stream: InputStream,
+        withName streamName: String,
+        fromPeer peerID: MCPeerID
+    ) {}
+
+    public func session(
+        _ session: MCSession,
+        didStartReceivingResourceWithName resourceName: String,
+        fromPeer peerID: MCPeerID,
+        with progress: Progress
+    ) {}
+
+    public func session(
+        _ session: MCSession,
+        didFinishReceivingResourceWithName resourceName: String,
+        fromPeer peerID: MCPeerID,
+        at localURL: URL?,
+        withError error: (any Error)?
+    ) {}
+}
+
+private extension NSLock {
+    func withLock<T>(_ operation: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try operation()
+    }
+}

--- a/Sources/BlinkPeer/BlinkLANPeerServer.swift
+++ b/Sources/BlinkPeer/BlinkLANPeerServer.swift
@@ -1,0 +1,352 @@
+@preconcurrency import MultipeerConnectivity
+
+import BlinkCore
+import CryptoKit
+import Foundation
+
+/// Advertises a read-only snapshot service over Multipeer Connectivity.
+/// `MCSession` encryption is mandatory; a new device receives no note data
+/// until the Mac explicitly approves its private credential.
+public final class BlinkLANPeerServer: NSObject, @unchecked Sendable {
+    public static let serviceType = "blink-notes"
+    public typealias ApprovalHandler = @Sendable (BlinkPeerClientIdentity) async -> Bool
+
+    public let host: BlinkPeerHost
+
+    private let snapshotService: BlinkSnapshotService
+    private let trustStore: BlinkPeerTrustStore
+    private let approvalHandler: ApprovalHandler
+    private let hostAgreementPrivateKey: Curve25519.KeyAgreement.PrivateKey
+    private let peerID: MCPeerID
+    private let session: MCSession
+    private let advertiser: MCNearbyServiceAdvertiser
+    private let lock = NSLock()
+    private var authorizedCredentialsByPeerKey: [String: String] = [:]
+    private var pendingApprovalPeerKeys = Set<String>()
+
+    public init(
+        hostID: String,
+        displayName: String,
+        snapshotService: BlinkSnapshotService,
+        trustStore: BlinkPeerTrustStore = BlinkPeerTrustStore(),
+        approvalHandler: @escaping ApprovalHandler = { _ in false }
+    ) {
+        let hostAgreementPrivateKey = trustStore.hostAgreementPrivateKey()
+        let hostPublicKey = hostAgreementPrivateKey.publicKey.rawRepresentation.base64EncodedString()
+        self.host = BlinkPeerHost(id: hostID, name: displayName, publicKey: hostPublicKey)
+        self.snapshotService = snapshotService
+        self.trustStore = trustStore
+        self.approvalHandler = approvalHandler
+        self.hostAgreementPrivateKey = hostAgreementPrivateKey
+
+        let peerID = MCPeerID(displayName: displayName)
+        self.peerID = peerID
+        self.session = MCSession(
+            peer: peerID,
+            securityIdentity: nil,
+            encryptionPreference: .required
+        )
+        self.advertiser = MCNearbyServiceAdvertiser(
+            peer: peerID,
+            discoveryInfo: [
+                "version": "3",
+                "hostID": hostID,
+                "hostKey": hostPublicKey,
+            ],
+            serviceType: Self.serviceType
+        )
+        super.init()
+        session.delegate = self
+        advertiser.delegate = self
+    }
+
+    public func start() {
+        advertiser.startAdvertisingPeer()
+    }
+
+    public func stop() {
+        advertiser.stopAdvertisingPeer()
+        session.disconnect()
+        lock.withLock {
+            authorizedCredentialsByPeerKey.removeAll()
+            pendingApprovalPeerKeys.removeAll()
+        }
+    }
+
+    public var trustedPeers: [BlinkTrustedPeer] {
+        trustStore.peers
+    }
+
+    @discardableResult
+    public func revokeTrustedPeer(id: String) -> Bool {
+        let hadLiveSession = lock.withLock { () -> Bool? in
+            guard trustStore.revoke(id: id) else { return nil }
+            let matchingKeys = authorizedCredentialsByPeerKey.compactMap { key, credential in
+                credential == id ? key : nil
+            }
+            matchingKeys.forEach { authorizedCredentialsByPeerKey[$0] = nil }
+            return !matchingKeys.isEmpty
+        }
+        guard let hadLiveSession else { return false }
+        if hadLiveSession {
+            // MCSession only exposes whole-session disconnect. Other approved
+            // devices can reconnect immediately without another prompt.
+            session.disconnect()
+        }
+        return true
+    }
+
+    private func receive(_ data: Data, from peer: MCPeerID) {
+        guard let envelope = try? JSONDecoder().decode(BlinkPeerRequestEnvelope.self, from: data),
+              envelope.version == 3,
+              let responseKey = try? BlinkPeerCrypto.symmetricKey(
+                  privateKey: hostAgreementPrivateKey,
+                  peerPublicKey: envelope.clientPublicKey
+              ),
+              let request = try? BlinkPeerCrypto.open(
+                  BlinkPeerRequest.self,
+                  from: envelope.sealedPayload,
+                  using: responseKey
+              )
+        else { return }
+
+        switch request {
+        case .requestAccess(let requestedIdentity):
+            let key = peerKey(peer)
+            guard requestedIdentity.credential.count == 64,
+                  requestedIdentity.credential.allSatisfy(\.isHexDigit)
+            else {
+                send(
+                    .failure(BlinkPeerFailure(code: "invalid-identity", message: "Blink on this iPhone needs to be reinstalled.")),
+                    id: envelope.id,
+                    to: peer,
+                    using: responseKey
+                )
+                return
+            }
+            let identity = BlinkPeerClientIdentity(
+                credential: requestedIdentity.credential,
+                name: peer.displayName
+            )
+
+            if lock.withLock({ trustStore.contains(credential: identity.credential) }) {
+                grantAccess(
+                    to: identity,
+                    requestID: envelope.id,
+                    peer: peer,
+                    using: responseKey,
+                    approving: false
+                )
+                return
+            }
+
+            let shouldAsk = lock.withLock { pendingApprovalPeerKeys.insert(key).inserted }
+            guard shouldAsk else {
+                send(
+                    .failure(BlinkPeerFailure(code: "approval-pending", message: "An approval request is already open on your Mac.")),
+                    id: envelope.id,
+                    to: peer,
+                    using: responseKey
+                )
+                return
+            }
+
+            Task { [approvalHandler] in
+                let approved = await approvalHandler(identity)
+                self.lock.withLock { _ = self.pendingApprovalPeerKeys.remove(key) }
+                guard approved else {
+                    self.send(
+                        .failure(BlinkPeerFailure(code: "access-denied", message: "Access wasn’t allowed on your Mac.")),
+                        id: envelope.id,
+                        to: peer,
+                        using: responseKey
+                    )
+                    return
+                }
+                self.grantAccess(
+                    to: identity,
+                    requestID: envelope.id,
+                    peer: peer,
+                    using: responseKey,
+                    approving: true
+                )
+            }
+
+        case .fetchSnapshot(let etag):
+            let authorizedCredential = lock.withLock { () -> String? in
+                let key = peerKey(peer)
+                guard let credential = authorizedCredentialsByPeerKey[key],
+                      trustStore.contains(credential: credential)
+                else {
+                    authorizedCredentialsByPeerKey[key] = nil
+                    return nil
+                }
+                return credential
+            }
+            guard let authorizedCredential else {
+                send(
+                    .failure(BlinkPeerFailure(code: "unauthorized", message: "Request access from this Mac before syncing.")),
+                    id: envelope.id,
+                    to: peer,
+                    using: responseKey
+                )
+                return
+            }
+            Task { [snapshotService] in
+                do {
+                    let result = try await snapshotService.fetchSnapshot(ifNoneMatch: etag)
+                    self.sendIfAuthorized(
+                        .snapshot(result),
+                        id: envelope.id,
+                        credential: authorizedCredential,
+                        to: peer,
+                        using: responseKey
+                    )
+                } catch {
+                    self.send(
+                        .failure(BlinkPeerFailure(code: "snapshot-failed", message: error.localizedDescription)),
+                        id: envelope.id,
+                        to: peer,
+                        using: responseKey
+                    )
+                }
+            }
+        }
+    }
+
+    private func grantAccess(
+        to identity: BlinkPeerClientIdentity,
+        requestID: UUID,
+        peer: MCPeerID,
+        using responseKey: SymmetricKey,
+        approving: Bool
+    ) {
+        guard session.connectedPeers.contains(peer) else { return }
+        let granted = lock.withLock { () -> Bool in
+            if approving {
+                _ = trustStore.approve(identity)
+            } else {
+                guard trustStore.contains(credential: identity.credential) else { return false }
+                _ = trustStore.approve(identity)
+            }
+            authorizedCredentialsByPeerKey[peerKey(peer)] = identity.credential
+            return true
+        }
+        guard granted else {
+            send(
+                .failure(BlinkPeerFailure(code: "unauthorized", message: "Request access from this Mac before syncing.")),
+                id: requestID,
+                to: peer,
+                using: responseKey
+            )
+            return
+        }
+        send(.accessGranted(host), id: requestID, to: peer, using: responseKey)
+    }
+
+    private func send(
+        _ response: BlinkPeerResponse,
+        id: UUID,
+        to peer: MCPeerID,
+        using responseKey: SymmetricKey
+    ) {
+        guard session.connectedPeers.contains(peer),
+              let sealedPayload = try? BlinkPeerCrypto.seal(response, using: responseKey),
+              let data = try? JSONEncoder().encode(
+                BlinkPeerResponseEnvelope(id: id, sealedPayload: sealedPayload)
+              ) else { return }
+        try? session.send(data, toPeers: [peer], with: .reliable)
+    }
+
+    /// Serialize the final authorization check and send initiation with revoke.
+    /// Once `session.send` returns, the encrypted payload was queued while the
+    /// credential was still trusted; revoke can then disconnect the session.
+    private func sendIfAuthorized(
+        _ response: BlinkPeerResponse,
+        id: UUID,
+        credential: String,
+        to peer: MCPeerID,
+        using responseKey: SymmetricKey
+    ) {
+        guard let sealedPayload = try? BlinkPeerCrypto.seal(response, using: responseKey),
+              let data = try? JSONEncoder().encode(
+                  BlinkPeerResponseEnvelope(id: id, sealedPayload: sealedPayload)
+              )
+        else { return }
+
+        lock.withLock {
+            guard authorizedCredentialsByPeerKey[peerKey(peer)] == credential,
+                  trustStore.contains(credential: credential),
+                  session.connectedPeers.contains(peer)
+            else { return }
+            try? session.send(data, toPeers: [peer], with: .reliable)
+        }
+    }
+
+    private func peerKey(_ peer: MCPeerID) -> String {
+        "\(peer.displayName)#\(peer.hash)"
+    }
+
+}
+
+extension BlinkLANPeerServer: MCNearbyServiceAdvertiserDelegate {
+    public func advertiser(
+        _ advertiser: MCNearbyServiceAdvertiser,
+        didReceiveInvitationFromPeer peerID: MCPeerID,
+        withContext context: Data?,
+        invitationHandler: @escaping (Bool, MCSession?) -> Void
+    ) {
+        invitationHandler(true, session)
+    }
+
+    public func advertiser(
+        _ advertiser: MCNearbyServiceAdvertiser,
+        didNotStartAdvertisingPeer error: any Error
+    ) {}
+}
+
+extension BlinkLANPeerServer: MCSessionDelegate {
+    public func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        if state == .notConnected {
+            lock.withLock {
+                let key = peerKey(peerID)
+                authorizedCredentialsByPeerKey[key] = nil
+                _ = pendingApprovalPeerKeys.remove(key)
+            }
+        }
+    }
+
+    public func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        receive(data, from: peerID)
+    }
+
+    public func session(
+        _ session: MCSession,
+        didReceive stream: InputStream,
+        withName streamName: String,
+        fromPeer peerID: MCPeerID
+    ) {}
+
+    public func session(
+        _ session: MCSession,
+        didStartReceivingResourceWithName resourceName: String,
+        fromPeer peerID: MCPeerID,
+        with progress: Progress
+    ) {}
+
+    public func session(
+        _ session: MCSession,
+        didFinishReceivingResourceWithName resourceName: String,
+        fromPeer peerID: MCPeerID,
+        at localURL: URL?,
+        withError error: (any Error)?
+    ) {}
+}
+
+private extension NSLock {
+    func withLock<T>(_ operation: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try operation()
+    }
+}

--- a/Sources/BlinkPeer/BlinkPeerProtocol.swift
+++ b/Sources/BlinkPeer/BlinkPeerProtocol.swift
@@ -1,0 +1,126 @@
+import BlinkCore
+import CryptoKit
+import Foundation
+
+public struct BlinkPeerHost: Codable, Equatable, Sendable {
+    public var id: String
+    public var name: String
+    public var publicKey: String
+
+    public init(id: String, name: String, publicKey: String = "") {
+        self.id = id
+        self.name = name
+        self.publicKey = publicKey
+    }
+}
+
+struct BlinkPeerRequestEnvelope: Codable {
+    var version: Int = 3
+    var id: UUID
+    var clientPublicKey: Data
+    var sealedPayload: Data
+}
+
+enum BlinkPeerRequest: Codable {
+    case requestAccess(BlinkPeerClientIdentity)
+    case fetchSnapshot(ifNoneMatch: String?)
+}
+
+struct BlinkPeerResponseEnvelope: Codable {
+    var version: Int = 3
+    var id: UUID
+    var sealedPayload: Data
+}
+
+enum BlinkPeerResponse: Codable {
+    case accessGranted(BlinkPeerHost)
+    case snapshot(BlinkSnapshotFetchResult)
+    case failure(BlinkPeerFailure)
+}
+
+struct BlinkPeerFailure: Codable, Equatable, Sendable {
+    var code: String
+    var message: String
+}
+
+public enum BlinkPeerError: Error, LocalizedError, Equatable, Sendable {
+    case peerUnavailable
+    case connectionFailed(String)
+    case accessDenied
+    case unauthorized
+    case invalidResponse
+    case requestTimedOut
+    case remoteFailure(code: String, message: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .peerUnavailable:
+            return "That Mac is no longer available nearby."
+        case .connectionFailed(let detail):
+            return "Blink could not connect to the Mac: \(detail)"
+        case .accessDenied:
+            return "Access wasn’t allowed on your Mac. You can try again."
+        case .unauthorized:
+            return "This iPhone no longer has access to the Mac. Request access again."
+        case .invalidResponse:
+            return "The Mac returned an invalid Blink response."
+        case .requestTimedOut:
+            return "The Mac did not respond in time."
+        case .remoteFailure(_, let message):
+            return message
+        }
+    }
+}
+
+public struct BlinkLANPeerCandidate: Equatable, Identifiable, Sendable {
+    public var id: String
+    public var name: String
+    public var hostID: String
+    public var publicKey: String
+
+    public init(id: String, name: String, hostID: String, publicKey: String) {
+        self.id = id
+        self.name = name
+        self.hostID = hostID
+        self.publicKey = publicKey
+    }
+}
+
+enum BlinkPeerCrypto {
+    private static let salt = Data("dev.arach.blink.peer.v3".utf8)
+
+    static func symmetricKey(
+        privateKey: Curve25519.KeyAgreement.PrivateKey,
+        peerPublicKey: Data
+    ) throws -> SymmetricKey {
+        let publicKey = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: peerPublicKey)
+        let secret = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
+        return secret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: salt,
+            sharedInfo: Data(),
+            outputByteCount: 32
+        )
+    }
+
+    static func seal<Value: Encodable>(_ value: Value, using key: SymmetricKey) throws -> Data {
+        let plaintext = try JSONEncoder().encode(value)
+        return try ChaChaPoly.seal(plaintext, using: key).combined
+    }
+
+    static func open<Value: Decodable>(
+        _ type: Value.Type,
+        from combined: Data,
+        using key: SymmetricKey
+    ) throws -> Value {
+        let box = try ChaChaPoly.SealedBox(combined: combined)
+        return try JSONDecoder().decode(type, from: ChaChaPoly.open(box, using: key))
+    }
+
+    static func credential(seed: String, hostPublicKey: Data) -> String {
+        let key = SymmetricKey(data: Data(seed.utf8))
+        return HMAC<SHA256>.authenticationCode(for: hostPublicKey, using: key)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}

--- a/Sources/BlinkPeer/BlinkPeerTrustStore.swift
+++ b/Sources/BlinkPeer/BlinkPeerTrustStore.swift
@@ -1,0 +1,121 @@
+import CryptoKit
+import Foundation
+
+/// The private, app-scoped credential an iPhone presents inside an encrypted
+/// peer session. The value is random and never shown as part of the pairing UI.
+public struct BlinkPeerClientIdentity: Codable, Equatable, Sendable {
+    public var credential: String
+    public var name: String
+
+    public init(credential: String, name: String) {
+        self.credential = credential
+        self.name = name
+    }
+}
+
+/// A device the Mac has explicitly approved for read-only note access.
+public struct BlinkTrustedPeer: Codable, Equatable, Identifiable, Sendable {
+    public var id: String
+    public var name: String
+    public var approvedAt: Date
+
+    public init(id: String, name: String, approvedAt: Date = .now) {
+        self.id = id
+        self.name = name
+        self.approvedAt = approvedAt
+    }
+}
+
+/// Persists approved device credentials. Authorization is still enforced per
+/// live encrypted session; this store only decides whether the Mac must ask the
+/// person again when that device reconnects.
+public final class BlinkPeerTrustStore: @unchecked Sendable {
+    private let defaults: UserDefaults
+    private let storageKey: String
+    private let lock = NSLock()
+
+    public init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = "blink.peer.trusted-devices"
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+    }
+
+    public var peers: [BlinkTrustedPeer] {
+        lock.withLock { load() }
+    }
+
+    public func contains(credential: String) -> Bool {
+        lock.withLock { load().contains { $0.id == credential } }
+    }
+
+    @discardableResult
+    public func approve(_ identity: BlinkPeerClientIdentity) -> BlinkTrustedPeer {
+        lock.withLock {
+            var current = load()
+            if let index = current.firstIndex(where: { $0.id == identity.credential }) {
+                current[index].name = identity.name
+                save(current)
+                return current[index]
+            }
+
+            let peer = BlinkTrustedPeer(id: identity.credential, name: identity.name)
+            current.append(peer)
+            save(current)
+            return peer
+        }
+    }
+
+    @discardableResult
+    public func revoke(id: String) -> Bool {
+        lock.withLock {
+            var current = load()
+            let oldCount = current.count
+            current.removeAll { $0.id == id }
+            guard current.count != oldCount else { return false }
+            save(current)
+            return true
+        }
+    }
+
+    /// A stable app-layer agreement key authenticates this Mac across
+    /// Multipeer sessions. The framework still supplies mandatory transport
+    /// encryption; this key creates an end-to-end sealed channel that a relay
+    /// or lookalike advertiser cannot decrypt.
+    func hostAgreementPrivateKey() -> Curve25519.KeyAgreement.PrivateKey {
+        lock.withLock {
+            let key = "\(storageKey).host-agreement-key"
+            if let data = defaults.data(forKey: key),
+               let existing = try? Curve25519.KeyAgreement.PrivateKey(rawRepresentation: data) {
+                return existing
+            }
+            let created = Curve25519.KeyAgreement.PrivateKey()
+            defaults.set(created.rawRepresentation, forKey: key)
+            return created
+        }
+    }
+
+    private func load() -> [BlinkTrustedPeer] {
+        guard let data = defaults.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([BlinkTrustedPeer].self, from: data)
+        else { return [] }
+        return decoded.sorted {
+            if $0.approvedAt != $1.approvedAt { return $0.approvedAt < $1.approvedAt }
+            return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
+    private func save(_ peers: [BlinkTrustedPeer]) {
+        guard let data = try? JSONEncoder().encode(peers) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ operation: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try operation()
+    }
+}

--- a/Tests/BlinkCoreTests/BlinkSnapshotTests.swift
+++ b/Tests/BlinkCoreTests/BlinkSnapshotTests.swift
@@ -1,0 +1,280 @@
+import Foundation
+import Testing
+@testable import BlinkCore
+
+@Suite("Blink snapshots")
+struct BlinkSnapshotTests {
+    @Test("full snapshots preserve exact frontmattered markdown and stable ETags")
+    func exactSnapshot() throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = NoteFileStore(directory: directory)
+        var presentation = NotePresentation()
+        presentation.workspace = "demo"
+        let note = Note(
+            id: "hello",
+            content: "# Hello\nBody",
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSince1970: 200),
+            tags: ["ios"],
+            pinned: true,
+            presentation: presentation,
+            extraFrontmatter: ["source: agent://example"]
+        )
+        try store.save(note)
+        let expectedMarkdown = try String(contentsOf: store.url(for: note.id), encoding: .utf8)
+        let first = try BlinkSnapshotBuilder(notesDirectory: directory) {
+            Date(timeIntervalSince1970: 1_000)
+        }.build()
+        let second = try BlinkSnapshotBuilder(notesDirectory: directory) {
+            Date(timeIntervalSince1970: 2_000)
+        }.build()
+
+        #expect(first.notes.count == 1)
+        #expect(first.notes[0].markdown == expectedMarkdown)
+        #expect(first.notes[0].presentation.workspace == "demo")
+        #expect(first.notes[0].tags == ["ios"])
+        #expect(first.notes[0].pinned)
+        #expect(first.etag == second.etag)
+        #expect(first.generatedAt != second.generatedAt)
+    }
+
+    @Test("identity-divergent files are quarantined instead of becoming notes")
+    func identityQuarantine() throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let encoded = Frontmatter.encode(
+            Note(
+                id: "claimed-id",
+                content: "# Divergent",
+                createdAt: Date(timeIntervalSince1970: 100),
+                updatedAt: Date(timeIntervalSince1970: 100)
+            )
+        )
+        try Data(encoded.utf8).write(to: directory.appendingPathComponent("file-id.md"))
+
+        let snapshot = try BlinkSnapshotBuilder(notesDirectory: directory).build()
+
+        #expect(snapshot.notes.isEmpty)
+        #expect(snapshot.issues == [
+            BlinkSnapshotIssue(
+                code: .identityMismatch,
+                fileName: "file-id.md",
+                expectedID: "file-id",
+                claimedID: "claimed-id"
+            )
+        ])
+    }
+
+    @Test("an unreadable notes root never becomes an authoritative empty snapshot")
+    func directoryFailure() throws {
+        let root = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let notADirectory = root.appendingPathComponent("Notes")
+        try Data("not a directory".utf8).write(to: notADirectory)
+
+        #expect(throws: BlinkSnapshotBuilderError.self) {
+            _ = try BlinkSnapshotBuilder(
+                notesDirectory: notADirectory,
+                maxStabilityAttempts: 2
+            ).build()
+        }
+    }
+
+    @Test("snapshot service returns not-modified for an exact corpus ETag")
+    func conditionalFetch() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try NoteFileStore(directory: directory).save(
+            Note(
+                id: "one",
+                content: "# One",
+                createdAt: Date(timeIntervalSince1970: 100),
+                updatedAt: Date(timeIntervalSince1970: 100)
+            )
+        )
+        let service = BlinkSnapshotService(
+            builder: BlinkSnapshotBuilder(notesDirectory: directory)
+        )
+
+        let first = try await service.fetchSnapshot(ifNoneMatch: nil)
+        let snapshot: BlinkSnapshot
+        switch first {
+        case .snapshot(let value): snapshot = value
+        case .notModified: Issue.record("First fetch unexpectedly returned not-modified")
+            return
+        }
+
+        #expect(
+            try await service.fetchSnapshot(ifNoneMatch: snapshot.etag)
+                == .notModified(etag: snapshot.etag)
+        )
+    }
+
+    @Test("tombstones persist atomically and appear only for absent notes")
+    func tombstones() async throws {
+        let root = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let notes = root.appendingPathComponent("Notes", isDirectory: true)
+        let storeURL = root.appendingPathComponent("sync/tombstones.json")
+        let tombstoneStore = BlinkTombstoneStore(fileURL: storeURL)
+        let deleted = try await tombstoneStore.recordDeletion(
+            id: "gone",
+            at: Date(timeIntervalSince1970: 300)
+        )
+        _ = try await tombstoneStore.recordDeletion(
+            id: "back-again",
+            at: Date(timeIntervalSince1970: 400)
+        )
+        try NoteFileStore(directory: notes).save(
+            Note(
+                id: "back-again",
+                content: "# Restored",
+                createdAt: Date(timeIntervalSince1970: 500),
+                updatedAt: Date(timeIntervalSince1970: 500)
+            )
+        )
+        let service = BlinkSnapshotService(
+            builder: BlinkSnapshotBuilder(notesDirectory: notes),
+            tombstoneStore: tombstoneStore
+        )
+
+        let result = try await service.fetchSnapshot(ifNoneMatch: nil)
+        guard case .snapshot(let snapshot) = result else {
+            Issue.record("Snapshot fetch unexpectedly returned not-modified")
+            return
+        }
+        #expect(snapshot.tombstones == [deleted])
+
+        let reloaded = BlinkTombstoneStore(fileURL: storeURL)
+        #expect(try await reloaded.all().map(\.id) == ["gone", "back-again"])
+    }
+
+    @Test("independent tombstone stores serialize concurrent journal updates")
+    func concurrentTombstoneWriters() async throws {
+        let root = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fileURL = root.appendingPathComponent("sync/tombstones.json")
+        let first = BlinkTombstoneStore(fileURL: fileURL)
+        let second = BlinkTombstoneStore(fileURL: fileURL)
+        let ids = (0..<40).map { "deleted-\($0)" }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for (index, id) in ids.enumerated() {
+                group.addTask {
+                    let store = index.isMultiple(of: 2) ? first : second
+                    _ = try await store.recordDeletion(
+                        id: id,
+                        at: Date(timeIntervalSince1970: Double(index))
+                    )
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        #expect(try await first.all().map(\.id).sorted() == ids.sorted())
+    }
+
+    @Test("a quarantined source file suppresses its stale tombstone")
+    func quarantineSuppressesStaleTombstone() throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Data("not frontmatter".utf8).write(
+            to: directory.appendingPathComponent("restored.md")
+        )
+        let stale = BlinkSnapshotTombstone(
+            id: "restored",
+            deletedAt: Date(timeIntervalSince1970: 10),
+            revision: "stale"
+        )
+
+        let snapshot = try BlinkSnapshotBuilder(notesDirectory: directory)
+            .build(tombstones: [stale])
+
+        #expect(snapshot.notes.isEmpty)
+        #expect(snapshot.issues.map(\.expectedID) == ["restored"])
+        #expect(snapshot.tombstones.isEmpty)
+    }
+
+    @Test("NoteStore records direct and externally observed deletions")
+    func noteStoreDeletionJournal() async throws {
+        let root = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let notes = root.appendingPathComponent("Notes", isDirectory: true)
+        let fileStore = NoteFileStore(directory: notes)
+        let tombstones = BlinkTombstoneStore(
+            fileURL: root.appendingPathComponent("sync/tombstones.json")
+        )
+        let store = NoteStore(fileStore: fileStore, tombstoneStore: tombstones)
+        _ = try await store.load()
+
+        let direct = try await store.create(content: "# Direct")
+        try await store.delete(id: direct.id)
+
+        let external = try await store.create(content: "# External")
+        try fileStore.delete(id: external.id)
+        let diff = await store.reconcile()
+
+        #expect(diff.deleted == [external.id])
+        #expect(diff.tombstoneFailures.isEmpty)
+        #expect(try await tombstones.all().map(\.id) == [direct.id, external.id].sorted())
+    }
+
+    @Test("mobile cache retains quarantined notes until an explicit tombstone")
+    func mobileCacheQuarantine() async throws {
+        let root = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cache = BlinkSnapshotCache(fileURL: root.appendingPathComponent("snapshot.json"))
+        let now = Date(timeIntervalSince1970: 12)
+        let note = BlinkSnapshotNote(
+            id: "keep-me",
+            revision: "r1",
+            markdown: "---\nid: keep-me\ncreated: 1970-01-01T00:00:12.000Z\nupdated: 1970-01-01T00:00:12.000Z\ntags: []\npinned: false\n---\nKeep me",
+            title: "Keep me",
+            updatedAt: now,
+            tags: [],
+            pinned: false,
+            presentation: NotePresentation()
+        )
+        let first = BlinkSnapshot(
+            generatedAt: now,
+            etag: "\"one\"",
+            notes: [note],
+            tombstones: [],
+            issues: []
+        )
+        _ = try await cache.apply(first)
+
+        let quarantined = BlinkSnapshot(
+            generatedAt: now.addingTimeInterval(1),
+            etag: "\"two\"",
+            notes: [],
+            tombstones: [],
+            issues: [
+                BlinkSnapshotIssue(
+                    code: .invalidFrontmatter,
+                    fileName: "keep-me.md",
+                    expectedID: "keep-me"
+                )
+            ]
+        )
+        let retained = try await cache.apply(quarantined)
+        #expect(retained.notes.map(\.id) == ["keep-me"])
+        #expect(retained.etag == "\"two\"")
+
+        var deleted = quarantined
+        deleted.etag = "\"three\""
+        deleted.tombstones = [
+            BlinkSnapshotTombstone(id: "keep-me", deletedAt: now, revision: "delete-r1")
+        ]
+        let removed = try await cache.apply(deleted)
+        #expect(removed.notes.isEmpty)
+    }
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("blink-snapshot-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/Tests/BlinkPeerTests/BlinkPeerProtocolTests.swift
+++ b/Tests/BlinkPeerTests/BlinkPeerProtocolTests.swift
@@ -1,0 +1,143 @@
+import BlinkCore
+@testable import BlinkPeer
+import CryptoKit
+import Foundation
+import Testing
+
+@Suite("Blink encrypted LAN peer protocol")
+struct BlinkPeerProtocolTests {
+    @Test("snapshot responses survive the peer wire codec")
+    func snapshotResponseRoundTrip() throws {
+        let snapshot = BlinkSnapshot(
+            generatedAt: Date(timeIntervalSince1970: 42),
+            etag: "\"snapshot-r1\"",
+            notes: [],
+            tombstones: [],
+            issues: []
+        )
+        let clientKey = Curve25519.KeyAgreement.PrivateKey()
+        let hostKey = Curve25519.KeyAgreement.PrivateKey()
+        let clientShared = try BlinkPeerCrypto.symmetricKey(
+            privateKey: clientKey,
+            peerPublicKey: hostKey.publicKey.rawRepresentation
+        )
+        let hostShared = try BlinkPeerCrypto.symmetricKey(
+            privateKey: hostKey,
+            peerPublicKey: clientKey.publicKey.rawRepresentation
+        )
+        let envelope = BlinkPeerResponseEnvelope(
+            id: UUID(),
+            sealedPayload: try BlinkPeerCrypto.seal(
+                BlinkPeerResponse.snapshot(.snapshot(snapshot)),
+                using: hostShared
+            )
+        )
+
+        let decoded = try JSONDecoder().decode(
+            BlinkPeerResponseEnvelope.self,
+            from: JSONEncoder().encode(envelope)
+        )
+        #expect(decoded.id == envelope.id)
+        let response = try BlinkPeerCrypto.open(
+            BlinkPeerResponse.self,
+            from: decoded.sealedPayload,
+            using: clientShared
+        )
+        guard case .snapshot(.snapshot(let result)) = response else {
+            Issue.record("Expected a full snapshot response")
+            return
+        }
+        #expect(result == snapshot)
+    }
+
+    @Test("device access requests survive the peer wire codec")
+    func accessRequestRoundTrip() throws {
+        let seed = UUID().uuidString.lowercased()
+        let clientKey = Curve25519.KeyAgreement.PrivateKey()
+        let hostKey = Curve25519.KeyAgreement.PrivateKey()
+        let clientShared = try BlinkPeerCrypto.symmetricKey(
+            privateKey: clientKey,
+            peerPublicKey: hostKey.publicKey.rawRepresentation
+        )
+        let hostShared = try BlinkPeerCrypto.symmetricKey(
+            privateKey: hostKey,
+            peerPublicKey: clientKey.publicKey.rawRepresentation
+        )
+        let identity = BlinkPeerClientIdentity(
+            credential: BlinkPeerCrypto.credential(
+                seed: seed,
+                hostPublicKey: hostKey.publicKey.rawRepresentation
+            ),
+            name: "Arach’s iPhone"
+        )
+        let envelope = BlinkPeerRequestEnvelope(
+            id: UUID(),
+            clientPublicKey: clientKey.publicKey.rawRepresentation,
+            sealedPayload: try BlinkPeerCrypto.seal(
+                BlinkPeerRequest.requestAccess(identity),
+                using: clientShared
+            )
+        )
+
+        let decoded = try JSONDecoder().decode(
+            BlinkPeerRequestEnvelope.self,
+            from: JSONEncoder().encode(envelope)
+        )
+        #expect(decoded.version == 3)
+        let request = try BlinkPeerCrypto.open(
+            BlinkPeerRequest.self,
+            from: decoded.sealedPayload,
+            using: hostShared
+        )
+        guard case .requestAccess(let result) = request else {
+            Issue.record("Expected a device access request")
+            return
+        }
+        #expect(result == identity)
+        #expect(decoded.sealedPayload.range(of: Data(seed.utf8)) == nil)
+    }
+
+    @Test("credentials are scoped to the authenticated host key")
+    func hostScopedCredentials() {
+        let seed = UUID().uuidString.lowercased()
+        let firstHost = Curve25519.KeyAgreement.PrivateKey().publicKey.rawRepresentation
+        let secondHost = Curve25519.KeyAgreement.PrivateKey().publicKey.rawRepresentation
+
+        let first = BlinkPeerCrypto.credential(seed: seed, hostPublicKey: firstHost)
+        let firstAgain = BlinkPeerCrypto.credential(seed: seed, hostPublicKey: firstHost)
+        let second = BlinkPeerCrypto.credential(seed: seed, hostPublicKey: secondHost)
+
+        #expect(first == firstAgain)
+        #expect(first != second)
+        #expect(first.count == 64)
+        #expect(!first.contains(seed))
+    }
+
+    @Test("approved devices persist and can be revoked")
+    func trustStoreLifecycle() throws {
+        let suiteName = "BlinkPeerTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = BlinkPeerTrustStore(defaults: defaults, storageKey: "trusted")
+        let identity = BlinkPeerClientIdentity(
+            credential: UUID().uuidString.lowercased(),
+            name: "Arach’s iPhone"
+        )
+
+        #expect(!store.contains(credential: identity.credential))
+        let approved = store.approve(identity)
+        #expect(approved.name == identity.name)
+        #expect(store.contains(credential: identity.credential))
+        #expect(store.peers == [approved])
+
+        let reloaded = BlinkPeerTrustStore(defaults: defaults, storageKey: "trusted")
+        #expect(
+            store.hostAgreementPrivateKey().rawRepresentation
+                == reloaded.hostAgreementPrivateKey().rawRepresentation
+        )
+        #expect(reloaded.peers == [approved])
+        #expect(reloaded.revoke(id: identity.credential))
+        #expect(reloaded.peers.isEmpty)
+        #expect(!reloaded.revoke(id: identity.credential))
+    }
+}


### PR DESCRIPTION
## Summary
- add stable, ETag-addressed full snapshots preserving exact markdown and quarantining unreadable or identity-divergent files
- add atomic mobile cache plus flock-serialized cross-process tombstones, retrying cleanup and suppressing stale deletions for present quarantined files
- add an encryption-required Multipeer transport wrapped in an end-to-end Curve25519/ChaChaPoly channel
- persist the Mac agreement key, derive non-reusable per-host device credentials, authenticate sealed responses, and make grant/revoke/fetch authorization transactional
- isolate every connection attempt in a fresh MCSession with generation-aware timeouts/callbacks
- expose BlinkCore and BlinkPeer on iOS 17+

## Verification
- clean isolated `BLINK_HUDSON_SOURCE=git swift test` (140 tests, 17 suites)
- clean build includes BlinkApp, `blink`, BlinkPeer, BlinkCoreTests, and BlinkPeerTests
- concurrent independent tombstone-store coverage
- sealed request/response codec, stable host key, and host-scoped credential coverage
- `git diff --check origin/main...HEAD`

## Review fixes
- addressed all five independent security/concurrency findings: revoke/grant races, lost tombstone updates, reconnect generations, bearer-credential exposure, and stale tombstone/quarantine behavior