### PR TITLE
📱 Add the encrypted iOS companion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 dist/
 out/
 *.xcodeproj
+apps/ios/BlinkMobile/Info.plist
 *.tsbuildinfo
 
 # Dependencies

--- a/.impeccable/surfaces/apps-ios-blinkmobile-contentview-swift.md
+++ b/.impeccable/surfaces/apps-ios-blinkmobile-contentview-swift.md
@@ -1,0 +1,34 @@
+---
+version: 1
+slug: "apps-ios-blinkmobile-contentview-swift"
+primary_target: "apps/ios/BlinkMobile/ContentView.swift"
+related_targets: ["apps/ios/BlinkMobile/BlinkMobileModel.swift","apps/ios/BlinkMobile/BlinkMobileApp.swift"]
+---
+
+Scope: Blink's native iPhone/iPad companion. Mode: Operate.
+
+Audience and job: one Blink user recalling the same Mac-authored notes away from
+their desk. They pair to a nearby Mac, sync, filter by workspace, search, and
+read from an offline cache.
+
+Primary task: find and read a note quickly while understanding whether the view
+is live or offline. The source content is exact frontmattered Markdown projected
+into native summaries and reading views.
+
+Direction: Index Tape. The app is a carbon copy of the desktop log: warm paper
+in light mode, neutral graphite in dark mode, a continuous indexed machine rail,
+full-bleed rules, square state marks, and explicit monospaced trust language.
+No forest wash and no rounded library cards. The workspace is the large title;
+the Blink mark controls scope. Compact search grows from the bottom rail into a
+real SwiftUI field; regular width uses native sidebar search. Keep native
+navigation, Dynamic Type, VoiceOver grouping, keyboard avoidance, sheets, and
+SF Symbols. The system serif is reserved for reader titles. Signal blue marks
+live state or selection; amber is degraded/stale only.
+
+Constraints: read-only v1; no desktop panel metaphor on mobile; no plaintext LAN
+transport; quarantined source files retain their last known-good cached note.
+Device approval is explicit on the Mac, credentials are host-scoped inside an
+end-to-end sealed channel, and access remains revocable from the Mac menu.
+
+Unresolved: mobile editing/conflicts, attachments, and Tailscale or
+managed-relay routes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,12 @@ Other useful references:
   math / panel physics.
 - `Sources/BlinkCLI` — `swift-argument-parser` CLI over BlinkCore. `BlinkPaths`
   keeps the app and CLI on the same locations.
+- `Sources/BlinkPeer` — encrypted Multipeer Connectivity discovery, pairing,
+  and snapshot transport shared by macOS and iOS. Bonjour advertises presence;
+  new devices request explicit Mac approval inside an encrypted session, and
+  remembered device access remains revocable from the Mac.
+- `apps/ios` — XcodeGen source for the read-only, offline-first iPhone/iPad
+  companion. It consumes the local BlinkCore and BlinkPeer package products.
 - `Tests/BlinkCoreTests` — narrow tests for storage, frontmatter, identity,
   workspaces, grid placement, and panel physics; run the matching suite for
   domain changes.
@@ -114,6 +120,7 @@ swift test                   # BlinkCore tests
 swift build --product blink  # notes CLI (docs/cli.md)
 (cd web/editor && bun install && bun run build)   # editor bundle
 ./scripts/run-app.sh --debug --restart            # bundle dist/Blink.app + launch
+(cd apps/ios && xcodegen generate)                 # generate BlinkMobile.xcodeproj
 ```
 
 ## Hard requirements (inherited from v1 bugs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,12 @@ Other useful references:
   math / panel physics.
 - `Sources/BlinkCLI` — `swift-argument-parser` CLI over BlinkCore. `BlinkPaths`
   keeps the app and CLI on the same locations.
+- `Sources/BlinkPeer` — encrypted Multipeer Connectivity discovery, pairing,
+  and snapshot transport shared by macOS and iOS. Bonjour advertises presence;
+  new devices request explicit Mac approval inside an encrypted session, and
+  remembered device access remains revocable from the Mac.
+- `apps/ios` — XcodeGen source for the read-only, offline-first iPhone/iPad
+  companion. It consumes the local BlinkCore and BlinkPeer package products.
 - `Tests/BlinkCoreTests` — narrow tests for storage, frontmatter, identity,
   workspaces, grid placement, and panel physics; run the matching suite for
   domain changes.
@@ -114,6 +120,7 @@ swift test                   # BlinkCore tests
 swift build --product blink  # notes CLI (docs/cli.md)
 (cd web/editor && bun install && bun run build)   # editor bundle
 ./scripts/run-app.sh --debug --restart            # bundle dist/Blink.app + launch
+(cd apps/ios && xcodegen generate)                 # generate BlinkMobile.xcodeproj
 ```
 
 ## Hard requirements (inherited from v1 bugs)

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,73 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+adaptive
+
+## Users
+
+Blink is for people who use spatial notes as a working set on a Mac and need to
+recall those notes away from the desk on an iPhone or iPad. The initial companion
+is optimized for one person pairing their own devices.
+
+## Product Purpose
+
+Blink makes notes spatial on macOS: the note is the window and the desktop is the
+workspace. Its mobile companion makes the same notes and workspace membership
+available for quick, read-only recall without turning Blink into a document
+library.
+
+## Positioning
+
+Markdown files remain the durable truth. Mobile access is a projection of that
+file-backed workspace, not a second authoritative store or a proprietary note
+format.
+
+## Operating Context
+
+On macOS, people capture, place, resize, shade, focus, and edit floating note
+panels. On iOS, they discover and pair with their Mac, sync a coherent snapshot,
+filter by workspace, search, and read from an offline cache.
+
+## Capabilities and Constraints
+
+- The first mobile transport is same-network LAN discovery.
+- Pairing uses an end-to-end sealed channel inside the encrypted peer session;
+  the device's reusable seed never leaves the device and derives a distinct
+  credential for each Mac.
+- Mobile is read-only in the first version; edits and conflict resolution remain
+  an open decision.
+- Exact frontmattered Markdown, foreign metadata, stable note identity, and
+  deletion evidence survive replication.
+- LAN, Tailscale, and future managed relay routes share an orchestration contract;
+  provider-specific vocabulary does not leak into Blink's content model.
+- Per-device macOS panel frames stay local and are not mobile document state.
+
+## Brand Commitments
+
+The user-visible name is Blink. The macOS product's graphite-and-paper surfaces,
+cool signal-blue accent, precise monospaced metadata, and quiet operational voice
+are the incumbent identity. Native mobile conventions take priority over porting
+desktop chrome literally.
+
+## Evidence on Hand
+
+The working macOS app, BlinkCore note/frontmatter tests, CLI documentation, and
+the existing Capture Popover are the source material. No customer claims,
+benchmarks, or third-party endorsements are available and none should be invented.
+
+## Product Principles
+
+- Keep Markdown as truth and caches replaceable.
+- Make the common capture-to-recall loop immediate.
+- Preserve identity and metadata before adding replication cleverness.
+- Prefer local, comprehensible behavior with explicit secure escalation.
+- Follow each Apple platform's native interaction model.
+
+## Accessibility & Inclusion
+
+The mobile companion uses Dynamic Type, semantic colors, native navigation and
+controls, VoiceOver labels, 44-point minimum targets, and Reduce Motion-aware
+transitions.

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
             name: "BlinkApp",
             dependencies: [
                 "BlinkCore",
+                "BlinkPeer",
                 .product(name: "HudsonUI", package: "hudson"),
                 .product(name: "HudsonShell", package: "hudson"),
                 .product(name: "HudsonObservability", package: "hudson"),

--- a/Sources/BlinkApp/AppDelegate.swift
+++ b/Sources/BlinkApp/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AppKit
 import BlinkCore
+import BlinkPeer
 import HudsonObservability
 import ServiceManagement
 import SwiftUI
@@ -18,6 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var activityCatalog: BlinkActivityCatalog?
     private var commandRequestObserver: NSObjectProtocol?
     private var notesWatcher: DirectoryWatcher?
+    private var peerServer: BlinkLANPeerServer?
     private let log = HudLogger(category: "blink.app")
 
     static func notesDirectory() -> URL {
@@ -34,6 +36,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             fileStore: NoteFileStore(directory: Self.notesDirectory()),
             tombstoneStore: BlinkTombstoneStore(fileURL: BlinkPaths.tombstones())
         )
+        startPeerServer()
         panelManager = PanelManager(store: store)
         model = AppModel(store: store, panelManager: panelManager)
         panelManager.onWorkspaceScopeRequested = { [weak self] scope in
@@ -265,6 +268,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        peerServer?.stop()
         HotkeyManager.shared.unregisterAll()
         if let commandRequestObserver {
             NotificationCenter.default.removeObserver(commandRequestObserver)
@@ -503,7 +507,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 },
                 beginDictation: { [weak self] in
                     self?.beginPopoverDictation()
-                }
+                },
+                trustedPeerCount: peerServer?.trustedPeers.count ?? 0
             )
         )
         host.sizingOptions = .preferredContentSize
@@ -568,6 +573,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         menu.addItem(.separator())
 
+        let accessItem = NSMenuItem(title: "Mobile Access", action: nil, keyEquivalent: "")
+        let accessMenu = NSMenu()
+        let trustedPeers = peerServer?.trustedPeers ?? []
+        if trustedPeers.isEmpty {
+            let emptyItem = NSMenuItem(title: "No approved devices", action: nil, keyEquivalent: "")
+            emptyItem.isEnabled = false
+            accessMenu.addItem(emptyItem)
+        } else {
+            for peer in trustedPeers {
+                let item = NSMenuItem(
+                    title: "Revoke “\(peer.name)”…",
+                    action: #selector(menuRevokePeer(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.representedObject = peer.id
+                accessMenu.addItem(item)
+            }
+        }
+        accessMenu.addItem(.separator())
+        let accessHelp = NSMenuItem(
+            title: "New devices ask for approval on this Mac",
+            action: nil,
+            keyEquivalent: ""
+        )
+        accessHelp.isEnabled = false
+        accessMenu.addItem(accessHelp)
+        accessItem.submenu = accessMenu
+        menu.addItem(accessItem)
+        menu.addItem(.separator())
+
         let settingsItem = NSMenuItem(title: "Settings…", action: #selector(menuSettings), keyEquivalent: ",")
         settingsItem.target = self
         menu.addItem(settingsItem)
@@ -626,8 +662,67 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         openGuide()
     }
 
+    @objc private func menuRevokePeer(_ sender: NSMenuItem) {
+        guard let id = sender.representedObject as? String,
+              let peer = peerServer?.trustedPeers.first(where: { $0.id == id })
+        else { return }
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Revoke access for \(peer.name)?"
+        alert.informativeText = "This device will stop syncing immediately. It must be approved again before it can read notes from this Mac."
+        alert.addButton(withTitle: "Revoke Access")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        if peerServer?.revokeTrustedPeer(id: id) == true {
+            log.info("[BLINK] revoked LAN device access", metadata: ["device": peer.name])
+        }
+    }
+
     @objc private func menuQuit() {
         NSApp.terminate(nil)
+    }
+
+    private func startPeerServer() {
+        let defaults = UserDefaults.standard
+        let hostIDKey = "blink.peer.host-id"
+        let hostID: String
+        if let saved = defaults.string(forKey: hostIDKey) {
+            hostID = saved
+        } else {
+            hostID = UUID().uuidString.lowercased()
+            defaults.set(hostID, forKey: hostIDKey)
+        }
+
+        let machineName = Host.current().localizedName ?? "Mac"
+        var displayName = "Blink · \(machineName)"
+        while displayName.utf8.count > 60 { displayName.removeLast() }
+        let server = BlinkLANPeerServer(
+            hostID: hostID,
+            displayName: displayName,
+            snapshotService: BlinkSnapshotService(
+                builder: BlinkSnapshotBuilder(notesDirectory: Self.notesDirectory()),
+                tombstoneStore: BlinkTombstoneStore(fileURL: BlinkPaths.tombstones())
+            ),
+            approvalHandler: { identity in
+                await Self.requestPeerApproval(for: identity)
+            }
+        )
+        server.start()
+        peerServer = server
+        log.info("[BLINK] encrypted LAN sync available", metadata: ["hostID": hostID])
+    }
+
+    @MainActor
+    private static func requestPeerApproval(for identity: BlinkPeerClientIdentity) -> Bool {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = "Allow \(identity.name) to read your Blink notes?"
+        alert.informativeText = "This request came from a nearby device on your local network. Allowing it creates an encrypted, read-only offline copy. You can revoke access from Blink’s menu."
+        alert.addButton(withTitle: "Allow")
+        alert.addButton(withTitle: "Not Now")
+        return alert.runModal() == .alertFirstButtonReturn
     }
 
     private func configureDiscovery() {

--- a/Sources/BlinkApp/CapturePopoverView.swift
+++ b/Sources/BlinkApp/CapturePopoverView.swift
@@ -24,6 +24,7 @@ struct CapturePopoverView: View {
     var toggleBlink: () -> Void
     var showGrid: () -> Void
     var beginDictation: () -> Void
+    var trustedPeerCount: Int
 
     @ObservedObject private var appearance = AppearanceManager.shared
     @ObservedObject private var configStore = BlinkConfigStore.shared
@@ -427,10 +428,21 @@ struct CapturePopoverView: View {
 
             Spacer()
 
-            Text("READY")
-                .font(mono(9.5, .medium))
-                .tracking(1.2)
-                .foregroundStyle(pal.inkMuted)
+            Label(
+                trustedPeerCount == 0
+                    ? "MOBILE READY"
+                    : "MOBILE · \(trustedPeerCount) APPROVED",
+                systemImage: trustedPeerCount == 0 ? "iphone.badge.plus" : "lock.shield"
+            )
+            .font(mono(9.5, .medium))
+            .tracking(1.2)
+            .foregroundStyle(pal.inkMuted)
+            .help("Nearby iPhones and iPads ask for approval on this Mac")
+            .accessibilityLabel(
+                trustedPeerCount == 0
+                    ? "Mobile access ready"
+                    : "\(trustedPeerCount) approved mobile \(trustedPeerCount == 1 ? "device" : "devices")"
+            )
 
             footerSeparator
 

--- a/Sources/BlinkPeer/BlinkLANPeerClient.swift
+++ b/Sources/BlinkPeer/BlinkLANPeerClient.swift
@@ -46,7 +46,7 @@ public final class BlinkLANPeerClient: NSObject, BlinkPeerTransport, @unchecked 
     public init(identity: BlinkPeerClientIdentity) {
         self.identity = identity
         var displayName = identity.name.trimmingCharacters(in: .whitespacesAndNewlines)
-        if displayName.isEmpty { displayName = "iPhone" }
+        if displayName.isEmpty { displayName = "Mobile device" }
         while displayName.utf8.count > 60 { displayName.removeLast() }
         let peerID = MCPeerID(displayName: displayName)
         self.peerID = peerID

--- a/Sources/BlinkPeer/BlinkLANPeerServer.swift
+++ b/Sources/BlinkPeer/BlinkLANPeerServer.swift
@@ -117,7 +117,7 @@ public final class BlinkLANPeerServer: NSObject, @unchecked Sendable {
                   requestedIdentity.credential.allSatisfy(\.isHexDigit)
             else {
                 send(
-                    .failure(BlinkPeerFailure(code: "invalid-identity", message: "Blink on this iPhone needs to be reinstalled.")),
+                    .failure(BlinkPeerFailure(code: "invalid-identity", message: "Blink on this device needs to be reinstalled.")),
                     id: envelope.id,
                     to: peer,
                     using: responseKey

--- a/Sources/BlinkPeer/BlinkPeerProtocol.swift
+++ b/Sources/BlinkPeer/BlinkPeerProtocol.swift
@@ -61,7 +61,7 @@ public enum BlinkPeerError: Error, LocalizedError, Equatable, Sendable {
         case .accessDenied:
             return "Access wasn’t allowed on your Mac. You can try again."
         case .unauthorized:
-            return "This iPhone no longer has access to the Mac. Request access again."
+            return "This device no longer has access to the Mac. Request access again."
         case .invalidResponse:
             return "The Mac returned an invalid Blink response."
         case .requestTimedOut:

--- a/Sources/BlinkPeer/BlinkPeerTrustStore.swift
+++ b/Sources/BlinkPeer/BlinkPeerTrustStore.swift
@@ -1,7 +1,7 @@
 import CryptoKit
 import Foundation
 
-/// The private, app-scoped credential an iPhone presents inside an encrypted
+/// The private, app-scoped credential a mobile device presents inside an encrypted
 /// peer session. The value is random and never shown as part of the pairing UI.
 public struct BlinkPeerClientIdentity: Codable, Equatable, Sendable {
     public var credential: String

--- a/apps/ios/BlinkMobile/BlinkMobileApp.swift
+++ b/apps/ios/BlinkMobile/BlinkMobileApp.swift
@@ -1,0 +1,41 @@
+import HudsonUI
+import SwiftUI
+
+@main
+struct BlinkMobileApp: App {
+    @StateObject private var model = BlinkMobileModel()
+    @Environment(\.scenePhase) private var scenePhase
+    @AppStorage(BlinkThemeChoice.storageKey) private var themeRaw = BlinkThemeChoice.default.rawValue
+    @AppStorage(BlinkAppearance.storageKey) private var appearanceRaw = BlinkAppearance.default.rawValue
+
+    private var appearance: BlinkAppearance {
+        BlinkAppearance(rawValue: appearanceRaw) ?? .default
+    }
+
+    private var currentHudTheme: HudTheme {
+        _ = themeRaw
+        return BlinkMobileTheme.hudTheme
+    }
+
+    private var currentTint: Color {
+        _ = themeRaw
+        return BlinkMobileTheme.signal
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(model: model)
+                .tint(currentTint)
+                .hudTheme(currentHudTheme)
+                .preferredColorScheme(appearance.colorScheme)
+        }
+        .onChange(of: scenePhase) { _, phase in
+            switch phase {
+            case .active: model.activate()
+            case .background: model.deactivate()
+            case .inactive: break
+            @unknown default: break
+            }
+        }
+    }
+}

--- a/apps/ios/BlinkMobile/BlinkMobileModel.swift
+++ b/apps/ios/BlinkMobile/BlinkMobileModel.swift
@@ -1,0 +1,219 @@
+import BlinkCore
+import BlinkPeer
+import Foundation
+import UIKit
+
+@MainActor
+final class BlinkMobileModel: ObservableObject {
+    private static let cacheHostIDKey = "blink.peer.cache-host-id"
+
+    enum CacheState: Equatable {
+        case loading
+        case ready
+        case failed(String)
+    }
+
+    enum DiscoveryState: Equatable {
+        case searching
+        case found
+        case noPeers
+        case failed(String)
+    }
+
+    enum ConnectionState: Equatable {
+        case disconnected
+        case requestingAccess(String)
+        case connected(BlinkPeerHost)
+
+        var host: BlinkPeerHost? {
+            guard case .connected(let host) = self else { return nil }
+            return host
+        }
+    }
+
+    @Published private(set) var snapshot: BlinkSnapshot?
+    @Published private(set) var nearbyPeers: [BlinkLANPeerCandidate] = []
+    @Published private(set) var connectionState: ConnectionState = .disconnected
+    @Published private(set) var isSyncing = false
+    @Published private(set) var cacheState: CacheState = .loading
+    @Published private(set) var discoveryState: DiscoveryState = .searching
+    @Published var presentedError: String?
+
+    private let client: BlinkLANPeerClient
+    private let cache: BlinkSnapshotCache
+    private var discoveryTask: Task<Void, Never>?
+    private var hasLoadedCache = false
+    private var discoveryStartedAt = Date()
+    private var cacheGeneration = 0
+
+    init() {
+        let defaults = UserDefaults.standard
+        let credentialKey = "blink.peer.device-credential"
+        let credential: String
+        if let saved = defaults.string(forKey: credentialKey), UUID(uuidString: saved) != nil {
+            credential = saved
+        } else {
+            credential = UUID().uuidString.lowercased()
+            defaults.set(credential, forKey: credentialKey)
+        }
+        client = BlinkLANPeerClient(
+            identity: BlinkPeerClientIdentity(
+                credential: credential,
+                name: UIDevice.current.name
+            )
+        )
+
+        let support = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!
+        cache = BlinkSnapshotCache(
+            fileURL: support
+                .appendingPathComponent("Blink", isDirectory: true)
+                .appendingPathComponent("snapshot.json", isDirectory: false)
+        )
+        client.observeConnection { [weak self] isConnected in
+            guard !isConnected else { return }
+            Task { @MainActor [weak self] in
+                self?.connectionState = .disconnected
+            }
+        }
+        activate()
+    }
+
+    var notes: [BlinkSnapshotNote] {
+        snapshot?.notes.sorted {
+            if $0.updatedAt != $1.updatedAt { return $0.updatedAt > $1.updatedAt }
+            return $0.id < $1.id
+        } ?? []
+    }
+
+    var lastSyncedAt: Date? { snapshot?.generatedAt }
+
+    func activate() {
+        if !hasLoadedCache {
+            hasLoadedCache = true
+            cacheGeneration += 1
+            let generation = cacheGeneration
+            Task { await loadCache(generation: generation) }
+        }
+        guard discoveryTask == nil else { return }
+        discoveryStartedAt = Date()
+        discoveryState = .searching
+        client.startBrowsing()
+        discoveryTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.nearbyPeers = self.client.availablePeers()
+                if let failure = self.client.browsingFailure {
+                    self.discoveryState = .failed(failure)
+                } else if !self.nearbyPeers.isEmpty {
+                    self.discoveryState = .found
+                } else if Date().timeIntervalSince(self.discoveryStartedAt) >= 5 {
+                    self.discoveryState = .noPeers
+                } else {
+                    self.discoveryState = .searching
+                }
+                try? await Task.sleep(for: .milliseconds(500))
+            }
+        }
+    }
+
+    func deactivate() {
+        client.stopBrowsing()
+        discoveryTask?.cancel()
+        discoveryTask = nil
+    }
+
+    func retryDiscovery() {
+        client.stopBrowsing()
+        discoveryStartedAt = Date()
+        discoveryState = .searching
+        client.startBrowsing()
+    }
+
+    func connect(to candidate: BlinkLANPeerCandidate) async -> Bool {
+        connectionState = .requestingAccess(candidate.name)
+        do {
+            let host = try await client.connect(to: candidate.id)
+            connectionState = .connected(host)
+            return await refresh()
+        } catch {
+            connectionState = .disconnected
+            presentedError = error.localizedDescription
+            return false
+        }
+    }
+
+    func disconnect() {
+        client.disconnect()
+        connectionState = .disconnected
+    }
+
+    @discardableResult
+    func refresh() async -> Bool {
+        guard let host = connectionState.host, !isSyncing else { return false }
+        isSyncing = true
+        defer { isSyncing = false }
+        do {
+            let defaults = UserDefaults.standard
+            let isSameHost = defaults.string(forKey: Self.cacheHostIDKey) == host.id
+            switch try await client.fetchSnapshot(ifNoneMatch: isSameHost ? snapshot?.etag : nil) {
+            case .notModified:
+                guard connectionState.host?.id == host.id else { return false }
+            case .snapshot(let incoming):
+                guard connectionState.host?.id == host.id else { return false }
+                cacheGeneration += 1
+                let generation = cacheGeneration
+                if !isSameHost {
+                    try await cache.removeAll()
+                }
+                let cached = try await cache.apply(incoming)
+                guard generation == cacheGeneration else { return false }
+                snapshot = cached
+                cacheState = .ready
+                defaults.set(host.id, forKey: Self.cacheHostIDKey)
+            }
+            return true
+        } catch {
+            if (error as? BlinkPeerError) == .unauthorized {
+                disconnect()
+            }
+            presentedError = error.localizedDescription
+            return false
+        }
+    }
+
+    func clearOfflineNotes() async {
+        do {
+            cacheGeneration += 1
+            let generation = cacheGeneration
+            try await cache.removeAll()
+            guard generation == cacheGeneration else { return }
+            snapshot = nil
+            cacheState = .ready
+            UserDefaults.standard.removeObject(forKey: Self.cacheHostIDKey)
+        } catch {
+            presentedError = error.localizedDescription
+        }
+    }
+
+    func retryCacheLoad() {
+        cacheState = .loading
+        cacheGeneration += 1
+        let generation = cacheGeneration
+        Task { await loadCache(generation: generation) }
+    }
+
+    private func loadCache(generation: Int) async {
+        do {
+            let cached = try await cache.load()
+            guard generation == cacheGeneration else { return }
+            snapshot = cached
+            cacheState = .ready
+        } catch {
+            guard generation == cacheGeneration else { return }
+            cacheState = .failed(error.localizedDescription)
+        }
+    }
+}

--- a/apps/ios/BlinkMobile/BlinkMobileSettingsView.swift
+++ b/apps/ios/BlinkMobile/BlinkMobileSettingsView.swift
@@ -1,0 +1,362 @@
+import BlinkPeer
+import HudsonUI
+import SwiftUI
+
+private enum BlinkSettingsRoute: Hashable {
+    case connection
+    case appearance
+    case storage
+}
+
+struct BlinkMobileSettingsView: View {
+    @ObservedObject var model: BlinkMobileModel
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage(BlinkThemeChoice.storageKey) private var themeRaw = BlinkThemeChoice.default.rawValue
+    @AppStorage(BlinkAppearance.storageKey) private var appearanceRaw = BlinkAppearance.default.rawValue
+    @State private var path: [BlinkSettingsRoute] = []
+
+    private var theme: BlinkThemeChoice {
+        BlinkThemeChoice(rawValue: themeRaw) ?? .default
+    }
+
+    private var appearance: BlinkAppearance {
+        BlinkAppearance(rawValue: appearanceRaw) ?? .default
+    }
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            ScrollView {
+                VStack(spacing: 22) {
+                    connectionSection
+                    appearanceSection
+                    storageSection
+                    aboutSection
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 18)
+                .padding(.bottom, 36)
+            }
+            .background(BlinkBackdrop())
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(BlinkMobileTheme.canvas, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .navigationDestination(for: BlinkSettingsRoute.self) { route in
+                switch route {
+                case .connection:
+                    ConnectionView(model: model)
+                case .appearance:
+                    BlinkAppearanceSettingsView()
+                case .storage:
+                    BlinkStorageSettingsView(model: model)
+                }
+            }
+        }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+    }
+
+    private var connectionSection: some View {
+        HudSettingsSection("Connection", labelTint: BlinkMobileTheme.faintInk) {
+            HudSettingsRow(
+                icon: connectionIcon,
+                iconColor: connectionColor,
+                title: "Mac",
+                subtitle: connectionSubtitle,
+                onTap: { path.append(.connection) }
+            ) {
+                BlinkSettingsBadge(connectionValue, color: connectionColor)
+            }
+        }
+    }
+
+    private var appearanceSection: some View {
+        HudSettingsSection("Appearance", labelTint: BlinkMobileTheme.faintInk) {
+            HudSettingsRow(
+                icon: "paintpalette",
+                iconColor: BlinkMobileTheme.signal,
+                title: "Theme",
+                subtitle: "\(theme.title) · \(appearance.title)",
+                onTap: { path.append(.appearance) }
+            )
+        }
+    }
+
+    private var storageSection: some View {
+        HudSettingsSection("On This Device", labelTint: BlinkMobileTheme.faintInk) {
+            HudSettingsRow(
+                icon: "iphone",
+                iconColor: BlinkMobileTheme.secondaryInk,
+                title: "Notes",
+                subtitle: storageSubtitle,
+                onTap: { path.append(.storage) }
+            ) {
+                BlinkSettingsBadge("\(model.notes.count)", color: BlinkMobileTheme.secondaryInk)
+            }
+        }
+    }
+
+    private var aboutSection: some View {
+        HudSettingsSection("About", labelTint: BlinkMobileTheme.faintInk) {
+            HudSettingsRow(
+                icon: "info.circle",
+                iconColor: BlinkMobileTheme.secondaryInk,
+                title: "Blink",
+                subtitle: "Read-only companion"
+            ) {
+                Text(version)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(BlinkMobileTheme.faintInk)
+            }
+        }
+    }
+
+    private var connectionIcon: String {
+        switch model.connectionState {
+        case .disconnected: "desktopcomputer"
+        case .requestingAccess: "ellipsis.circle"
+        case .connected: "lock.fill"
+        }
+    }
+
+    private var connectionColor: Color {
+        switch model.connectionState {
+        case .disconnected: BlinkMobileTheme.faintInk
+        case .requestingAccess: BlinkMobileTheme.amber
+        case .connected: BlinkMobileTheme.signal
+        }
+    }
+
+    private var connectionValue: String {
+        switch model.connectionState {
+        case .disconnected: "OFF"
+        case .requestingAccess: "WAITING"
+        case .connected: "LIVE"
+        }
+    }
+
+    private var connectionSubtitle: String {
+        switch model.connectionState {
+        case .disconnected: "Not connected"
+        case .requestingAccess(let name): name
+        case .connected(let host): host.name
+        }
+    }
+
+    private var storageSubtitle: String {
+        guard let lastSyncedAt = model.lastSyncedAt else { return "No notes saved" }
+        return "Updated \(blinkSettingsAge(since: lastSyncedAt).lowercased())"
+    }
+
+    private var version: String {
+        let short = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "1"
+        return "v\(short) (\(build))"
+    }
+}
+
+private struct BlinkAppearanceSettingsView: View {
+    @AppStorage(BlinkThemeChoice.storageKey) private var themeRaw = BlinkThemeChoice.default.rawValue
+    @AppStorage(BlinkAppearance.storageKey) private var appearanceRaw = BlinkAppearance.default.rawValue
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 22) {
+                HudSettingsSection("Display", labelTint: BlinkMobileTheme.faintInk) {
+                    HudSettingsControlRow(
+                        title: "Mode",
+                        subtitle: "System, light, or dark",
+                        icon: "circle.lefthalf.filled",
+                        iconColor: BlinkMobileTheme.signal
+                    ) {
+                        Picker("Mode", selection: $appearanceRaw) {
+                            ForEach(BlinkAppearance.allCases) { appearance in
+                                Text(appearance.title).tag(appearance.rawValue)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                    }
+                }
+
+                HudSettingsSection("Theme", labelTint: BlinkMobileTheme.faintInk) {
+                    ForEach(Array(BlinkThemeChoice.allCases.enumerated()), id: \.element.id) { index, theme in
+                        BlinkThemeRow(
+                            theme: theme,
+                            isSelected: theme.rawValue == themeRaw,
+                            action: { themeRaw = theme.rawValue }
+                        )
+                        if index < BlinkThemeChoice.allCases.count - 1 {
+                            Rectangle()
+                                .fill(BlinkMobileTheme.hairline)
+                                .frame(height: 1)
+                                .padding(.leading, 52)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 18)
+            .padding(.bottom, 36)
+        }
+        .background(BlinkBackdrop())
+        .navigationTitle("Appearance")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(BlinkMobileTheme.canvas, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+    }
+}
+
+private struct BlinkThemeRow: View {
+    let theme: BlinkThemeChoice
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                HStack(spacing: 2) {
+                    ForEach(Array(theme.previewColors.enumerated()), id: \.offset) { _, color in
+                        Rectangle()
+                            .fill(color)
+                            .frame(width: 10, height: 28)
+                    }
+                }
+                .overlay {
+                    Rectangle()
+                        .stroke(BlinkMobileTheme.hairline, lineWidth: 1)
+                }
+                .frame(width: 34)
+                .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(theme.title)
+                        .font(.body)
+                        .foregroundStyle(BlinkMobileTheme.ink)
+                    Text(theme.detail)
+                        .font(.caption)
+                        .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? BlinkMobileTheme.signal : BlinkMobileTheme.faintInk)
+            }
+            .padding(.horizontal, 14)
+            .frame(minHeight: 58)
+            .contentShape(Rectangle())
+            .background(isSelected ? BlinkMobileTheme.signal.opacity(0.08) : Color.clear)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(theme.title), \(theme.detail)")
+        .accessibilityValue(isSelected ? "Selected" : "")
+    }
+}
+
+private struct BlinkStorageSettingsView: View {
+    @ObservedObject var model: BlinkMobileModel
+    @State private var confirmingRemoval = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 22) {
+                HudSettingsSection("Local Notes", labelTint: BlinkMobileTheme.faintInk) {
+                    HudSettingsRow(
+                        icon: "doc.on.doc",
+                        iconColor: BlinkMobileTheme.signal,
+                        title: "Saved",
+                        subtitle: updatedValue
+                    ) {
+                        BlinkSettingsBadge("\(model.notes.count)", color: BlinkMobileTheme.signal)
+                    }
+                    Rectangle()
+                        .fill(BlinkMobileTheme.hairline)
+                        .frame(height: 1)
+                        .padding(.leading, 52)
+                    HudSettingsRow(
+                        icon: "wifi.slash",
+                        iconColor: BlinkMobileTheme.secondaryInk,
+                        title: "Without your Mac",
+                        subtitle: model.snapshot == nil ? "Unavailable" : "Available"
+                    )
+                }
+
+                if model.snapshot != nil {
+                    HudSettingsSection("Data", labelTint: BlinkMobileTheme.faintInk) {
+                        HudSettingsRow(
+                            icon: "trash",
+                            iconColor: .red,
+                            title: "Remove Notes",
+                            subtitle: "Mac notes are not changed",
+                            onTap: { confirmingRemoval = true }
+                        )
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 18)
+            .padding(.bottom, 36)
+        }
+        .background(BlinkBackdrop())
+        .navigationTitle("On This Device")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(BlinkMobileTheme.canvas, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .confirmationDialog(
+            "Remove notes from this device?",
+            isPresented: $confirmingRemoval,
+            titleVisibility: .visible
+        ) {
+            Button("Remove Notes", role: .destructive) {
+                Task { await model.clearOfflineNotes() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Notes on your Mac are unchanged. Reconnect to make them available here again.")
+        }
+    }
+
+    private var updatedValue: String {
+        guard let lastSyncedAt = model.lastSyncedAt else { return "Not updated" }
+        return "Updated \(blinkSettingsAge(since: lastSyncedAt).lowercased())"
+    }
+}
+
+private struct BlinkSettingsBadge: View {
+    let text: String
+    let color: Color
+
+    init(_ text: String, color: Color) {
+        self.text = text
+        self.color = color
+    }
+
+    var body: some View {
+        Text(text)
+            .font(.caption2.monospaced().weight(.semibold))
+            .tracking(0.7)
+            .foregroundStyle(color)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 4)
+            .background(color.opacity(0.10))
+            .overlay {
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(color.opacity(0.28), lineWidth: 1)
+            }
+    }
+}
+
+private func blinkSettingsAge(since date: Date, now: Date = Date()) -> String {
+    let interval = max(0, now.timeIntervalSince(date))
+    if interval < 60 { return "JUST NOW" }
+    if interval < 3_600 { return "\(Int(interval / 60))M AGO" }
+    if interval < 86_400 { return "\(Int(interval / 3_600))H AGO" }
+    if interval < 30 * 86_400 { return "\(Int(interval / 86_400))D AGO" }
+    return date.formatted(date: .abbreviated, time: .omitted).uppercased()
+}

--- a/apps/ios/BlinkMobile/BlinkMobileTheme.swift
+++ b/apps/ios/BlinkMobile/BlinkMobileTheme.swift
@@ -1,0 +1,240 @@
+import HudsonUI
+import SwiftUI
+import UIKit
+
+enum BlinkAppearance: String, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    static let storageKey = "blink.mobile.appearance"
+    static let `default`: BlinkAppearance = .system
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .system: "System"
+        case .light: "Light"
+        case .dark: "Dark"
+        }
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: nil
+        case .light: .light
+        case .dark: .dark
+        }
+    }
+
+    static var stored: BlinkAppearance {
+        BlinkAppearance(
+            rawValue: UserDefaults.standard.string(forKey: storageKey) ?? ""
+        ) ?? .default
+    }
+}
+
+enum BlinkThemeChoice: String, CaseIterable, Identifiable {
+    case indexTape
+    case field
+    case deck
+    case scope
+    case focus
+    case console
+
+    static let storageKey = "blink.mobile.theme"
+    static let `default`: BlinkThemeChoice = .indexTape
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .indexTape: "Index Tape"
+        case .field: "Field"
+        case .deck: "Deck"
+        case .scope: "Scope"
+        case .focus: "Focus"
+        case .console: "Console"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .indexTape: "Paper · cobalt"
+        case .field: "Warm paper · emerald"
+        case .deck: "Graphite · amber"
+        case .scope: "Cream · brass"
+        case .focus: "Umber · signal yellow"
+        case .console: "Neutral · blue"
+        }
+    }
+
+    static var stored: BlinkThemeChoice {
+        BlinkThemeChoice(
+            rawValue: UserDefaults.standard.string(forKey: storageKey) ?? ""
+        ) ?? .default
+    }
+
+    fileprivate var palette: BlinkThemePalette {
+        switch self {
+        case .indexTape:
+            BlinkThemePalette(
+                signal: .init(light: 0x2D5DAF, dark: 0x83B4FF),
+                canvas: .init(light: 0xF2F0EC, dark: 0x0A0B0C),
+                surface: .init(light: 0xFCFAF6, dark: 0x121416),
+                raisedSurface: .init(light: 0xFFFFFF, dark: 0x17191C),
+                rail: .init(light: 0xEBE7DF, dark: 0x0E1012),
+                hairline: .init(light: 0xDAD5CB, dark: 0x2A2E31),
+                ink: .init(light: 0x17130F, dark: 0xFBEEE8),
+                secondaryInk: .init(light: 0x5C554F, dark: 0xB8BEC0),
+                faintInk: .init(light: 0x6F695F, dark: 0x9AA0A2),
+                amber: .init(light: 0x7E6029, dark: 0xD6B96C)
+            )
+        case .field:
+            BlinkThemePalette(
+                signal: .init(light: 0x07785B, dark: 0x10B981),
+                canvas: .init(light: 0xF6F3ED, dark: 0x0A0A0A),
+                surface: .init(light: 0xFFFDF9, dark: 0x171717),
+                raisedSurface: .init(light: 0xFFFFFC, dark: 0x211C18),
+                rail: .init(light: 0xF2EEE6, dark: 0x111113),
+                hairline: .init(light: 0xCDC5B8, dark: 0x262626),
+                ink: .init(light: 0x23211D, dark: 0xE5E5E5),
+                secondaryInk: .init(light: 0x58534B, dark: 0xB8B8B8),
+                faintInk: .init(light: 0x69635A, dark: 0x969696),
+                amber: .init(light: 0xA15B00, dark: 0xF59E0B)
+            )
+        case .deck:
+            BlinkThemePalette(
+                signal: .init(light: 0x9A690E, dark: 0xE4B65C),
+                canvas: .init(light: 0xF4F1E8, dark: 0x0D0F12),
+                surface: .init(light: 0xFFFCF5, dark: 0x131518),
+                raisedSurface: .init(light: 0xFFFFFF, dark: 0x181B1F),
+                rail: .init(light: 0xEAE4D6, dark: 0x0A0B0D),
+                hairline: .init(light: 0xD8CFBD, dark: 0x303237),
+                ink: .init(light: 0x211F1A, dark: 0xE2E2DF),
+                secondaryInk: .init(light: 0x605B50, dark: 0xA0A09B),
+                faintInk: .init(light: 0x756E61, dark: 0x85857F),
+                amber: .init(light: 0x9A690E, dark: 0xE4B65C)
+            )
+        case .scope:
+            BlinkThemePalette(
+                signal: .init(light: 0x9A6828, dark: 0xE89A3C),
+                canvas: .init(light: 0xFBFAF7, dark: 0x0A0907),
+                surface: .init(light: 0xF8F6F1, dark: 0x13110E),
+                raisedSurface: .init(light: 0xFFFFFD, dark: 0x1A1714),
+                rail: .init(light: 0xF2F0EA, dark: 0x151310),
+                hairline: .init(light: 0xE4DFD6, dark: 0x322D27),
+                ink: .init(light: 0x1A1612, dark: 0xF5F3EE),
+                secondaryInk: .init(light: 0x5A5045, dark: 0xA8A096),
+                faintInk: .init(light: 0x766A5A, dark: 0x968876),
+                amber: .init(light: 0x7E6029, dark: 0xD6B96C)
+            )
+        case .focus:
+            BlinkThemePalette(
+                signal: .init(light: 0x706B00, dark: 0xEAE434),
+                canvas: .init(light: 0xFAF7F1, dark: 0x17120F),
+                surface: .init(light: 0xFFFCF7, dark: 0x251D17),
+                raisedSurface: .init(light: 0xFFFFFF, dark: 0x30261E),
+                rail: .init(light: 0xF0E8DD, dark: 0x201913),
+                hairline: .init(light: 0xD9CCBD, dark: 0x42382F),
+                ink: .init(light: 0x2A2019, dark: 0xF4EEE6),
+                secondaryInk: .init(light: 0x6B5C4E, dark: 0xBCAE9E),
+                faintInk: .init(light: 0x766A5E, dark: 0x96897D),
+                amber: .init(light: 0xA65513, dark: 0xF2A65A)
+            )
+        case .console:
+            BlinkThemePalette(
+                signal: .init(light: 0x235DAD, dark: 0x3B82F6),
+                canvas: .init(light: 0xFAFAFA, dark: 0x0A0A0A),
+                surface: .init(light: 0xF5F5F5, dark: 0x171717),
+                raisedSurface: .init(light: 0xFFFFFF, dark: 0x1D1D1D),
+                rail: .init(light: 0xEFEFEF, dark: 0x060606),
+                hairline: .init(light: 0xDBDBDB, dark: 0x272727),
+                ink: .init(light: 0x171717, dark: 0xE5E5E5),
+                secondaryInk: .init(light: 0x525252, dark: 0xA3A3A3),
+                faintInk: .init(light: 0x737373, dark: 0x8F8F8F),
+                amber: .init(light: 0xA15B00, dark: 0xF59E0B)
+            )
+        }
+    }
+}
+
+private struct AdaptiveHex {
+    let light: UInt32
+    let dark: UInt32
+
+    var color: Color {
+        Color(uiColor: UIColor { traits in
+            UIColor(blinkRGB: traits.userInterfaceStyle == .dark ? dark : light)
+        })
+    }
+}
+
+private struct BlinkThemePalette {
+    let signal: AdaptiveHex
+    let canvas: AdaptiveHex
+    let surface: AdaptiveHex
+    let raisedSurface: AdaptiveHex
+    let rail: AdaptiveHex
+    let hairline: AdaptiveHex
+    let ink: AdaptiveHex
+    let secondaryInk: AdaptiveHex
+    let faintInk: AdaptiveHex
+    let amber: AdaptiveHex
+}
+
+enum BlinkMobileTheme {
+    private static var palette: BlinkThemePalette { BlinkThemeChoice.stored.palette }
+
+    static var signal: Color { palette.signal.color }
+    static var canvas: Color { palette.canvas.color }
+    static var surface: Color { palette.surface.color }
+    static var raisedSurface: Color { palette.raisedSurface.color }
+    static var rail: Color { palette.rail.color }
+    static var hairline: Color { palette.hairline.color }
+    static var ink: Color { palette.ink.color }
+    static var secondaryInk: Color { palette.secondaryInk.color }
+    static var faintInk: Color { palette.faintInk.color }
+    static var amber: Color { palette.amber.color }
+
+    static var hudTheme: HudTheme {
+        HudTheme(
+            palette: HudThemePalette(
+                bg: canvas,
+                surface: surface,
+                chrome: rail,
+                ink: ink,
+                muted: secondaryInk,
+                dim: faintInk,
+                border: hairline,
+                accent: signal,
+                accentSoft: signal.opacity(0.10),
+                statusOk: signal,
+                statusWarn: amber,
+                statusError: Color(red: 0.78, green: 0.20, blue: 0.18),
+                statusInfo: signal
+            ),
+            hairline: HudThemeHairline(subtle: hairline, standard: hairline),
+            radius: .default,
+            focus: HudThemeFocus(ring: signal.opacity(0.85), ringWidth: 1.5)
+        )
+    }
+}
+
+extension BlinkThemeChoice {
+    var previewColors: [Color] {
+        [palette.canvas.color, palette.surface.color, palette.signal.color]
+    }
+}
+
+private extension UIColor {
+    convenience init(blinkRGB: UInt32) {
+        self.init(
+            red: CGFloat((blinkRGB >> 16) & 0xFF) / 255,
+            green: CGFloat((blinkRGB >> 8) & 0xFF) / 255,
+            blue: CGFloat(blinkRGB & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+}

--- a/apps/ios/BlinkMobile/BlinkPadWorkspaceView.swift
+++ b/apps/ios/BlinkMobile/BlinkPadWorkspaceView.swift
@@ -1,0 +1,617 @@
+import BlinkCore
+import HudsonUI
+import SwiftUI
+
+/// Regular-width iPad surface. The portable `blink.slot` value supplies spatial
+/// intent; exact Mac panel frames remain correctly local to the Mac.
+struct BlinkPadWorkspaceView: View {
+    @ObservedObject var model: BlinkMobileModel
+    let notes: [BlinkSnapshotNote]
+    let scopedNoteCount: Int
+    @Binding var workspace: WorkspaceScope
+    let workspaceIDs: [String]
+    @Binding var query: String
+    @Binding var selection: String?
+    let onOpenSettings: () -> Void
+
+    @State private var deskIndex = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var desks: [[BlinkPadSlot]] {
+        BlinkPadSlot.makeDesks(notes: notes)
+    }
+
+    private var selectedNote: BlinkSnapshotNote? {
+        guard let selection else { return nil }
+        return model.notes.first { $0.id == selection }
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                topBar
+
+                if let lastSyncedAt = model.lastSyncedAt {
+                    BlinkPadStatusStrip(
+                        state: model.connectionState,
+                        lastSyncedAt: lastSyncedAt,
+                        isSyncing: model.isSyncing,
+                        issueCount: model.snapshot?.issues.count ?? 0,
+                        noteCount: scopedNoteCount
+                    )
+                }
+
+                board
+            }
+            .background(BlinkBackdrop())
+            .overlay(alignment: .trailing) {
+                if let selectedNote {
+                    BlinkPadReader(
+                        note: selectedNote,
+                        index: model.notes.firstIndex(where: { $0.id == selectedNote.id }).map { $0 + 1 } ?? 1,
+                        onClose: { selection = nil }
+                    )
+                    .frame(
+                        width: min(540, max(430, geometry.size.width * 0.48)),
+                        height: min(720, geometry.size.height - 48)
+                    )
+                    .padding(24)
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                }
+            }
+        }
+        .tint(BlinkMobileTheme.signal)
+        .animation(
+            reduceMotion ? nil : .snappy(duration: 0.28, extraBounce: 0),
+            value: selection
+        )
+        .onChange(of: desks.count) { _, count in
+            deskIndex = min(deskIndex, max(0, count - 1))
+        }
+    }
+
+    private var topBar: some View {
+        HStack(spacing: 18) {
+            Menu {
+                Button("All Notes") { workspace = .all }
+                Button("Unfiled") { workspace = .unfiled }
+                if !workspaceIDs.isEmpty { Divider() }
+                ForEach(workspaceIDs, id: \.self) { id in
+                    Button(id) { workspace = .workspace(id) }
+                }
+            } label: {
+                HStack(spacing: 12) {
+                    BlinkMark(size: 30)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("WORKSPACE")
+                            .font(.caption2.monospaced().weight(.semibold))
+                            .tracking(1.2)
+                            .foregroundStyle(BlinkMobileTheme.faintInk)
+                        HStack(spacing: 7) {
+                            Text(workspace.title)
+                                .font(.title2.weight(.semibold))
+                                .foregroundStyle(BlinkMobileTheme.ink)
+                                .lineLimit(1)
+                            Image(systemName: "chevron.down")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(BlinkMobileTheme.faintInk)
+                        }
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Workspace: \(workspace.title)")
+
+            Spacer(minLength: 12)
+
+            BlinkPadSearchField(
+                query: $query,
+                prompt: "Search \(workspace.title)"
+            )
+            .frame(minWidth: 220, idealWidth: 280, maxWidth: 340)
+
+            if model.connectionState.host != nil {
+                Button {
+                    Task { await model.refresh() }
+                } label: {
+                    if model.isSyncing {
+                        ProgressView()
+                            .frame(width: 20, height: 20)
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .buttonBorderShape(.circle)
+                .disabled(model.isSyncing)
+                .accessibilityLabel("Sync now")
+            }
+
+            Button(action: onOpenSettings) {
+                Image(systemName: "gearshape")
+            }
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.circle)
+            .accessibilityLabel("Settings")
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 14)
+        .background(BlinkMobileTheme.canvas)
+    }
+
+    @ViewBuilder
+    private var board: some View {
+        switch model.cacheState {
+        case .loading:
+            ContentUnavailableView {
+                ProgressView()
+            } description: {
+                Text("Loading notes…")
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .failed(let message):
+            ContentUnavailableView {
+                Label("Notes unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(message)
+            } actions: {
+                Button("Try Again") { model.retryCacheLoad() }
+                    .buttonStyle(.borderedProminent)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .ready:
+            if notes.isEmpty {
+                emptyBoard
+            } else {
+                deskBoard
+            }
+        }
+    }
+
+    private var deskBoard: some View {
+        VStack(spacing: 0) {
+            TabView(selection: $deskIndex) {
+                ForEach(desks.indices, id: \.self) { index in
+                    BlinkPadDesk(
+                        slots: desks[index],
+                        selectedID: selection,
+                        onSelect: { note in selection = note.id }
+                    )
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 18)
+                    .tag(index)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+
+            deskFooter
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var deskFooter: some View {
+        HStack(spacing: 12) {
+            Text("DESK \(deskIndex + 1) / \(desks.count)")
+                .font(.caption.monospaced().weight(.semibold))
+                .tracking(0.8)
+
+            Text("·")
+                .foregroundStyle(BlinkMobileTheme.hairline)
+
+            Text("9 SLOTS")
+                .font(.caption.monospaced())
+
+            Spacer()
+
+            if desks.count > 1 {
+                Button {
+                    deskIndex = max(0, deskIndex - 1)
+                } label: {
+                    Image(systemName: "chevron.left")
+                }
+                .disabled(deskIndex == 0)
+                .accessibilityLabel("Previous desk")
+
+                Button {
+                    deskIndex = min(desks.count - 1, deskIndex + 1)
+                } label: {
+                    Image(systemName: "chevron.right")
+                }
+                .disabled(deskIndex == desks.count - 1)
+                .accessibilityLabel("Next desk")
+            }
+        }
+        .foregroundStyle(BlinkMobileTheme.faintInk)
+        .padding(.horizontal, 28)
+        .frame(height: 44)
+        .background(BlinkMobileTheme.rail)
+        .overlay(alignment: .top) {
+            BlinkMobileTheme.hairline.frame(height: 1)
+        }
+    }
+
+    private var emptyBoard: some View {
+        ContentUnavailableView {
+            Label(emptyTitle, systemImage: emptySymbol)
+        } description: {
+            Text(emptyDescription)
+        } actions: {
+            if model.notes.isEmpty {
+                Button(model.connectionState.host == nil ? "Open Settings" : "Sync Now") {
+                    if model.connectionState.host == nil {
+                        onOpenSettings()
+                    } else {
+                        Task { await model.refresh() }
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyTitle: String {
+        if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return "No matches" }
+        if model.notes.isEmpty { return "Connect to your Mac" }
+        return "No notes here"
+    }
+
+    private var emptySymbol: String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "square.grid.3x3" : "magnifyingglass"
+    }
+
+    private var emptyDescription: String {
+        if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Try another search."
+        }
+        if model.notes.isEmpty { return "Open Settings to choose a nearby Mac." }
+        return "Choose another workspace."
+    }
+}
+
+private struct BlinkPadSearchField: View {
+    @Binding var query: String
+    let prompt: String
+
+    var body: some View {
+        HStack(spacing: 9) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(BlinkMobileTheme.faintInk)
+
+            TextField(prompt, text: $query)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.search)
+
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .symbolRenderingMode(.hierarchical)
+                }
+                .foregroundStyle(BlinkMobileTheme.faintInk)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 13)
+        .frame(height: 42)
+        .background(BlinkMobileTheme.surface)
+        .overlay {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(BlinkMobileTheme.hairline, lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+}
+
+private struct BlinkPadStatusStrip: View {
+    let state: BlinkMobileModel.ConnectionState
+    let lastSyncedAt: Date
+    let isSyncing: Bool
+    let issueCount: Int
+    let noteCount: Int
+
+    private var isStale: Bool {
+        Date().timeIntervalSince(lastSyncedAt) > 7 * 24 * 60 * 60
+    }
+
+    private var isDegraded: Bool { issueCount > 0 || isStale }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Rectangle()
+                .fill(isDegraded ? BlinkMobileTheme.amber : state.host == nil ? BlinkMobileTheme.faintInk : BlinkMobileTheme.signal)
+                .frame(width: 7, height: 7)
+                .accessibilityHidden(true)
+
+            Text(statusLine)
+                .font(.caption.monospaced().weight(.medium))
+                .tracking(0.45)
+                .foregroundStyle(isDegraded ? BlinkMobileTheme.amber : BlinkMobileTheme.secondaryInk)
+
+            Spacer()
+
+            Text("\(noteCount) NOTE\(noteCount == 1 ? "" : "S")")
+                .font(.caption.monospaced().weight(.medium))
+                .tracking(0.8)
+                .foregroundStyle(BlinkMobileTheme.faintInk)
+        }
+        .padding(.horizontal, 26)
+        .frame(height: 36)
+        .background(BlinkMobileTheme.canvas)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(isDegraded ? BlinkMobileTheme.amber : BlinkMobileTheme.signal.opacity(0.55))
+                .frame(height: 2)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(statusLine.capitalized), \(noteCount) notes")
+    }
+
+    private var statusLine: String {
+        let age = conciseAge(since: lastSyncedAt)
+        if issueCount > 0 {
+            return "\(issueCount) SYNC ISSUE\(issueCount == 1 ? "" : "S") · UPDATED \(age)"
+        }
+        if isSyncing { return "SYNCING" }
+        switch state {
+        case .disconnected:
+            return isStale ? "SYNC DUE · UPDATED \(age)" : "UPDATED \(age)"
+        case .requestingAccess(let name):
+            return "APPROVAL NEEDED · \(name.uppercased())"
+        case .connected(let host):
+            return "\(host.name.uppercased()) · UPDATED \(age)"
+        }
+    }
+}
+
+private struct BlinkPadDesk: View {
+    let slots: [BlinkPadSlot]
+    let selectedID: String?
+    let onSelect: (BlinkSnapshotNote) -> Void
+
+    var body: some View {
+        HudTiling(
+            items: slots,
+            constraints: TilingConstraints(
+                maxColumns: 3,
+                maxRows: 3,
+                gap: 14,
+                minItemWidth: 150,
+                minItemHeight: 110,
+                maxFill: 1,
+                fillStrategy: .maximize,
+                alignLastRow: .start
+            )
+        ) { slot in
+            if let note = slot.note {
+                BlinkPadNoteTile(
+                    note: note,
+                    slot: slot.number,
+                    isPlaced: note.presentation.slot == slot.number,
+                    isSelected: note.id == selectedID,
+                    action: { onSelect(note) }
+                )
+            } else {
+                BlinkPadEmptySlot(number: slot.number)
+            }
+        }
+    }
+}
+
+private struct BlinkPadNoteTile: View {
+    let note: BlinkSnapshotNote
+    let slot: Int
+    let isPlaced: Bool
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 0) {
+                VStack(alignment: .trailing, spacing: 7) {
+                    if note.pinned {
+                        Rectangle()
+                            .fill(BlinkMobileTheme.ink)
+                            .frame(width: 7, height: 7)
+                    } else {
+                        Text(String(format: "%02d", slot))
+                            .font(.caption2.monospaced().weight(.semibold))
+                    }
+
+                    Text(indexTapeStamp(for: note.updatedAt))
+                        .font(.caption2.monospaced())
+
+                    Spacer(minLength: 0)
+
+                    if isPlaced {
+                        Rectangle()
+                            .fill(BlinkMobileTheme.signal)
+                            .frame(width: 7, height: 7)
+                    }
+                }
+                .foregroundStyle(BlinkMobileTheme.faintInk)
+                .padding(.vertical, 14)
+                .padding(.trailing, 8)
+                .frame(width: 44, alignment: .trailing)
+                .frame(maxHeight: .infinity)
+                .background(BlinkMobileTheme.rail)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(note.title)
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(BlinkMobileTheme.ink)
+                        .lineLimit(2)
+
+                    let excerpt = noteExcerpt(note)
+                    if !excerpt.isEmpty {
+                        Text(excerpt)
+                            .font(.subheadline)
+                            .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                            .lineLimit(4)
+                            .lineSpacing(2)
+                    }
+
+                    Spacer(minLength: 2)
+
+                    HStack(spacing: 7) {
+                        if let noteWorkspace = note.presentation.workspace {
+                            Text(noteWorkspace)
+                        }
+                        if let tag = note.tags.first {
+                            Text("#\(tag)")
+                        }
+                    }
+                    .font(.caption.monospaced())
+                    .foregroundStyle(BlinkMobileTheme.faintInk)
+                    .lineLimit(1)
+                }
+                .padding(14)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .background(isSelected ? BlinkMobileTheme.signal.opacity(0.10) : BlinkMobileTheme.surface)
+            }
+            .contentShape(Rectangle())
+            .overlay {
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(isSelected ? BlinkMobileTheme.signal : BlinkMobileTheme.hairline, lineWidth: 1)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .hoverEffect(.highlight)
+        .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel("Slot \(slot), \(note.title), \(noteExcerpt(note))")
+        .accessibilityValue(isSelected ? "Selected" : "")
+    }
+}
+
+private struct BlinkPadEmptySlot: View {
+    let number: Int
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(BlinkMobileTheme.hairline.opacity(0.72), style: StrokeStyle(lineWidth: 1, dash: [5, 7]))
+
+            Text(String(format: "%02d", number))
+                .font(.caption2.monospaced())
+                .foregroundStyle(BlinkMobileTheme.faintInk.opacity(0.62))
+                .padding(12)
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+private struct BlinkPadReader: View {
+    let note: BlinkSnapshotNote
+    let index: Int
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                BlinkMark(size: 18)
+                Text("ENTRY \(String(format: "%02d", index))")
+                    .font(.caption.monospaced().weight(.medium))
+                    .tracking(0.8)
+                    .foregroundStyle(BlinkMobileTheme.faintInk)
+
+                Spacer()
+
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.subheadline.weight(.semibold))
+                        .frame(width: 30, height: 30)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                .accessibilityLabel("Close note")
+                .keyboardShortcut(.cancelAction)
+            }
+            .padding(.horizontal, 20)
+            .frame(height: 52)
+            .background(BlinkMobileTheme.rail)
+            .overlay(alignment: .bottom) {
+                BlinkMobileTheme.hairline.frame(height: 1)
+            }
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 22) {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(note.title)
+                            .font(.system(.largeTitle, design: .serif, weight: .semibold))
+                            .foregroundStyle(BlinkMobileTheme.ink)
+                            .accessibilityAddTraits(.isHeader)
+
+                        HStack(spacing: 8) {
+                            Text(note.updatedAt.formatted(date: .abbreviated, time: .shortened).uppercased())
+                            if let noteWorkspace = note.presentation.workspace {
+                                Text("·")
+                                Text(noteWorkspace.uppercased())
+                            }
+                        }
+                        .font(.caption.monospaced())
+                        .foregroundStyle(BlinkMobileTheme.faintInk)
+                    }
+
+                    BlinkMobileTheme.hairline.frame(height: 1)
+
+                    MarkdownDocumentView(markdown: noteContent(note), noteTitle: note.title)
+                }
+                .padding(24)
+                .frame(maxWidth: 680, alignment: .leading)
+            }
+        }
+        .background(BlinkMobileTheme.raisedSurface)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .shadow(color: .black.opacity(0.30), radius: 24, y: 14)
+        .accessibilityElement(children: .contain)
+    }
+}
+
+private struct BlinkPadSlot: Identifiable, Sendable {
+    let desk: Int
+    let number: Int
+    let note: BlinkSnapshotNote?
+
+    var id: String { "desk-\(desk)-slot-\(number)" }
+
+    static func makeDesks(notes: [BlinkSnapshotNote]) -> [[BlinkPadSlot]] {
+        guard !notes.isEmpty else { return [] }
+
+        var firstDesk = [BlinkSnapshotNote?](repeating: nil, count: 9)
+        var deferred: [BlinkSnapshotNote] = []
+
+        for note in notes {
+            if let slot = note.presentation.slot,
+               (1...9).contains(slot),
+               firstDesk[slot - 1] == nil {
+                firstDesk[slot - 1] = note
+            } else {
+                deferred.append(note)
+            }
+        }
+
+        for index in firstDesk.indices where firstDesk[index] == nil && !deferred.isEmpty {
+            firstDesk[index] = deferred.removeFirst()
+        }
+
+        var desks: [[BlinkSnapshotNote?]] = [firstDesk]
+        while !deferred.isEmpty {
+            var next = [BlinkSnapshotNote?](repeating: nil, count: 9)
+            for index in next.indices where !deferred.isEmpty {
+                next[index] = deferred.removeFirst()
+            }
+            desks.append(next)
+        }
+
+        return desks.enumerated().map { deskIndex, notes in
+            notes.enumerated().map { slotIndex, note in
+                BlinkPadSlot(desk: deskIndex, number: slotIndex + 1, note: note)
+            }
+        }
+    }
+}

--- a/apps/ios/BlinkMobile/ContentView.swift
+++ b/apps/ios/BlinkMobile/ContentView.swift
@@ -1,0 +1,1199 @@
+import BlinkCore
+import BlinkPeer
+import SwiftUI
+import UIKit
+
+struct BlinkBackdrop: View {
+    var body: some View {
+        BlinkMobileTheme.canvas
+            .ignoresSafeArea()
+    }
+}
+
+struct BlinkMark: View {
+    var size: CGFloat = 26
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: size * 0.18)
+                .stroke(BlinkMobileTheme.signal, lineWidth: max(1, size * 0.06))
+            Rectangle()
+                .fill(BlinkMobileTheme.signal)
+                .frame(width: size * 0.22, height: size * 0.22)
+                .offset(x: -size * 0.12, y: -size * 0.12)
+            Rectangle()
+                .fill(BlinkMobileTheme.signal)
+                .frame(width: size * 0.22, height: size * 0.22)
+                .offset(x: size * 0.12, y: size * 0.12)
+        }
+        .frame(width: size, height: size)
+        .accessibilityHidden(true)
+    }
+}
+
+/*
+ THESIS: Blink mobile is the carbon copy of a spatial desk: chronology is the
+ structure and ledger discipline is the geometry. OWN-WORLD: warm paper or
+ graphite, a continuous indexed rail, sharp rules, square state marks, and
+ monospaced machine language. STORY: choose a workspace, verify the copy's age,
+ scan the log, search from the thumb rail, and read exact Markdown offline.
+ FIRST VIEWPORT: workspace large title, explicit trust rule, indexed entries,
+ and a bottom search launcher on compact widths. FORM: approved Index Tape
+ direction adapted to native SwiftUI navigation, Dynamic Type, and VoiceOver.
+ */
+
+struct ContentView: View {
+    @ObservedObject var model: BlinkMobileModel
+    @State private var selection: String?
+    @State private var selectedLogIndex: Int?
+    @State private var query = ""
+    @State private var workspace: WorkspaceScope = .all
+    @State private var showingSettings = false
+    @State private var compactSearchActive = false
+    @FocusState private var compactSearchFocused: Bool
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private var scopedNotes: [BlinkSnapshotNote] {
+        model.notes.filter { note in
+            switch workspace {
+            case .all: true
+            case .unfiled: note.presentation.workspace == nil
+            case .workspace(let id): note.presentation.workspace == id
+            }
+        }
+    }
+
+    private var filteredNotes: [BlinkSnapshotNote] {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !needle.isEmpty else { return scopedNotes }
+        return scopedNotes.filter { note in
+            note.title.lowercased().contains(needle)
+                || note.tags.contains { $0.lowercased().contains(needle) }
+                || noteContent(note).lowercased().contains(needle)
+        }
+    }
+
+    private var workspaceIDs: [String] {
+        Array(Set(model.notes.compactMap(\.presentation.workspace))).sorted()
+    }
+
+    var body: some View {
+        Group {
+            if horizontalSizeClass == .regular, !dynamicTypeSize.isAccessibilitySize {
+                BlinkPadWorkspaceView(
+                    model: model,
+                    notes: filteredNotes,
+                    scopedNoteCount: scopedNotes.count,
+                    workspace: $workspace,
+                    workspaceIDs: workspaceIDs,
+                    query: $query,
+                    selection: $selection,
+                    onOpenSettings: { showingSettings = true }
+                )
+            } else {
+                NavigationSplitView {
+                    adaptiveSidebar
+                } detail: {
+                    if let selection,
+                       let note = model.notes.first(where: { $0.id == selection }) {
+                        NoteDetailView(
+                            note: note,
+                            index: detailIndex(for: note)
+                        )
+                    } else {
+                        detailPlaceholder
+                    }
+                }
+            }
+        }
+        .tint(BlinkMobileTheme.signal)
+        .toolbarBackground(BlinkMobileTheme.canvas, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .background(BlinkBackdrop())
+        .onChange(of: selection) { _, selectedID in
+            guard let selectedID else {
+                selectedLogIndex = nil
+                return
+            }
+            selectedLogIndex = scopedNotes.firstIndex(where: { $0.id == selectedID }).map { $0 + 1 }
+                ?? model.notes.firstIndex(where: { $0.id == selectedID }).map { $0 + 1 }
+        }
+        .sheet(isPresented: $showingSettings) {
+            BlinkMobileSettingsView(model: model)
+        }
+        .alert(
+            "Blink couldn't finish that",
+            isPresented: Binding(
+                get: { model.presentedError != nil },
+                set: { if !$0 { model.presentedError = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) { model.presentedError = nil }
+        } message: {
+            Text(model.presentedError ?? "Try again.")
+        }
+    }
+
+    private var sidebar: some View {
+        Group {
+            switch model.cacheState {
+            case .loading:
+                ContentUnavailableView {
+                    ProgressView()
+                } description: {
+                    Text("Loading notes…")
+                }
+            case .failed(let message):
+                ContentUnavailableView {
+                    Label("Notes unavailable", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(message)
+                } actions: {
+                    Button("Try Again") { model.retryCacheLoad() }
+                        .buttonStyle(.borderedProminent)
+                }
+            case .ready:
+                if model.notes.isEmpty {
+                    emptyState
+                } else {
+                    notesList
+                }
+            }
+        }
+        .background(BlinkBackdrop())
+        .navigationTitle(workspace.title)
+        .navigationBarTitleDisplayMode(.large)
+        .toolbar { toolbarContent }
+    }
+
+    @ViewBuilder
+    private var adaptiveSidebar: some View {
+        if horizontalSizeClass == .regular {
+            sidebar
+                .navigationSplitViewColumnWidth(min: 320, ideal: 340, max: 380)
+                .searchable(
+                    text: $query,
+                    placement: .sidebar,
+                    prompt: "Search \(workspace.title)"
+                )
+        } else {
+            sidebar
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    if canSearch {
+                        compactSearchFooter
+                    }
+                }
+        }
+    }
+
+    private var canSearch: Bool {
+        if case .ready = model.cacheState {
+            return !model.notes.isEmpty
+        }
+        return false
+    }
+
+    private func detailIndex(for note: BlinkSnapshotNote) -> Int {
+        if let currentScopeIndex = scopedNotes.firstIndex(where: { $0.id == note.id }) {
+            return currentScopeIndex + 1
+        }
+        // iPad intentionally keeps the current reader visible across scope
+        // changes. Retain the log identity from the scope that opened it.
+        return selectedLogIndex
+            ?? model.notes.firstIndex(where: { $0.id == note.id }).map { $0 + 1 }
+            ?? 1
+    }
+
+    private var notesList: some View {
+        List(selection: $selection) {
+            if let lastSyncedAt = model.lastSyncedAt {
+                Section {
+                    SyncSummary(
+                        state: model.connectionState,
+                        lastSyncedAt: lastSyncedAt,
+                        isSyncing: model.isSyncing,
+                        issueCount: model.snapshot?.issues.count ?? 0
+                    )
+                }
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+            }
+
+            Section {
+                if filteredNotes.isEmpty {
+                    if query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        ContentUnavailableView(
+                            "No notes here",
+                            systemImage: "note.text",
+                            description: Text("Choose another workspace or sync with your Mac.")
+                        )
+                        .listRowBackground(Color.clear)
+                    } else {
+                        ContentUnavailableView.search(text: query)
+                            .listRowBackground(Color.clear)
+                    }
+                } else {
+                    ForEach(filteredNotes, id: \.id) { note in
+                        NavigationLink(value: note.id) {
+                            NoteRow(
+                                note: note,
+                                index: (scopedNotes.firstIndex(where: { $0.id == note.id }) ?? 0) + 1,
+                                isSelected: selection == note.id
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .navigationLinkIndicatorVisibility(.hidden)
+                        .listRowInsets(EdgeInsets())
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                    }
+                }
+            } header: {
+                BlinkSectionHeader(
+                    title: workspace.title,
+                    count: filteredNotes.count,
+                    isSearching: !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                )
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(Color.clear)
+        .contentMargins(.top, 0, for: .scrollContent)
+        .listSectionSpacing(0)
+        .refreshable { await model.refresh() }
+        .scrollDismissesKeyboard(.interactively)
+    }
+
+    private var compactSearchFooter: some View {
+        VStack(spacing: 0) {
+            Rectangle()
+                .fill(compactSearchActive ? BlinkMobileTheme.signal : BlinkMobileTheme.hairline)
+                .frame(height: compactSearchActive ? 2 : 1)
+
+            if compactSearchActive {
+                HStack(spacing: 0) {
+                    Image(systemName: "magnifyingglass")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(BlinkMobileTheme.faintInk)
+                        .frame(width: 42, height: 50)
+                        .accessibilityHidden(true)
+
+                    TextField(
+                        "",
+                        text: $query,
+                        prompt: Text(dynamicTypeSize.isAccessibilitySize
+                            ? "SEARCH NOTES"
+                            : "SEARCH · \(workspace.title.uppercased())")
+                            .foregroundStyle(BlinkMobileTheme.faintInk)
+                    )
+                        .font(.subheadline.monospaced())
+                        .foregroundStyle(BlinkMobileTheme.ink)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .submitLabel(.search)
+                        .focused($compactSearchFocused)
+                        .accessibilityLabel("Search \(workspace.title)")
+
+                    if !query.isEmpty {
+                        Button {
+                            query = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .symbolRenderingMode(.hierarchical)
+                                .frame(width: 44, height: 50)
+                        }
+                        .foregroundStyle(BlinkMobileTheme.faintInk)
+                        .accessibilityLabel("Clear search")
+                    }
+
+                    Button {
+                        query = ""
+                        compactSearchFocused = false
+                        compactSearchActive = false
+                    } label: {
+                        if dynamicTypeSize.isAccessibilitySize {
+                            Image(systemName: "xmark")
+                                .font(.headline.weight(.semibold))
+                        } else {
+                            Text("Cancel")
+                                .font(.caption.monospaced().weight(.semibold))
+                                .textCase(.uppercase)
+                        }
+                    }
+                    .frame(minWidth: 50, minHeight: 50)
+                    .foregroundStyle(BlinkMobileTheme.signal)
+                    .accessibilityLabel("Cancel search")
+                }
+                .background(BlinkMobileTheme.raisedSurface)
+            } else {
+                Button {
+                    compactSearchActive = true
+                    Task { @MainActor in
+                        await Task.yield()
+                        compactSearchFocused = true
+                    }
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "magnifyingglass")
+                        Text(dynamicTypeSize.isAccessibilitySize
+                            ? "SEARCH"
+                            : "SEARCH · \(workspace.title.uppercased())")
+                            .lineLimit(1)
+                        Spacer()
+                        if !dynamicTypeSize.isAccessibilitySize {
+                            Text("⌘F")
+                                .foregroundStyle(BlinkMobileTheme.faintInk)
+                        }
+                    }
+                    .font(.caption.monospaced().weight(.medium))
+                    .tracking(0.8)
+                    .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                    .padding(.horizontal, 16)
+                    .frame(maxWidth: .infinity, minHeight: 50)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut("f", modifiers: .command)
+                .accessibilityLabel("Search \(workspace.title)")
+                .background(BlinkMobileTheme.rail)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            VStack(spacing: 16) {
+                BlinkMark(size: 44)
+                Text(emptyStateTitle)
+                    .font(.title2.weight(.semibold))
+            }
+        } description: {
+            Text(emptyStateDescription)
+                .foregroundStyle(BlinkMobileTheme.secondaryInk)
+        } actions: {
+            Button(emptyStateActionTitle) {
+                if model.connectionState.host == nil {
+                    showingSettings = true
+                } else {
+                    Task { await model.refresh() }
+                }
+            }
+                .buttonStyle(.borderedProminent)
+        }
+        .padding(.horizontal, 24)
+    }
+
+    private var emptyStateTitle: String {
+        if model.snapshot != nil { return "No notes yet" }
+        if model.connectionState.host != nil { return "Notes removed" }
+        return "Connect to your Mac"
+    }
+
+    private var emptyStateDescription: String {
+        if model.snapshot != nil {
+            return model.connectionState.host == nil
+                ? "No notes were found in the last update."
+                : "Create a note on your Mac, then sync."
+        }
+        if model.connectionState.host != nil {
+            return "Sync to restore notes on this device."
+        }
+        return "Open Settings to choose a nearby Mac."
+    }
+
+    private var emptyStateActionTitle: String {
+        model.connectionState.host == nil ? "Open Settings" : "Sync Now"
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .topBarLeading) {
+            Menu {
+                Button("All Notes") { workspace = .all }
+                Button("Unfiled") { workspace = .unfiled }
+                if !workspaceIDs.isEmpty { Divider() }
+                ForEach(workspaceIDs, id: \.self) { id in
+                    Button(id) { workspace = .workspace(id) }
+                }
+            } label: {
+                HStack(spacing: 5) {
+                    BlinkMark(size: 24)
+                    Image(systemName: "chevron.down")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(BlinkMobileTheme.faintInk)
+                }
+            }
+            .accessibilityLabel("Workspace: \(workspace.title)")
+        }
+
+        ToolbarItemGroup(placement: .topBarTrailing) {
+            if model.connectionState.host != nil {
+                Button {
+                    Task { await model.refresh() }
+                } label: {
+                    if model.isSyncing {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                }
+                .disabled(model.isSyncing)
+                .accessibilityLabel("Sync now")
+            }
+
+            Button { showingSettings = true } label: {
+                Image(systemName: "gearshape")
+            }
+            .accessibilityLabel("Settings")
+        }
+    }
+
+    private var detailPlaceholder: some View {
+        ContentUnavailableView {
+            VStack(spacing: 16) {
+                BlinkMark(size: 40)
+                Text("Choose a note")
+                    .font(.title2.weight(.semibold))
+            }
+        } description: {
+            Text("Select a note to read.")
+                .foregroundStyle(BlinkMobileTheme.secondaryInk)
+        }
+        .background(BlinkBackdrop())
+    }
+}
+
+private struct BlinkSectionHeader: View {
+    let title: String
+    let count: Int
+    let isSearching: Bool
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(alignment: .leading, spacing: 5) {
+                    headerIdentity
+                    Text("\(count) REC")
+                        .foregroundStyle(BlinkMobileTheme.faintInk)
+                }
+            } else {
+                HStack(spacing: 8) {
+                    headerIdentity
+                    Spacer(minLength: 8)
+                    Text("\(count) REC")
+                        .foregroundStyle(BlinkMobileTheme.faintInk)
+                }
+            }
+        }
+        .font(.caption2.monospaced().weight(.medium))
+        .tracking(1.15)
+        .textCase(nil)
+        .padding(.horizontal, 2)
+        .padding(.top, 10)
+        .padding(.bottom, 5)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(title), \(count) \(count == 1 ? "note" : "notes")")
+    }
+
+    private var headerIdentity: some View {
+        HStack(spacing: 8) {
+            Text(isSearching ? "MATCHES" : "LOG")
+                .foregroundStyle(isSearching ? BlinkMobileTheme.signal : BlinkMobileTheme.faintInk)
+            Text("/")
+                .foregroundStyle(BlinkMobileTheme.hairline)
+            Text(title.uppercased())
+                .foregroundStyle(BlinkMobileTheme.faintInk)
+                .lineLimit(1)
+        }
+    }
+}
+
+enum WorkspaceScope: Hashable {
+    case all
+    case unfiled
+    case workspace(String)
+
+    var title: String {
+        switch self {
+        case .all: "All Notes"
+        case .unfiled: "Unfiled"
+        case .workspace(let id): id
+        }
+    }
+}
+
+private struct SyncSummary: View {
+    let state: BlinkMobileModel.ConnectionState
+    let lastSyncedAt: Date
+    let isSyncing: Bool
+    let issueCount: Int
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Rectangle()
+                .fill(statusColor)
+                .frame(height: 2)
+
+            HStack(alignment: .firstTextBaseline, spacing: 9) {
+                Rectangle()
+                    .fill(pipColor)
+                    .frame(width: 7, height: 7)
+                    .accessibilityHidden(true)
+
+                Text(statusLine)
+                    .font(.caption.monospaced().weight(.medium))
+                    .tracking(0.45)
+                    .foregroundStyle(isDegraded ? BlinkMobileTheme.amber : BlinkMobileTheme.secondaryInk)
+                    .lineLimit(3)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 11)
+        }
+        .background(BlinkMobileTheme.canvas)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(statusLine.capitalized)
+    }
+
+    private var isDegraded: Bool {
+        issueCount > 0 || isStale
+    }
+
+    private var isStale: Bool {
+        Date().timeIntervalSince(lastSyncedAt) > 7 * 24 * 60 * 60
+    }
+
+    private var statusColor: Color {
+        if isDegraded { return BlinkMobileTheme.amber }
+        if isSyncing || state.host != nil { return BlinkMobileTheme.signal.opacity(0.62) }
+        return BlinkMobileTheme.hairline
+    }
+
+    private var pipColor: Color {
+        if isDegraded { return BlinkMobileTheme.amber }
+        if isSyncing || state.host != nil { return BlinkMobileTheme.signal }
+        return BlinkMobileTheme.faintInk
+    }
+
+    private var statusLine: String {
+        let age = conciseAge(since: lastSyncedAt)
+        if issueCount > 0 {
+            return "\(issueCount) SYNC ISSUE\(issueCount == 1 ? "" : "S") · UPDATED \(age)"
+        }
+        if isSyncing {
+            if let host = state.host {
+                return "SYNCING · \(host.name.uppercased())"
+            }
+            return "SYNCING"
+        }
+        switch state {
+        case .disconnected:
+            return isStale ? "SYNC DUE · UPDATED \(age)" : "UPDATED \(age)"
+        case .requestingAccess(let name):
+            return "APPROVAL NEEDED · \(name.uppercased())"
+        case .connected(let host):
+            return "\(host.name.uppercased()) · UPDATED \(age)"
+        }
+    }
+}
+
+private struct NoteRow: View {
+    let note: BlinkSnapshotNote
+    let index: Int
+    let isSelected: Bool
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ZStack(alignment: .topLeading) {
+                BlinkMobileTheme.rail
+                if isSelected {
+                    BlinkMobileTheme.signal
+                        .frame(width: 2)
+                }
+
+                VStack(alignment: .trailing, spacing: 7) {
+                    if note.pinned {
+                        Rectangle()
+                            .fill(BlinkMobileTheme.ink)
+                            .frame(width: 7, height: 7)
+                    } else {
+                        Text(String(format: "%02d", index))
+                            .font(.caption2.monospaced().weight(.semibold))
+                    }
+
+                    if !dynamicTypeSize.isAccessibilitySize {
+                        Text(indexTapeStamp(for: note.updatedAt))
+                            .font(.caption2.monospaced())
+                    }
+                }
+                .foregroundStyle(BlinkMobileTheme.faintInk)
+                .padding(.top, 15)
+                .padding(.trailing, 8)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            .frame(width: dynamicTypeSize.isAccessibilitySize ? 32 : 48)
+            .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(note.title)
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(BlinkMobileTheme.ink)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+
+                let excerpt = noteExcerpt(note)
+                if !excerpt.isEmpty {
+                    Text(excerpt)
+                        .font(.subheadline)
+                        .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                        .lineLimit(dynamicTypeSize.isAccessibilitySize ? 4 : 2)
+                        .lineSpacing(2)
+                }
+
+                rowMetadata
+            }
+            .padding(.horizontal, 13)
+            .padding(.vertical, 13)
+            .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
+            .background(isSelected ? BlinkMobileTheme.signal.opacity(0.10) : BlinkMobileTheme.surface)
+            .overlay(alignment: .bottom) {
+                BlinkMobileTheme.hairline.frame(height: 1)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(isSelected ? "Selected" : "")
+    }
+
+    @ViewBuilder
+    private var rowMetadata: some View {
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(alignment: .leading, spacing: 3) {
+                metadataItems
+            }
+            .textCase(.lowercase)
+            .font(.caption.monospaced())
+            .foregroundStyle(BlinkMobileTheme.faintInk)
+        } else {
+            HStack(spacing: 7) {
+                metadataItems
+            }
+            .textCase(.lowercase)
+            .font(.caption.monospaced())
+            .foregroundStyle(BlinkMobileTheme.faintInk)
+            .lineLimit(1)
+        }
+    }
+
+    @ViewBuilder
+    private var metadataItems: some View {
+        if dynamicTypeSize.isAccessibilitySize {
+            Text(indexTapeStamp(for: note.updatedAt))
+        }
+        if let workspace = note.presentation.workspace {
+            Text(workspace)
+        }
+        if let firstTag = note.tags.first {
+            Text("#\(firstTag)")
+        }
+    }
+
+    private var accessibilityLabel: String {
+        var parts = [note.pinned ? "Pinned note" : "Note \(index)", note.title]
+        let excerpt = noteExcerpt(note)
+        if !excerpt.isEmpty { parts.append(excerpt) }
+        parts.append(indexTapeStamp(for: note.updatedAt))
+        if let workspace = note.presentation.workspace { parts.append(workspace) }
+        if let firstTag = note.tags.first { parts.append("tag \(firstTag)") }
+        return parts.joined(separator: ", ")
+    }
+}
+
+private struct NoteDetailView: View {
+    let note: BlinkSnapshotNote
+    let index: Int
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollView {
+                HStack(alignment: .top, spacing: 0) {
+                    if !dynamicTypeSize.isAccessibilitySize {
+                        VStack(alignment: .trailing, spacing: 7) {
+                            Text(String(format: "%02d", index))
+                                .font(.caption2.monospaced().weight(.semibold))
+                            Text(indexTapeStamp(for: note.updatedAt))
+                                .font(.caption2.monospaced())
+                        }
+                        .foregroundStyle(BlinkMobileTheme.faintInk)
+                        .padding(.top, 29)
+                        .padding(.trailing, 8)
+                        .frame(width: 48, alignment: .topTrailing)
+                        .frame(maxHeight: .infinity, alignment: .topTrailing)
+                        .background(BlinkMobileTheme.rail)
+                        .accessibilityHidden(true)
+                    }
+
+                    VStack(alignment: .leading, spacing: 24) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack(spacing: 8) {
+                                BlinkMark(size: 17)
+                                Text("MARKDOWN / READ ONLY")
+                                    .font(.caption2.monospaced().weight(.medium))
+                                    .tracking(1.0)
+                                    .foregroundStyle(BlinkMobileTheme.faintInk)
+                            }
+
+                            if dynamicTypeSize.isAccessibilitySize {
+                                Text("ENTRY \(String(format: "%02d", index)) · \(indexTapeStamp(for: note.updatedAt))")
+                                    .font(.caption.monospaced())
+                                    .foregroundStyle(BlinkMobileTheme.faintInk)
+                            }
+
+                            Text(note.title)
+                                .font(.system(.largeTitle, design: .serif, weight: .semibold))
+                                .foregroundStyle(BlinkMobileTheme.ink)
+
+                            HStack(spacing: 8) {
+                                Text(note.updatedAt.formatted(date: .abbreviated, time: .shortened).uppercased())
+                                if let workspace = note.presentation.workspace {
+                                    Text("·")
+                                    Text(workspace.uppercased())
+                                }
+                            }
+                            .font(.caption.monospaced())
+                            .foregroundStyle(BlinkMobileTheme.faintInk)
+                        }
+
+                        Divider()
+                            .overlay(BlinkMobileTheme.hairline)
+
+                        MarkdownDocumentView(markdown: noteContent(note), noteTitle: note.title)
+
+                        if !note.tags.isEmpty {
+                            ViewThatFits(in: .horizontal) {
+                                HStack { tagViews }
+                                VStack(alignment: .leading) { tagViews }
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 24)
+                    .frame(maxWidth: 720, alignment: .leading)
+                    .frame(maxWidth: .infinity)
+                }
+                .frame(
+                    maxWidth: .infinity,
+                    minHeight: geometry.size.height,
+                    alignment: .topLeading
+                )
+            }
+        }
+        .background(BlinkBackdrop())
+        .navigationTitle(note.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    private var tagViews: some View {
+        ForEach(note.tags, id: \.self) { tag in
+            Text("#\(tag)")
+                .font(.caption.monospaced())
+                .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                .padding(.horizontal, 9)
+                .padding(.vertical, 5)
+                .background(BlinkMobileTheme.surface)
+                .overlay {
+                    Rectangle()
+                        .stroke(BlinkMobileTheme.hairline, lineWidth: 1)
+                }
+        }
+    }
+}
+
+private let indexTapeClockFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = .autoupdatingCurrent
+    formatter.setLocalizedDateFormatFromTemplate("HHmm")
+    return formatter
+}()
+
+private let indexTapeOldDateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = .autoupdatingCurrent
+    formatter.dateFormat = "M·yy"
+    return formatter
+}()
+
+func indexTapeStamp(for date: Date, now: Date = Date()) -> String {
+    let calendar = Calendar.autoupdatingCurrent
+    if calendar.isDate(date, inSameDayAs: now) {
+        return indexTapeClockFormatter.string(from: date)
+    }
+
+    let days = calendar.dateComponents(
+        [.day],
+        from: calendar.startOfDay(for: date),
+        to: calendar.startOfDay(for: now)
+    ).day ?? 0
+    if days >= 0, days < 7 {
+        return date.formatted(.dateTime.weekday(.abbreviated)).uppercased()
+    }
+    if calendar.component(.year, from: date) == calendar.component(.year, from: now) {
+        return date.formatted(.dateTime.day().month(.abbreviated)).uppercased()
+    }
+    return indexTapeOldDateFormatter.string(from: date).uppercased()
+}
+
+func conciseAge(since date: Date, now: Date = Date()) -> String {
+    let interval = max(0, now.timeIntervalSince(date))
+    if interval < 60 { return "JUST NOW" }
+    if interval < 3_600 { return "\(Int(interval / 60))M AGO" }
+    if interval < 86_400 { return "\(Int(interval / 3_600))H AGO" }
+    if interval < 30 * 86_400 { return "\(Int(interval / 86_400))D AGO" }
+    return date.formatted(date: .abbreviated, time: .omitted).uppercased()
+}
+
+struct MarkdownDocumentView: View {
+    let markdown: String
+    let noteTitle: String
+
+    private var blocks: [MarkdownBlock] {
+        MarkdownBlock.parse(markdown, omittingRepeatedTitle: noteTitle)
+    }
+
+    var body: some View {
+        LazyVStack(alignment: .leading, spacing: 16) {
+            ForEach(blocks) { block in
+                blockView(block)
+            }
+        }
+        .foregroundStyle(BlinkMobileTheme.ink)
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func blockView(_ block: MarkdownBlock) -> some View {
+        switch block.kind {
+        case .heading(let level, let text):
+            Text(inlineMarkdown(text))
+                .font(headingFont(level))
+                .foregroundStyle(BlinkMobileTheme.ink)
+                .accessibilityAddTraits(.isHeader)
+        case .paragraph(let text):
+            Text(inlineMarkdown(text))
+                .font(.body)
+        case .listItem(let marker, let text):
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(marker)
+                    .font(.body.monospaced())
+                    .foregroundStyle(BlinkMobileTheme.signal)
+                    .frame(minWidth: 18, alignment: .trailing)
+                Text(inlineMarkdown(text))
+                    .font(.body)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .accessibilityElement(children: .combine)
+        case .code(let text):
+            ScrollView(.horizontal) {
+                Text(text)
+                    .font(.body.monospaced())
+                    .padding()
+            }
+            .background(BlinkMobileTheme.surface)
+            .overlay {
+                Rectangle()
+                    .stroke(BlinkMobileTheme.hairline, lineWidth: 1)
+            }
+            .accessibilityLabel("Code block")
+            .accessibilityValue(text)
+        }
+    }
+
+    private func headingFont(_ level: Int) -> Font {
+        switch level {
+        case 1: .system(.title2, design: .serif, weight: .semibold)
+        case 2: .system(.title3, design: .serif, weight: .semibold)
+        default: .headline
+        }
+    }
+
+    private func inlineMarkdown(_ text: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(text)
+    }
+}
+
+private struct MarkdownBlock: Identifiable {
+    enum Kind {
+        case heading(level: Int, text: String)
+        case paragraph(String)
+        case listItem(marker: String, text: String)
+        case code(String)
+    }
+
+    var id: Int
+    var kind: Kind
+
+    static func parse(_ markdown: String, omittingRepeatedTitle title: String) -> [MarkdownBlock] {
+        let lines = markdown.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var blocks: [MarkdownBlock] = []
+        var paragraph: [String] = []
+        var code: [String]?
+
+        func append(_ kind: Kind) {
+            blocks.append(MarkdownBlock(id: blocks.count, kind: kind))
+        }
+
+        func flushParagraph() {
+            guard !paragraph.isEmpty else { return }
+            append(.paragraph(paragraph.joined(separator: " ")))
+            paragraph.removeAll()
+        }
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("```") {
+                if let codeLines = code {
+                    append(.code(codeLines.joined(separator: "\n")))
+                    code = nil
+                } else {
+                    flushParagraph()
+                    code = []
+                }
+                continue
+            }
+            if code != nil {
+                code?.append(line)
+                continue
+            }
+            if trimmed.isEmpty {
+                flushParagraph()
+                continue
+            }
+            if let heading = heading(in: trimmed) {
+                flushParagraph()
+                append(.heading(level: heading.level, text: heading.text))
+                continue
+            }
+            if let item = listItem(in: trimmed) {
+                flushParagraph()
+                append(.listItem(marker: item.marker, text: item.text))
+                continue
+            }
+            paragraph.append(trimmed)
+        }
+
+        flushParagraph()
+        if let code { append(.code(code.joined(separator: "\n"))) }
+
+        if let first = blocks.first,
+           case .heading(_, let headingTitle) = first.kind,
+           headingTitle.caseInsensitiveCompare(title) == .orderedSame {
+            blocks.removeFirst()
+            for index in blocks.indices { blocks[index].id = index }
+        }
+        return blocks
+    }
+
+    private static func heading(in line: String) -> (level: Int, text: String)? {
+        let level = line.prefix(while: { $0 == "#" }).count
+        guard (1...6).contains(level) else { return nil }
+        let boundary = line.index(line.startIndex, offsetBy: level)
+        guard boundary < line.endIndex, line[boundary].isWhitespace else { return nil }
+        return (level, line[boundary...].trimmingCharacters(in: .whitespaces))
+    }
+
+    private static func listItem(in line: String) -> (marker: String, text: String)? {
+        for marker in ["-", "*", "+"] where line.hasPrefix(marker + " ") {
+            return ("•", String(line.dropFirst(2)))
+        }
+        let digits = line.prefix(while: { $0.isNumber })
+        guard !digits.isEmpty else { return nil }
+        let boundary = line.index(line.startIndex, offsetBy: digits.count)
+        guard boundary < line.endIndex, line[boundary] == "." || line[boundary] == ")" else {
+            return nil
+        }
+        let afterMarker = line.index(after: boundary)
+        guard afterMarker < line.endIndex, line[afterMarker].isWhitespace else { return nil }
+        return ("\(digits).", line[afterMarker...].trimmingCharacters(in: .whitespaces))
+    }
+}
+
+struct ConnectionView: View {
+    @ObservedObject var model: BlinkMobileModel
+    @State private var pendingPeer: BlinkLANPeerCandidate?
+
+    var body: some View {
+        List {
+            if let host = model.connectionState.host {
+                Section("Mac") {
+                    Label(host.name, systemImage: "desktopcomputer")
+                    LabeledContent("Transport", value: "Local network")
+                    LabeledContent("Security", value: "Encrypted")
+                }
+                .listRowBackground(BlinkMobileTheme.surface)
+                Section {
+                    Button("Sync Now") {
+                        Task { await model.refresh() }
+                    }
+                    .disabled(model.isSyncing)
+                    Button("Disconnect", role: .destructive) {
+                        model.disconnect()
+                    }
+                }
+                .listRowBackground(BlinkMobileTheme.surface)
+            } else {
+                nearbySection
+                approvalSection
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(BlinkBackdrop())
+        .navigationTitle("Connection")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(BlinkMobileTheme.canvas, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .alert(
+            "Connect to \(pendingPeer?.name ?? "this Mac")?",
+            isPresented: Binding(
+                get: { pendingPeer != nil },
+                set: { if !$0 { pendingPeer = nil } }
+            )
+        ) {
+            Button("Cancel", role: .cancel) { pendingPeer = nil }
+            Button("Request Access") {
+                guard let peer = pendingPeer else { return }
+                pendingPeer = nil
+                Task {
+                    _ = await model.connect(to: peer)
+                }
+            }
+        } message: {
+            Text("Your Mac will ask you to allow this device. Access remains until you revoke it on the Mac.")
+        }
+    }
+
+    @ViewBuilder
+    private var nearbySection: some View {
+        Section {
+            switch model.discoveryState {
+            case .searching:
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text("Looking for Blink on your network…")
+                        .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                }
+            case .found:
+                ForEach(model.nearbyPeers) { peer in
+                    Button {
+                        pendingPeer = peer
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Label(peer.name, systemImage: "desktopcomputer")
+                                Text("Nearby")
+                                    .font(.caption)
+                                    .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                            }
+                            Spacer()
+                            if case .requestingAccess(let name) = model.connectionState,
+                               name == peer.name {
+                                ProgressView()
+                            } else {
+                                Image(systemName: "chevron.forward")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(BlinkMobileTheme.faintInk)
+                            }
+                        }
+                    }
+                    .foregroundStyle(.primary)
+                    .disabled(model.connectionState != .disconnected)
+                }
+            case .noPeers:
+                Label("No Macs found", systemImage: "desktopcomputer.trianglebadge.exclamationmark")
+                    .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                Button("Look Again") { model.retryDiscovery() }
+            case .failed(let message):
+                Label("Discovery unavailable", systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                Button("Try Again") { model.retryDiscovery() }
+                Button("Open Settings") {
+                    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                    UIApplication.shared.open(url)
+                }
+            }
+        } header: {
+            Text("Nearby Macs")
+        } footer: {
+            Text("Open Blink on your Mac. Both devices must be on the same network.")
+        }
+        .listRowBackground(BlinkMobileTheme.surface)
+    }
+
+    @ViewBuilder
+    private var approvalSection: some View {
+        switch model.connectionState {
+        case .requestingAccess(let name):
+            Section {
+                HStack(alignment: .top, spacing: 12) {
+                    ProgressView()
+                        .padding(.top, 2)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Approve on \(name)")
+                            .font(.headline)
+                        Text("Waiting for approval")
+                            .font(.subheadline)
+                            .foregroundStyle(BlinkMobileTheme.secondaryInk)
+                    }
+                }
+            } header: {
+                Text("Access")
+            }
+            .listRowBackground(BlinkMobileTheme.surface)
+        case .disconnected:
+            Section {
+                Label("Approval is required on the Mac.", systemImage: "lock.shield")
+                    .foregroundStyle(BlinkMobileTheme.secondaryInk)
+            } footer: {
+                Text("The Mac remembers this device until you revoke access.")
+            }
+            .listRowBackground(BlinkMobileTheme.surface)
+        case .connected:
+            EmptyView()
+        }
+    }
+}
+
+func noteContent(_ note: BlinkSnapshotNote) -> String {
+    (try? Frontmatter.decode(note.markdown).content) ?? note.markdown
+}
+
+func noteExcerpt(_ note: BlinkSnapshotNote) -> String {
+    var lines = noteContent(note)
+        .split(separator: "\n", omittingEmptySubsequences: false)
+        .map(String.init)
+    if let firstContentIndex = lines.firstIndex(where: {
+        !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }) {
+        let first = lines[firstContentIndex]
+            .trimmingCharacters(in: CharacterSet(charactersIn: "# "))
+        if first.caseInsensitiveCompare(note.title) == .orderedSame {
+            lines.remove(at: firstContentIndex)
+        }
+    }
+    return lines.joined(separator: " ")
+        .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+}

--- a/apps/ios/DESIGN.md
+++ b/apps/ios/DESIGN.md
@@ -1,0 +1,67 @@
+# Blink Mobile Design — Index Tape
+
+Blink Mobile is the carbon copy of a spatial desktop: a chronological note log
+that remains trustworthy when the Mac is gone. Chronology supplies the
+structure; ledger discipline supplies the geometry.
+
+## Visual world
+
+- Warm paper in light mode, neutral graphite in dark mode. Never forest green.
+- Flat, full-bleed surfaces separated by rules. Cards and decorative glass do
+  not belong in the log or reader.
+- Signal blue marks the one live thing on screen. Amber means degraded or stale
+  data, never ordinary offline use.
+- System typography carries interface copy; monospaced text carries indices,
+  timestamps, state, and measurement; the system serif carries reader titles.
+
+## Signature components
+
+- The workspace name is the large navigation title. The Blink mark opens scope.
+- Sync is a two-point rule plus a square pip and terse state: update age in the
+  normal case, Mac name while connected, and action language only when stale or
+  blocked.
+- First connection is one mobile-device request followed by one Mac approval. Blink
+  remembers the approved device until the Mac revokes it; pairing codes never
+  enter the interface.
+- The top-right complication opens local Settings. Connection, appearance, and
+  on-device notes are separate pages built from Hudson settings primitives.
+- Index Tape is the default theme. Field, Deck, Scope, Focus, and Console are
+  app-generic treatments adapted from proven palettes across the Arach app
+  family. Theme and light/system/dark mode persist locally.
+- Every row has one continuous machine rail: a zero-padded index above a static
+  time stamp. A pin square replaces the index.
+- Compact search grows from the bottom rail into a real SwiftUI field. At
+  regular width, search uses the native sidebar placement.
+- The reader repeats the indexed gutter and stays flat, sharp, and read-only.
+
+## Tokens
+
+Light: canvas `#F2F0EC`, surface `#FCFAF6`, raised `#FFFFFF`, rail `#EBE7DF`,
+rule `#DAD5CB`, ink `#17130F`, secondary `#5C554F`, faint `#6F695F`, signal
+`#2D5DAF`, amber `#7E6029`.
+
+Dark: canvas `#0A0B0C`, surface `#121416`, raised `#17191C`, rail `#0E1012`,
+rule `#2A2E31`, ink `#FBEEE8`, secondary `#9AA0A2`, faint `#7A7F81`, signal
+`#83B4FF`, amber `#D6B96C`.
+
+## Native adaptation
+
+The Studio study is a direction, not a point-size contract. SwiftUI controls
+retain Dynamic Type, VoiceOver grouping, keyboard avoidance, 44-point targets,
+native navigation, and interactive keyboard dismissal. Rail metadata collapses
+before clipping at accessibility sizes. State is always stated in text as well
+as color.
+
+## iPad desk
+
+- Regular-width iPad layouts become a spatial nine-slot desk instead of a
+  stretched phone log. A note's portable `blink.slot` value chooses its place;
+  exact Mac window frames remain local to that Mac.
+- Unplaced notes and slot collisions fill the next open cells in chronological
+  order. More than nine notes create additional swipeable desks, preserving a
+  predictable grid rather than shrinking notes into thumbnails.
+- Opening a note raises a readable panel above the desk, keeping nearby notes
+  visible as spatial context. Closing it returns to the same desk and place.
+- Search, workspace scope, sync, settings, and themes are shared with iPhone.
+  Compact multitasking widths and accessibility Dynamic Type deliberately fall
+  back to the chronological log.

--- a/apps/ios/Fixtures/demo-snapshot.json
+++ b/apps/ios/Fixtures/demo-snapshot.json
@@ -1,0 +1,39 @@
+{
+  "etag": "\"demo-workspace\"",
+  "generatedAt": 1785636000000,
+  "issues": [],
+  "notes": [
+    {
+      "id": "launch-checklist",
+      "markdown": "---\nid: launch-checklist\ncreated: 2026-07-31T14:00:00.000Z\nupdated: 2026-08-01T18:40:00.000Z\ntags: [release, ios]\npinned: true\nblink:\n  workspace: Launch\n---\n# Launch checklist\n\n- Verify the encrypted LAN handshake\n- Read notes after the Mac disconnects\n- Check Dynamic Type on the detail view",
+      "pinned": true,
+      "presentation": { "workspace": "Launch" },
+      "revision": "demo-launch-r1",
+      "tags": ["release", "ios"],
+      "title": "Launch checklist",
+      "updatedAt": 1785619200000
+    },
+    {
+      "id": "pairing-notes",
+      "markdown": "---\nid: pairing-notes\ncreated: 2026-07-30T14:00:00.000Z\nupdated: 2026-08-01T16:15:00.000Z\ntags: [security]\npinned: false\nblink:\n  workspace: Hudson\n---\n# Pairing notes\n\nBonjour advertises the Mac public key. Each snapshot request and response is sealed end to end inside the encrypted peer session.",
+      "pinned": false,
+      "presentation": { "workspace": "Hudson" },
+      "revision": "demo-pairing-r1",
+      "tags": ["security"],
+      "title": "Pairing notes",
+      "updatedAt": 1785610500000
+    },
+    {
+      "id": "saturday",
+      "markdown": "---\nid: saturday\ncreated: 2026-07-28T14:00:00.000Z\nupdated: 2026-07-31T21:00:00.000Z\ntags: []\npinned: false\n---\n# Saturday\n\nPick up coffee beans, walk by the canal, and leave enough quiet time to sketch the next workspace.",
+      "pinned": false,
+      "presentation": {},
+      "revision": "demo-saturday-r1",
+      "tags": [],
+      "title": "Saturday",
+      "updatedAt": 1785531600000
+    }
+  ],
+  "tombstones": [],
+  "version": 1
+}

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -1,0 +1,57 @@
+name: BlinkMobile
+options:
+  bundleIdPrefix: dev.arach
+  deploymentTarget:
+    iOS: "17.0"
+  xcodeVersion: "26.0"
+packages:
+  Blink:
+    path: ../..
+  Hudson:
+    path: ../../../hudson
+targets:
+  BlinkMobile:
+    type: application
+    platform: iOS
+    sources:
+      - path: BlinkMobile
+    dependencies:
+      - package: Blink
+        product: BlinkCore
+      - package: Blink
+        product: BlinkPeer
+      - package: Hudson
+        product: HudsonUI
+    info:
+      path: BlinkMobile/Info.plist
+      properties:
+        CFBundleDisplayName: Blink
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        UILaunchScreen: {}
+        NSLocalNetworkUsageDescription: Blink uses your local network to securely sync notes from your Mac.
+        NSBonjourServices:
+          - _blink-notes._tcp
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: dev.arach.blink.mobile
+        PRODUCT_NAME: Blink
+        MARKETING_VERSION: 0.1.0
+        CURRENT_PROJECT_VERSION: 1
+        SWIFT_VERSION: 6.0
+        DEVELOPMENT_TEAM: 2U83JFPW66
+        TARGETED_DEVICE_FAMILY: 1,2
+        SUPPORTS_MACCATALYST: NO
+        CODE_SIGN_STYLE: Automatic
+schemes:
+  BlinkMobile:
+    build:
+      targets:
+        BlinkMobile: all
+    run:
+      config: Debug

--- a/docs/ios-sync.md
+++ b/docs/ios-sync.md
@@ -1,0 +1,101 @@
+# Blink iOS: local-first snapshot contract
+
+## Scope
+
+The first iOS surface is a read-only, offline-capable view of the same note files
+the Mac app and `blink` CLI use. It starts with LAN as its only enabled route,
+but its transport boundary can later use Hudson's Tailscale or managed-relay
+providers without changing Blink's replication model.
+
+## Ownership
+
+- Hudson owns generic peer identity/trust models, route providers, route
+  settings, cascade, and diagnostics.
+- Blink owns snapshots, note revisions, tombstones, quarantine, workspace/style
+  projection, attachment policy, offline cache, iOS UI, and the first proven LAN
+  peer channel in `BlinkPeer`.
+- OpenScout donates generic route and connection behavior to Hudson while OSN
+  remains an OpenScout provider.
+
+## V1 snapshot
+
+The Mac returns one complete `BlinkSnapshot`:
+
+- exact UTF-8 bytes of each frontmattered Markdown file;
+- a SHA-256 revision for each note;
+- a strong whole-snapshot ETag;
+- parsed summary fields for native list rendering;
+- durable tombstones for absent notes;
+- quarantine issues for unreadable, malformed, or identity-divergent files.
+
+Each quarantine issue names the expected filename identity. An iOS cache keeps
+its last known value for that identity until the file becomes readable again or
+an explicit tombstone arrives; quarantine is never interpreted as deletion.
+
+The mobile app atomically replaces its cached snapshot on a successful changed
+response and retains it on an authenticated not-modified response. The cache is
+bound to the Mac host identity that produced it: connecting to a different Mac
+forces a full snapshot and never merges quarantined notes across hosts.
+
+`generatedAt` is diagnostic and is excluded from the ETag. A corpus that has not
+changed therefore remains cacheable across requests and app launches.
+
+## Consistency
+
+V1 deliberately avoids a manifest-then-live-file race: note bodies travel in the
+same snapshot response as their revisions. `BlinkSnapshotBuilder` requires two
+identical consecutive directory reads before publishing. Atomic note writes
+prevent torn individual files; the repeated capture prevents a directory change
+from being presented as a stable snapshot.
+
+If the corpus later becomes too large for full snapshots, the replacement must
+use immutable snapshot leases keyed by generation. Fetching a manifest and then
+reading current live files by id is not an acceptable incremental design.
+
+## Encrypted LAN transport
+
+The iOS feature depends only on `BlinkPeerTransport`. The first implementation
+uses Bonjour discovery through Multipeer Connectivity with
+`MCEncryptionPreference.required`; there is no plaintext HTTP listener. Bonjour
+advertises a stable Mac host identity and Curve25519 agreement public key. Every
+application payload is then sealed end to end with a per-connection key using
+ChaChaPoly, independently of the Multipeer transport encryption.
+
+The Mac accepts a peer session but serves nothing until the mobile app requests
+access inside that sealed channel. Each app installation keeps a private random
+seed and derives a different credential for each Mac public key; the reusable
+seed never leaves the device. The Mac shows a native approval alert naming the
+nearby device. Allowing the request stores only that host-scoped credential, so
+later connections from the same installation do not repeat the prompt. A relay,
+lookalike host, or same-network observer cannot decrypt the payload or reuse the
+credential. Same-network presence is discovery, never authorization.
+
+Approved devices are listed under **Mobile Access** in Blink's right-click menu.
+Revoking a device deletes its stored credential and disconnects its live session;
+the device must be explicitly approved again before it can fetch another
+snapshot. The offline snapshot already on the device remains available because it
+is a replaceable local cache, not continuing access to the Mac.
+
+`BlinkPeer` is kept separate from the app UI so the encrypted peer channel can be
+proven here and later donated to Hudson without moving Blink's snapshot model.
+Ordinary LAN HTTP with only a bearer token or request MAC remains prohibited
+because it can expose note contents to passive network observers.
+
+The initial Hudson route policy is LAN-first. Tailscale and hosted relays are
+providers added to the same cascade, not new Blink sync implementations.
+
+## Building the companion
+
+The checked-in XcodeGen source lives at `apps/ios/project.yml`:
+
+```sh
+cd apps/ios
+xcodegen generate
+xcodebuild -project BlinkMobile.xcodeproj -scheme BlinkMobile \
+  -destination 'generic/platform=iOS Simulator' build
+```
+
+The generated project consumes the repository's local `BlinkCore` and
+`BlinkPeer` Swift package products. The fixture in `apps/ios/Fixtures` documents
+representative offline list and detail states without pretending to be
+production data.

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -99,6 +99,12 @@ cat > "$app_path/Contents/Info.plist" <<PLIST
   <true/>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>Blink uses your local network to share notes with your paired iPhone or iPad.</string>
+  <key>NSBonjourServices</key>
+  <array>
+    <string>_blink-notes._tcp</string>
+  </array>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
 </dict>

--- a/tools/release/Blink.entitlements
+++ b/tools/release/Blink.entitlements
@@ -10,5 +10,7 @@
     <!-- The read-mode renderer loads remote images over https (ATS-gated). -->
     <key>com.apple.security.network.client</key>
     <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
 </dict>
 </plist>

--- a/tools/release/build-dmg.sh
+++ b/tools/release/build-dmg.sh
@@ -109,6 +109,12 @@ cat > "$BUNDLE/Contents/Info.plist" <<PLIST
   <true/>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>Blink uses your local network to share notes with your paired iPhone or iPad.</string>
+  <key>NSBonjourServices</key>
+  <array>
+    <string>_blink-notes._tcp</string>
+  </array>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
 </dict>


### PR DESCRIPTION
Summary
- add the read-only, offline-first iPhone and iPad companion with workspace filtering, native search, settings, themes, and the nine-slot iPad desk
- host sealed v3 LAN snapshot access from the Mac with explicit approval, persistent trust, live revocation, and Mobile Access status
- bind offline caches to their source Mac, reset revoked sessions, and document the transport and product contracts
- add XcodeGen, Bonjour, local-network, sandbox network-server, signing, and adaptive orientation metadata

Verification
- BLINK_HUDSON_SOURCE=git swift test — 140 tests in 17 suites
- XcodeGen generic iOS Simulator Debug build — passed
- XcodeGen generic iOS Release device build — passed
- codesign --verify --deep --strict — passed; Apple Development signature, team 2U83JFPW66

Notes
- remaining build warnings are pre-existing HudsonUI local-variable warnings outside this repository