### PR TITLE
🎨 Add the shared Blink design studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ Config/signing.env
 
 # Local planning and design tooling
 design/
+!design/
+design/*
+!design/studio/
+!design/studio/**
 docs/functionality-v1.md
 docs/notes-representation.md
 docs/v2-plan.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,8 @@ When documents disagree, use this order:
 
 Other useful references:
 
-- UI studies / visual spec: `design/studio` (local, untracked, and absent from
-  a fresh clone; `bun dev` → `localhost:3060/studio`).
+- UI studies / visual spec: `design/studio` (tracked shared-Studio app;
+  `bun dev` → `localhost:3060/studio`).
 - The CLI operates on the same files as the app:
   `blink ls/cat/new/present/type/write/search/rm/path/workspace`; see
   `docs/cli.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,8 @@ When documents disagree, use this order:
 
 Other useful references:
 
-- UI studies / visual spec: `design/studio` (local, untracked, and absent from
-  a fresh clone; `bun dev` → `localhost:3060/studio`).
+- UI studies / visual spec: `design/studio` (tracked shared-Studio app;
+  `bun dev` → `localhost:3060/studio`).
 - The CLI operates on the same files as the app:
   `blink ls/cat/new/present/type/write/search/rm/path/workspace`; see
   `docs/cli.md`.

--- a/design/studio/.gitignore
+++ b/design/studio/.gitignore
@@ -1,0 +1,11 @@
+# Next.js / build artifacts
+.next/
+out/
+node_modules/
+
+# annotation sidecars are session state, not source
+.studio/annotations/
+
+# misc
+*.tsbuildinfo
+.DS_Store

--- a/design/studio/.studio/AGENTS.md
+++ b/design/studio/.studio/AGENTS.md
@@ -1,0 +1,27 @@
+# Blink Studio + Local Agents
+
+This studio follows the shared studio hybrid workflow: human iteration in the
+browser, zero-friction pickup by local agents.
+
+## Human surface (browser)
+
+- Doc pages (`plans/v2-plan`, `plans/ui-map`, `foundations/functionality-v1`)
+  render through `<AnnotatableDoc>`: click blocks or select spans to leave
+  notes, 🎤 for dictation, ★ to pin the notes that should become decisions.
+- Study pages (`studies/*`) are live macOS and iOS mockups with design intent,
+  specs, and open questions. Controlled comparisons keep product behavior and
+  fixture data fixed while visual treatments vary.
+
+## Local agent surface
+
+- Annotations persist to `.studio/annotations/<sanitized-key>.json` via the
+  local API route (`app/api/studio/annotations/route.ts`).
+- Any local process can `cat` those sidecars or hit
+  `GET /api/studio/annotations?key=<href>`.
+- Pinned notes are derived into structured `TreatmentDecision`s via
+  `annotationsToDecisions`.
+
+## Source of truth
+
+The plan documents are NOT copied into this app — `app/api/docs/[doc]/route.ts`
+reads them live from `blink/docs/`. Edit the markdown, refresh the page.

--- a/design/studio/README.md
+++ b/design/studio/README.md
@@ -1,0 +1,30 @@
+# Blink Studio
+
+Design studio for **Blink** across macOS and iOS. Spatial panel, menubar, and
+command studies live beside controlled companion-app comparisons and the
+product's source documents.
+
+Built on the shared [`studio`](https://github.com/arach/studio) primitives,
+consumed via the studio repo's Bun workspace—the same shared shell and registry
+model used by Hudson and OpenScout, without copying their project-specific
+navigation.
+
+## Run
+
+```sh
+# install once, from the shared studio workspace root
+cd ~/dev/studio && bun install
+
+# then
+cd ~/dev/blink/design/studio
+bun dev        # → http://localhost:3060/studio
+```
+
+## Layout
+
+- `src/studio/studioRegistry.ts` — taxonomy (foundations / plans / studies) + pages
+- `src/studio/studies/` — live macOS and iOS UI studies
+- `src/studio/studies/IOSDesignDirectionsStudy.tsx` — controlled Opus / Grok / Kimi iOS comparison + Index Tape synthesis
+- `specs/` — agent-authored design directions retained as source material
+- `app/api/docs/` — serves `blink/docs/*.md` so plan pages render the real files
+- `.studio/annotations/` — sidecars written by in-browser annotations (pins, dictation); terminal agents read these back

--- a/design/studio/app/api/docs/[doc]/route.ts
+++ b/design/studio/app/api/docs/[doc]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+// Serves the real planning docs from the blink repo's docs/ directory so the
+// studio renders the single source of truth instead of copies.
+
+const DOCS: Record<string, string> = {
+  'v2-plan': 'v2-plan.md',
+  'ui-map': 'v2-ui-map.md',
+  'functionality-v1': 'functionality-v1.md',
+  'notes-representation': 'notes-representation.md',
+  'config': 'config.md',
+};
+
+const DOCS_DIR = join(process.cwd(), '..', '..', 'docs');
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ doc: string }> },
+) {
+  const { doc } = await params;
+  const filename = DOCS[doc];
+  if (!filename) {
+    return NextResponse.json({ ok: false, error: 'unknown doc' }, { status: 404 });
+  }
+
+  try {
+    const body = await readFile(join(DOCS_DIR, filename), 'utf8');
+    return NextResponse.json({ ok: true, doc, body });
+  } catch (err) {
+    return NextResponse.json({ ok: false, error: String(err) }, { status: 500 });
+  }
+}

--- a/design/studio/app/api/studio/annotations/route.ts
+++ b/design/studio/app/api/studio/annotations/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { writeFile, readFile, mkdir } from 'fs/promises';
+import { join } from 'path';
+
+// Real local persistence for annotations. Writes sidecar JSON files so local
+// agents (Cursor, scout, terminal Claude, etc.) can read design feedback from
+// the workspace at any time.
+//
+// Convention: .studio/annotations/<sanitized-key>.json
+
+const STUDIO_DIR = join(process.cwd(), '.studio');
+const ANNOTATIONS_DIR = join(STUDIO_DIR, 'annotations');
+
+async function ensureDir() {
+  await mkdir(ANNOTATIONS_DIR, { recursive: true });
+}
+
+function sanitizeKey(key: string): string {
+  return key.replace(/[^a-zA-Z0-9-_]/g, '-').replace(/-+/g, '-').toLowerCase();
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { persistKey, slug, annotations, decisions } = body;
+
+    const key = sanitizeKey(persistKey || slug || 'unknown');
+    const payload = {
+      updatedAt: new Date().toISOString(),
+      slug,
+      persistKey: key,
+      annotations: annotations ?? [],
+      decisions: decisions ?? [],
+    };
+
+    await ensureDir();
+    const filePath = join(ANNOTATIONS_DIR, `${key}.json`);
+    await writeFile(filePath, JSON.stringify(payload, null, 2), 'utf8');
+
+    return NextResponse.json({ ok: true, key, filePath, written: payload });
+  } catch (err) {
+    console.error('[blink-studio/api] persist error', err);
+    return NextResponse.json({ ok: false, error: String(err) }, { status: 500 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const rawKey = searchParams.get('key') || searchParams.get('slug');
+  if (!rawKey) {
+    return NextResponse.json({ ok: false, error: 'key or slug required' }, { status: 400 });
+  }
+
+  const key = sanitizeKey(rawKey);
+  const filePath = join(ANNOTATIONS_DIR, `${key}.json`);
+
+  try {
+    const content = await readFile(filePath, 'utf8');
+    const data = JSON.parse(content);
+    return NextResponse.json({ ok: true, key, filePath, data });
+  } catch {
+    return NextResponse.json({ ok: true, key, filePath, data: null });
+  }
+}

--- a/design/studio/app/globals.css
+++ b/design/studio/app/globals.css
@@ -1,0 +1,39 @@
+@import "tailwindcss";
+@import "hudsonkit/styles";
+@import "studio/theme.css";
+@import "studio/doc.css";
+@import "studio/shell.css";
+
+@source "../app/**/*.{ts,tsx}";
+@source "../src/**/*.{ts,tsx}";
+@source "../node_modules/hudsonkit/src/**/*.{ts,tsx}";
+@source "../node_modules/studio/src/**/*.{ts,tsx}";
+
+@theme inline {
+  --color-studio-canvas: var(--studio-canvas);
+  --color-studio-canvas-alt: var(--studio-canvas-alt);
+  --color-studio-surface: var(--studio-surface);
+  --color-studio-ink: var(--studio-ink);
+  --color-studio-ink-strong: var(--studio-ink-strong);
+  --color-studio-ink-faint: var(--studio-ink-faint);
+  --color-studio-edge: var(--studio-edge);
+  --color-studio-rule: var(--studio-rule);
+  --color-studio-rule-strong: var(--studio-rule-strong);
+  --color-studio-chip-bg: var(--studio-chip-bg);
+  --color-studio-chip-border: var(--studio-chip-border);
+  --color-scout-accent: var(--scout-accent);
+  --color-scout-accent-soft: var(--scout-accent-soft);
+  --tracking-eyebrow: 0.18em;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--studio-canvas);
+  color: var(--studio-ink);
+  font-family: var(--studio-font-sans);
+}

--- a/design/studio/app/layout.tsx
+++ b/design/studio/app/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { getHudsonThemeScript } from "hudsonkit/theme-script";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Blink Studio",
+  description:
+    "Design studio for Blink v2 — spatial note panels, menubar capture, and command-flow studies before the Swift/AppKit build.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: getHudsonThemeScript({
+              storageKey: "blink.studio.theme",
+              defaultTheme: "dark",
+              defaultTemplate: "hudson",
+            }),
+          }}
+        />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/design/studio/app/page.tsx
+++ b/design/studio/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function RootPage() {
+  redirect("/studio");
+}

--- a/design/studio/app/studio/[[...slug]]/page.tsx
+++ b/design/studio/app/studio/[[...slug]]/page.tsx
@@ -1,0 +1,5 @@
+import { StudioApp } from "@/studio/StudioApp";
+
+export default function StudioRoute() {
+  return <StudioApp />;
+}

--- a/design/studio/next-env.d.ts
+++ b/design/studio/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/design/studio/next.config.ts
+++ b/design/studio/next.config.ts
@@ -1,0 +1,16 @@
+import type { NextConfig } from "next";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// This app lives at ~/dev/blink/design/studio but consumes `studio` and
+// `hudsonkit` from sibling repos (~/dev/studio, ~/dev/hudson) via the studio
+// bun workspace. Pin Turbopack's root to the common ancestor (~/dev) so it can
+// resolve the symlinked packages instead of mis-inferring the workspace root.
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const nextConfig: NextConfig = {
+  turbopack: { root: path.resolve(here, "../../..") },
+  transpilePackages: ["hudsonkit", "studio"],
+};
+
+export default nextConfig;

--- a/design/studio/package.json
+++ b/design/studio/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "blink-studio",
+  "description": "Cross-platform product and interface studies for Blink.",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "studio dev --port 3060 -- next dev --port 3060",
+    "dev:raw": "next dev --port 3060",
+    "build": "next build",
+    "start": "next start --port 3060",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-webgl": "^0.19.0",
+    "@xterm/xterm": "^6.0.0",
+    "html2canvas-pro": "^2.0.0",
+    "hudsonkit": "workspace:*",
+    "lucide-react": "^0.574.0",
+    "next": "^16.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "studio": "file:../../../studio"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.3.0",
+    "@types/node": "^20",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "tailwindcss": "^4.3.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/design/studio/postcss.config.mjs
+++ b/design/studio/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/design/studio/specs/ios-field-log.md
+++ b/design/studio/specs/ios-field-log.md
@@ -1,0 +1,63 @@
+# Blink iOS — Field Log
+
+Pure visual direction by **Grok**, returned through Scout as
+`ref:z-a8x57g`. Product behavior is deliberately unchanged.
+
+## Thesis
+
+The companion is a pocket instrument for recalling a spatial desk, not a
+miniature library. Paper carries content; graphite frames structure; signal
+blue is the only live system color. The composition reads **status → scope →
+log → search** and stays calm when the Mac is unavailable.
+
+## Composition
+
+- Large `blink` title with a thin material toolbar.
+- A rounded trust capsule above the notes: connection state, peer, and snapshot
+  age are system status rather than list content.
+- `LOG / {SCOPE}` instrument rail with a trailing record count.
+- Continuous paper bands: title + relative time, two-line excerpt, then one
+  workspace and one tag.
+- A 48pt thumb-reachable search dock floats above the home indicator.
+- Reader: mono `MARKDOWN / READ ONLY` kicker, New York title, one hairline,
+  Markdown body, and restrained outlined tags.
+
+## Tokens
+
+| Token | Light | Dark |
+| --- | --- | --- |
+| canvas | `#F2ECE0` | `#07100B` |
+| surface | `#F9F4E9` | `#101C15` |
+| raised | `#FFFCF5` | `#17271D` |
+| ink | `#181711` | `#F4EDDD` |
+| secondary | `#5C5548` | `#B9B09F` |
+| faint | `#6D6452` | `#918978` |
+| hairline | `#D1C5AE` | `#2D4637` |
+| signal | `#2D5DAF` | `#83B4FF` |
+| amber | `#8B6B2F` | `#D6B96C` |
+
+The backdrop is canvas plus one soft signal radial. Paper bands are opaque;
+only toolbar and search dock use material.
+
+## Type law
+
+- SF Pro: navigation, row titles, excerpts, Markdown body.
+- SF Mono: scope rail, sync telemetry, timestamps, tags, and trust state.
+- New York: reader title and primary Markdown headings only.
+
+## Must have
+
+1. Trust capsule → instrument rail → paper bands → search dock.
+2. Signal blue is the only interaction accent; amber means retained/offline
+   state only.
+3. Paper rows use hairlines and very little shadow—no card-in-card stack.
+4. iPad uses a 320–360pt list beside a centered reader capped at 720pt.
+5. Dynamic Type stacks timestamps below titles and turns the sync capsule into
+   a vertical block at accessibility sizes.
+
+## Optional flourish
+
+- A pressed-paper top highlight on the trust capsule and search dock.
+- A subtle light-mode dock shadow.
+- A two-point signal selection rail in the iPad sidebar.
+- Pairing-code completion animation when Reduce Motion is off.

--- a/design/studio/specs/ios-index-tape.md
+++ b/design/studio/specs/ios-index-tape.md
@@ -1,0 +1,235 @@
+# Blink iOS — Index Tape
+
+Pure visual synthesis by **Grok**, merging Opus **Paper Tape** and Kimi
+**Ledger** into one direction. Product behavior is deliberately unchanged.
+
+Controlled fixture (unchanged across the study matrix): Launch scope, offline
+copy updated 2h ago, 3 REC, three notes (Launch checklist / Pairing notes /
+Design review), same device geometry, read-only.
+
+---
+
+## 1. Thesis
+
+**Chronology is the structure; ledger is the discipline.**
+
+The pocket companion cannot be a desk, so it becomes a **carbon copy of the
+desk log**: one continuous paper tape running under a machine rail. The rail
+holds everything the machine knows — entry index, static time stamp, pin. The
+paper holds only what a human wrote. Geometry is sharp and full-bleed (Ledger);
+composition is chronological and dense (Paper Tape). Offline is the product
+working, not a warning.
+
+This is not a feature bag. One system wins every conflict:
+
+| Conflict | Winner | Why |
+| --- | --- | --- |
+| Rounded cards vs zero-radius rules | Ledger | Soft cards read as iOS library; the desk is instrumented paper |
+| Capsule / strip vs status rule | Paper Tape | Density and offline-as-success need the rule, not a hero card |
+| Time rail vs numbered index | **Both, one gutter** | Rail stamps carry `%02d` over static time; pin replaces the index |
+| Bottom dock vs top search | Paper Tape placement, Ledger sharpness | Thumb reach for compact; zero-radius mono field, not a pill |
+| Forest dark vs graphite | Graphite | Same product as the Mac popover |
+| Amber offline vs neutral offline | Neutral | Offline is the promised state |
+
+---
+
+## 2. Screen composition
+
+### Log (iPhone, compact)
+
+```
+┌──────────────────────────────────────────────┐
+│ [mark]                                   ((•))│  toolbar: workspace mark / link
+│ Launch                                       │  large title = workspace scope
+│ ════════════════════════════════════════════ │  2pt status rule (state-colored)
+│ ■  OFFLINE COPY · UPDATED 2H AGO             │  square pip + mono line
+│                                              │
+│ LOG / LAUNCH                           3 REC │  instrument header
+├────┬─────────────────────────────────────────┤
+│ 01 │ Launch checklist                        │
+│14:22│ Verify the encrypted LAN handshake —   │
+│  ▪ │ read notes after the Mac disconnects…   │
+│    │ launch · #release                       │
+├────┼─────────────────────────────────────────┤
+│ 02 │ Pairing notes                           │
+│ MON│ Payloads are sealed end to end…         │
+│    │ hudson · #security                      │
+├────┼─────────────────────────────────────────┤
+│ 03 │ Design review                           │
+│4 AUG│ Keep note recall calm…                 │
+│    │ blink · #ios                            │
+└────┴─────────────────────────────────────────┘
+│ SEARCH · LAUNCH                              │  sharp bottom index field
+└──────────────────────────────────────────────┘
+```
+
+Vertical rhythm: toolbar 34 · title 40 · status rule+line 30 · section 24 ·
+rows (min 84) · bottom field 36.
+
+### Reader
+
+```
+   ■ MARKDOWN / READ ONLY     ← mono kicker + mark (only signal on the page)
+   Launch checklist           ← New York large title
+   AUG 1, 2026 · 17:20 · LAUNCH
+   ──────────────────────────
+   body…
+   #release  #ios             ← sharp mono chips (0 radius or 2pt max)
+```
+
+Leading 28pt index gutter echoes the list rail (`01` at title baseline). Flat
+canvas — no floating paper card, no botanical wash.
+
+---
+
+## 3. Color tokens
+
+Graphite-and-paper. **No forest green.** Signal is the sole live accent.
+
+### Light
+
+| Token | Hex | Role |
+| --- | --- | --- |
+| `canvas` | `#F2F0EC` | ground |
+| `surface` | `#FCFAF6` | plate / pressed |
+| `raised` | `#FFFFFF` | search field fill |
+| `rail` | `#EBE7DF` | machine gutter |
+| `rule` | `#DAD5CB` | hairlines |
+| `ink` | `#17130F` | titles, body |
+| `secondary` | `#5C554F` | excerpts |
+| `faint` | `#6F695F` | mono meta |
+| `signal` | `#2D5DAF` | live only |
+| `signal-soft` | `rgba(45,93,175,0.10)` | selection wash / match |
+| `amber` | `#7E6029` | degraded data only |
+
+### Dark
+
+| Token | Hex | Role |
+| --- | --- | --- |
+| `canvas` | `#0A0B0C` | ground |
+| `surface` | `#121416` | plate / pressed |
+| `raised` | `#17191C` | search field fill |
+| `rail` | `#0E1012` | machine gutter |
+| `rule` | `#2A2E31` | hairlines |
+| `ink` | `#FBEEE8` | titles (warm paper memory) |
+| `secondary` | `#9AA0A2` | excerpts |
+| `faint` | `#7A7F81` | mono meta |
+| `signal` | `#83B4FF` | live only |
+| `signal-soft` | `rgba(131,180,255,0.14)` | selection wash / match |
+| `amber` | `#D6B96C` | degraded data only |
+
+### Signal rule
+
+One live thing per screen: status rule when linked/syncing, **or** search-match
+highlight while querying, **or** the reader kicker mark. Never all three.
+
+### Amber rule
+
+Amber only for `snapshot.issues > 0` or data older than 7 days. **Offline copy
+is neutral ink** — square pip is `ink-ghost` / faint, not amber.
+
+---
+
+## 4. Row anatomy
+
+```
+│◄── 48 ──►│◄ plate ─────────────────────────────│
+│  01      │  Launch checklist                   │
+│  14:22   │  excerpt two lines…                 │
+│   ▪      │  launch · #release                  │
+│          ├─────────────────────────────────────│  separator at plate lead
+```
+
+| Zone | Spec |
+| --- | --- |
+| Rail width | 48pt (`rail` fill), trailing 1px `rule` |
+| Index | mono 9pt, `%02d`, `faint`, right-aligned. **Pin replaces index** (5×5 ink square) when pinned — Ledger law |
+| Stamp | mono 8pt static time under index: `14:22` / `MON` / `4 AUG` — Paper Tape law, never live-relative |
+| Title | SF 13pt semibold, `ink`, 1 line. No chevron, no trailing time |
+| Excerpt | SF 10pt, `secondary`, 2 lines |
+| Meta | mono 8pt, `faint`: `workspace · #tag` |
+| Corners | **0 radius** everywhere on the list |
+| Selection | `signal-soft` plate wash + 2pt signal bar on rail leading edge |
+
+---
+
+## 5. Search and sync
+
+### Sync
+
+Full-bleed **2pt rule** under the large title + one mono line with a **6pt square
+pip** leading.
+
+| State | Rule | Pip | Line |
+| --- | --- | --- | --- |
+| Offline copy (fixture) | `rule` / ghost | square, faint | `OFFLINE COPY · UPDATED 2H AGO` |
+| Linked | `signal` @ 55% | square, signal | `LINKED · HOST · 2H AGO` |
+| Syncing | signal sweep | square, signal | `SYNCING` |
+| Degraded | amber | square, amber | `N NOTES RETAINED · …` |
+
+### Search
+
+Bottom **index field**, full width minus 0 inset to side rules: height 36pt,
+**0 radius**, `raised` fill, top hairline only (reads as a ledger footer, not a
+floating pill). Placeholder mono tracked: `SEARCH · LAUNCH`. Scope is stated
+inside the field.
+
+While querying: section `LOG` → `MATCHES`; optional match weight + `signal-soft`
+fill on hits.
+
+---
+
+## 6. Light / dark, iPad, motion, a11y
+
+- Light: warm-neutral paper. Dark: neutral graphite. No green gradient.
+- Elevation by hairlines only on phone; iPad reader may use one restrained sheet
+  shadow if the split study needs spatial depth later.
+- iPad: 340pt sidebar = same Index Tape list; detail = flat reader with leading
+  index gutter; search moves to sidebar top at regular width.
+- Motion: row press 120ms fill; sync rule color 220ms; Reduce Motion → opacity
+  cuts only.
+- A11y: row is one element; rail stamps hidden from VoiceOver; Dynamic Type
+  collapses rail content onto the plate; contrast ≥ 4.5:1 for body text; state
+  never color-only.
+
+---
+
+## 7. Three unmistakable details
+
+1. **Indexed machine rail** — continuous gutter with `%02d` over static time;
+   pin square replaces the index, never decorates the title.
+2. **Sync as rule + square** — Paper Tape density meets Ledger’s square state
+   language; offline is quiet success.
+3. **Zero-radius carbon geometry** — full-bleed rules, sharp search footer, no
+   soft library cards.
+
+---
+
+## 8. Must-have vs optional
+
+**Must-have**
+
+1. Workspace as large title; `blink` reduced to mark-as-scope control.
+2. 48pt rail with index + static stamp; pin replaces index.
+3. Sync rule + square pip; offline neutral.
+4. Zero-radius list and search field; no chevrons.
+5. Graphite dark; signal rationed; amber degraded-only.
+6. Two-type-worlds: SF / mono / New York labor split.
+7. Controlled fixture content unchanged.
+
+**Optional**
+
+1. Day-boundary perforation on the rail rule.
+2. Pull-to-refresh filling the rail with signal.
+3. Match-centered excerpt window while searching.
+4. iPad floating reader sheet (borrow Paper Tape only if split study needs it).
+
+---
+
+## 9. Lineage
+
+| Inherited from | Kept |
+| --- | --- |
+| Paper Tape (Opus) | Continuous tape, rail stamps, workspace title, sync-as-rule, offline neutral, bottom search placement, two-type worlds, graphite |
+| Ledger (Kimi) | Zero-radius rules, entry indices, square pip, pin-replaces-index, selection bar, flat reader, sharp mono discipline |
+| Rejected from both | Paper Tape’s soft search pill radius; Ledger’s top native search as compact primary; Field Log capsule / forest dark (out of scope for this merge) |

--- a/design/studio/specs/ios-ledger.md
+++ b/design/studio/specs/ios-ledger.md
@@ -1,0 +1,59 @@
+# Blink iOS — Ledger
+
+Pure visual direction by **Kimi**, returned through Scout as
+`ref:0-4qjlsi`. Product behavior is deliberately unchanged.
+
+## Thesis
+
+Blink on iOS should be a page from the same book as the macOS capture popover,
+not a rounded cousin. Notes become entries in a ruled field log: sharp corners,
+numbered rows, mono metadata, and signal blue reserved for scope, selection,
+and sync.
+
+## Composition
+
+- Standard large-title navigation with `blink` and native toolbar controls.
+- Native top search field; the floating bottom dock is intentionally rejected.
+- A 44pt, full-width sync strip with a six-point **square** state pip.
+- `LOG / ALL NOTES · N REC` sits directly on the canvas.
+- Full-bleed zero-radius rows with numbered mono indices, hairlines, and a
+  two-point selection rule.
+- Reader: flat canvas, mono kicker, New York title, one metadata line, and no
+  decorative material.
+
+## Tokens
+
+| Token | Light | Dark |
+| --- | --- | --- |
+| canvas | `#F3EEE2` | `#0C0E10` |
+| raised | `#FAF6EC` | `#131619` |
+| hairline | `#D8CDB6` | `#262B30` |
+| ink | `#1A1915` | `#E8E9E4` |
+| secondary | `#5A5446` | `#9BA09C` |
+| faint | `#746C5F` | `#7C8280` |
+| signal | `#2D5DAF` | `#7FA9F5` |
+| amber | `#8B6B2F` | `#D6B96C` |
+
+No gradients, shadows, or blur materials. Dark mode is neutral graphite rather
+than the landing page's forest.
+
+## Row anatomy
+
+`%02d` index or signal pin → title + short relative time → two-line excerpt →
+uppercase workspace + first tag. The disclosure chevron is removed. Selected
+rows receive only a signal wash and a two-point leading rule.
+
+## Must have
+
+1. Zero-radius ruled rows—no card stack, rounded sync card, or floating search.
+2. A square sync pip paired with explicit state copy.
+3. SF Pro for content, SF Mono for telemetry, and New York only in the reader.
+4. Neutral graphite dark mode and one signal-blue accent.
+5. iPad keeps the same ruled list in a 320pt sidebar with a flat reader column.
+
+## Optional flourish
+
+- Numbered rows may be cut if density becomes too mechanical.
+- The syncing pip may blink at the landing page's 1.06s caret cadence.
+- Search matches may receive a restrained signal tint.
+- Pins may replace rather than precede the row index.

--- a/design/studio/specs/ios-paper-tape.md
+++ b/design/studio/specs/ios-paper-tape.md
@@ -1,0 +1,419 @@
+# Blink iOS — "Paper Tape"
+
+A purely visual design direction for the read-only iOS/iPadOS companion.
+Scope: composition, hierarchy, material, type, row anatomy, motion, responsive
+behavior. **No product behavior changes.** Preserved as-is: read-only,
+offline-first recall; list, search, workspace scope, peer sync status, note
+detail; native iPhone/iPad idiom.
+
+Target medium: a code-native study in `design/studio` (registered alongside
+`MenubarPopoverStudy` / `NotePanelStudy`), not a ship-ready patch to
+`apps/ios/BlinkMobile/ContentView.swift`.
+
+---
+
+## 1. Thesis
+
+**On the Mac, Blink is spatial. In the pocket, Blink is chronological.**
+
+The phone cannot give you a desk, so it should stop pretending. What it can give
+you is the same workspace **read as a continuous tape** — a paper column of notes
+running under a graphite instrument rail that carries everything the machine
+knows (time, pin, day boundaries, sync). The paper stays clean because the rail
+absorbs the metadata.
+
+That split — *human ink on paper, machine ink on graphite* — is the whole
+direction. It is the same graphite-and-paper world as the Mac popover
+(`CapturePopoverView`), rotated 90° into a single scrolling column.
+
+### What this direction fixes in the current build
+
+| Observed | Read |
+| --- | --- |
+| Dark mode surfaces are forest green (`#07100B`/`#101C15`/`#2D4637`) | Inherited from the landing page's `[data-theme="black"]`, not from the app. The Mac popover's dark world is neutral graphite. The phone currently looks like a different product than the Mac. |
+| `Available offline` sits in a card with an **amber** dot | Amber reads as warning. Offline is this product's *correct, default, promised* state. The hero feature is being drawn as a fault. |
+| Title block + sync card consume ~40% of the first viewport | Three note rows visible on a 6.9" display. A recall app should show the log. |
+| `Text(note.updatedAt, style: .relative)` → `6 hrs, 23 mins` | Live-ticking, two-unit, variable-width. Noisy, and it re-lays out the row while you read. |
+| Separators inset to ~x=136 | Aligned to nothing in the row. Reads as an accident. |
+| Disclosure chevrons on custom-filled rows | Redundant with the push affordance; adds a third right-edge element after the timestamp. |
+| No search match highlighting | The single biggest functional gap for a recall-first product. |
+
+---
+
+## 2. Screen composition
+
+### 2.1 List (iPhone, compact)
+
+```
+┌──────────────────────────────────────────────┐
+│ ⧉                                         ((•))│  toolbar: mark+workspace / link
+│                                              │
+│ Launch                                       │  large title = WORKSPACE
+│ ──────────────────────────────────────────── │  status rule (2pt, state-colored)
+│ LINKED · STUDIO-MINI · 2H AGO                │  mono status line  (tap → sheet)
+│                                              │
+│ LOG                                    7 REC │  instrument header
+├──────┬───────────────────────────────────────┤
+│14:22 │ Launch checklist                      │
+│  ▪   │ Verify the encrypted LAN handshake —  │
+│      │ read notes after the Mac disconnects… │
+│      │ launch · #release                     │
+│      ├─────────────────────────────────────  │
+│ MON  │ Pairing notes                         │
+│      │ Payloads are sealed end to end …      │
+│      │ hudson · #security                    │
+│      ├─────────────────────────────────────  │
+│ 4 AUG│ Saturday                              │
+│  ▲   │ ← rail (44pt)   ▲ plate                │
+└──────┴───────────────────────────────────────┘
+        ╭──────────────────────────────╮
+        │ ⌕  SEARCH · LAUNCH           │        bottom search pill
+        ╰──────────────────────────────╯
+```
+
+**Must-have moves**
+
+1. **The workspace is the large title.** `blink` shrinks to the `BlinkMark` in
+   the leading toolbar item (which is already the workspace menu — so the mark
+   *is* the scope control). The biggest text on screen tells you where you are,
+   matching the Mac's workspace scope. Wordmark-as-title is vanity; it is the
+   one thing the user never needs to be told.
+2. **Sync card → status rule.** ~110pt of card becomes a 2pt full-bleed rule +
+   one mono line, ~34pt total. Net recovery: ~6 rows in the first viewport
+   instead of 3.
+3. **The rail** (§4) is introduced as a persistent 44pt leading gutter.
+4. Search stays bottom-anchored and thumb-reachable — that placement is already
+   right; only its typography and match feedback change.
+
+Vertical rhythm from the safe-area top: toolbar 44 · large title block 52 ·
+status rule + line 34 · 16 gap · instrument header 26 · rows.
+
+### 2.2 Detail (reader)
+
+Unchanged structure, tightened:
+
+```
+   ▪ MARKDOWN / READ ONLY            ← eyebrow, mono, ink-muted
+   Launch checklist                  ← serif largeTitle, ink-strong
+   AUG 1, 2026 · 17:20 · LAUNCH      ← mono meta, one line, no icon
+   ────────────────────────────────  ← rule, full measure
+   (body)
+   #release  #ios                    ← mono chips at the foot
+```
+
+- The eyebrow's `▪` is the `BlinkMark`, 14pt, signal. It is the only signal-blue
+  element in the reader.
+- Meta collapses to one mono line; drop the `square.grid.2x2` glyph — at 12pt it
+  is texture, not information. The workspace name in mono says it better.
+- Body measure clamped to **68 characters** (≈ the existing 720pt cap, expressed
+  typographically so it survives Dynamic Type).
+- Optional: a 1px `rule`-colored vertical line at the reader's leading margin,
+  full column height — the rail's echo, so detail and list feel like one object.
+
+---
+
+## 3. Color tokens
+
+Two palettes, both graphite-and-paper. **No green anywhere.** The landing page's
+forest world is the marketing site's identity; the app's is the popover's.
+
+### 3.1 Light — *Paper*
+
+| Token | Hex | Use | Contrast on `paper-0` |
+| --- | --- | --- | --- |
+| `paper-0` | `#F2F0EC` | canvas | — |
+| `paper-1` | `#FCFAF6` | plate, pressed row, reader sheet | — |
+| `paper-2` | `#E8E5DF` | recessed field, search pill | — |
+| `rail` | `#EBE7DF` | rail gutter fill | — |
+| `rule` | `#DAD5CB` | hairlines, separators | 1.28 (non-text) |
+| `ink-strong` | `#17130F` | titles, reader body | 16.2 |
+| `ink` | `#342F2A` | primary body | 11.6 |
+| `ink-mid` | `#5C554F` | excerpt | 6.4 |
+| `ink-muted` | `#6F695F` | mono meta, rail stamps | 4.8 |
+| `ink-faint` | `#8F8880` | ≥17pt or decorative only | 3.1 |
+| `ink-ghost` | `#ADA79E` | never text; dividers/ticks | 2.1 |
+| `signal` | `#2D5DAF` | the one live thing | 5.6 |
+| `signal-soft` | `rgba(45,93,175,0.10)` | search match fill | — |
+| `amber` | `#7E6029` | **degraded data only** | 5.1 |
+
+### 3.2 Dark — *Graphite*
+
+| Token | Hex | Use | Contrast on `graphite-0` |
+| --- | --- | --- | --- |
+| `graphite-0` | `#0A0B0C` | canvas | — |
+| `graphite-1` | `#121416` | plate, pressed row | — |
+| `graphite-2` | `#17191C` | reader sheet, search pill | — |
+| `rail` | `#0E1012` | rail gutter fill | — |
+| `rule` | `#2A2E31` | hairlines, separators | 1.44 (non-text) |
+| `ink-strong` | `#FBEEE8` | titles, reader body (warm — paper remembered) | 17.4 |
+| `ink` | `#D2D5D3` | primary body | 13.3 |
+| `ink-mid` | `#9AA0A2` | excerpt | 7.4 |
+| `ink-muted` | `#7A7F81` | mono meta, rail stamps | 4.9 |
+| `ink-faint` | `#5F6467` | ≥17pt or decorative only | ~3.2 |
+| `ink-ghost` | `#3D4143` | never text; dividers/ticks | 1.9 |
+| `signal` | `#83B4FF` | the one live thing | 9.3 |
+| `signal-soft` | `rgba(131,180,255,0.14)` | search match fill | — |
+| `amber` | `#D6B96C` | **degraded data only** | 10.3 |
+
+Both palettes are lifted from `PopoverPalette.light` / `.dark`
+(`CapturePopoverView.swift:1645–1700`) so the two apps are provably one product.
+`ink-mid`/`ink-muted` are retuned to clear 4.5:1; the current
+`secondaryInk`/`faintInk` do not.
+
+### 3.3 The signal rule (must-have)
+
+> **Signal blue marks exactly one thing per screen: what is live right now.**
+
+- List: the status rule + its square, *or* the search-match highlight when
+  searching. Never both.
+- Row: nothing. Pins are `ink-strong`, not signal — a pin is a user's decision,
+  not a live event.
+- Reader: the eyebrow mark, and list-item bullets. Nothing else.
+
+Everything else is ink. This is what stops a warm-neutral app from turning into
+a blue-accented iOS template.
+
+### 3.4 The amber rule (must-have)
+
+> **Amber means "this data is not what it claims."**
+
+Only: `snapshot.issues > 0` (last-known notes retained), or a snapshot older
+than 7 days. **Being offline is not amber.** Offline is neutral ink — it is the
+product working.
+
+---
+
+## 4. Note-row anatomy
+
+Two zones, separated by a continuous 1px `rule` running the full length of the
+list. Minimum row height 72pt.
+
+```
+│◄── 44 ──►│◄── 14 ──►│                                    │◄18►│
+│          │                                                     │
+│   14:22  │  Launch checklist                                   │  ← title
+│          │  Verify the encrypted LAN handshake — read notes    │  ← excerpt
+│     ▪    │  after the Mac disconnects…                         │
+│          │  launch · #release                                  │  ← mono meta
+│          ├─────────────────────────────────────────────────────│  ← separator
+```
+
+### Rail (44pt, `rail` fill)
+
+| Element | Spec |
+| --- | --- |
+| Stamp | mono 11pt medium, tracking 0.6, `ink-muted`, right-aligned to rail trailing −10, baseline aligned to the title's first baseline |
+| Stamp format | `14:22` today · `MON` this week · `4 AUG` this year · `8·25` older. **Static** — computed once at snapshot load, never `Text(style: .relative)` |
+| Pin | 5×5pt filled square, `ink-strong`, centered in the rail, 8pt below the stamp. Echoes `BlinkMark`'s two offset squares |
+| Day tick *(optional)* | at each date boundary the rail's trailing rule thickens to 2pt for 10pt — a perforation |
+
+The rail's continuity is the point. It is the tape; the rows are what is printed
+on it.
+
+### Plate
+
+| Line | Spec |
+| --- | --- |
+| Title | `.headline` semibold, `ink-strong`, 1 line, truncate tail. **No trailing timestamp, no chevron** |
+| Excerpt | `.subheadline`, `ink-mid`, 2 lines, `lineSpacing 2` |
+| Meta | mono `.caption` 12pt, `ink-muted`, 1 line: `workspace · #tag`. No SF Symbol. Row omitted entirely when both are absent |
+| Padding | top 12 / bottom 13 / trailing 18 |
+| Separator | 1px `rule`, **leading inset = 58pt** (rail 44 + plate lead 14), full-bleed trailing. Replaces the current arbitrary ~136pt inset |
+| Press | plate fill → `paper-1` / `graphite-1`, 120ms ease-out. No scale, no bounce |
+
+### Accessibility sizes (≥ AX1)
+
+The rail **collapses**: its content moves to the top of the plate as a mono line
+(`14:22` / `MON 4 AUG` long form), rail fill removed, separator inset drops to
+18pt. All HStacks become VStacks; excerpt 2 → 4 lines; title allowed 3 lines.
+This is the same collapse strategy already in the codebase — keep it, now with
+one thing to collapse instead of four.
+
+---
+
+## 5. Search and sync
+
+### 5.1 Search
+
+- Bottom pill, `paper-2` / `graphite-2` fill, 1px `rule`, radius 22, 52pt tall.
+- Placeholder: mono 15pt `ink-muted`, `SEARCH · <WORKSPACE>` — the scope is
+  stated inside the field, so a search in a workspace can never be mistaken for
+  a global one.
+- On focus the instrument header swaps `LOG` → `MATCHES` and the count becomes
+  live (this already exists in `BlinkSectionHeader` — keep it, it's good).
+- **Match highlighting (must-have):** matched substrings in title and excerpt get
+  `signal-soft` fill (2pt horizontal padding, 3pt radius) **and** semibold
+  weight. Weight carries it for color-blind and high-contrast users.
+- Excerpt becomes **match-centered** while searching: the 2 shown lines window
+  around the first body hit rather than always starting at the note's head.
+  Recall products live or die on this.
+- Empty result keeps `ContentUnavailableView.search(text:)` — native, correct.
+
+### 5.2 Sync
+
+Card → **rule**. Full-bleed 2pt bar directly under the large title, plus one mono
+11pt line, tracking 1.0. Whole block is one tappable target (visual 34pt,
+touch 44pt) opening the existing connection sheet.
+
+| State | Rule | Square | Line |
+| --- | --- | --- | --- |
+| Offline copy | `ink-ghost` | none | `OFFLINE COPY · UPDATED 2H AGO` (`ink-muted`) |
+| Connecting | `signal` @ 40% | none | `CONNECTING · STUDIO-MINI` |
+| Linked | `signal` @ 55% | 5pt `signal` | `LINKED · STUDIO-MINI · 2H AGO` |
+| Syncing | `signal` sweep (§7) | 5pt `signal` | `SYNCING` |
+| Degraded | `amber` | 5pt `amber` | `3 NOTES RETAINED · UPDATED 6D AGO` |
+
+State is **never** color-only — the mono word always names it.
+
+The `internaldrive` / `lock.fill` icon tile is dropped. A 38pt icon to say
+"offline" in an app whose entire premise is offline is a tautology occupying
+prime real estate.
+
+---
+
+## 6. Light / dark behavior
+
+- Both modes ship the full token set; `UITraitCollection` resolves them (keep the
+  existing `adaptive(light:dark:)` helper — only the values change).
+- **Light** is warm-neutral paper. `BlinkBackdrop`'s radial signal wash drops to
+  `0.05` and moves to `UnitPoint(0.92, -0.04)` — a hint of daylight from the
+  corner, not a tint.
+- **Dark** is neutral graphite. Backdrop = flat `graphite-0` plus a 1.5% dither
+  at the top-right. **The green gradient is removed entirely.**
+- Elevation is carried by **hairlines, not shadows**, in both modes. One
+  exception: the iPad reader sheet (§7).
+- Nav/toolbar background stays `.ultraThinMaterial` — it is the one place system
+  material is more credible than a custom fill.
+- Increase Contrast: `rule` → `ink-faint`, `ink-mid` → `ink`, `signal-soft`
+  opacity → 0.20, all separators to 1.5pt.
+
+---
+
+## 7. iPad adaptation
+
+`NavigationSplitView(.balanced)`, sidebar 340pt (min 300, max 400).
+
+- **Sidebar = the tape.** Identical rail + plate anatomy; stamps take their long
+  form (`MON 14:22`). Selected row: `paper-1`/`graphite-1` fill with a **3pt
+  signal bar in the rail** — the selection is live, so it earns the blue.
+- **Detail = the panel on the desk.** This is the one place the spatial metaphor
+  survives to iPad, and it is why iPad is not a large phone:
+
+  - The reader is a **floating sheet**, not a full-bleed scroll view.
+  - `paper-1` / `graphite-2` fill, 1px `rule`, radius 14, max width 680pt,
+    centered on the `paper-0`/`graphite-0` canvas.
+  - Padding 40 top / 56 sides / 64 bottom.
+  - The **only** shadow in the app: `0 18 40 -18 rgba(40,32,20,0.28)` light,
+    `0 22 48 -20 rgba(0,0,0,0.72)` dark. A note on a desk casts one.
+  - Canvas behind it carries the `TerminalGrid` at 2% — the same grid the
+    popover canvas uses.
+- Search moves to the sidebar top at regular width (system default). The bottom
+  pill is compact-only.
+- Placeholder detail keeps `BlinkMark` + copy, centered in the sheet's footprint
+  with the sheet rendered as a 1px dashed `rule` outline — the empty desk.
+- *Optional:* hardware keyboard — ↑/↓ selection, ⌘F search, `Space` page-down.
+
+---
+
+## 8. Motion
+
+Everything short, everything interruptible. Nothing loops.
+
+| Moment | Spec | Tier |
+| --- | --- | --- |
+| Row press | fill 120ms `easeOut` | must |
+| Push to reader | `.navigationTransition(.zoom)` sourced on the plate (iOS 18+); title cross-fades headline → serif largeTitle. Absent below 18 — no custom fallback | must |
+| Sync state change | 220ms color cross-fade on rule + line | must |
+| Snapshot arrival | square scales 1.0 → 1.35 → 1.0 over 300ms, **once** | must |
+| Syncing sweep | 900ms `signal` gradient traveling L→R along the 2pt rule, repeating only while `isSyncing` | must |
+| Pull-to-refresh | the rail fills top-down with `signal` in proportion to pull distance — the tape advancing — then releases | optional, high payoff |
+| Row insertion after sync | 200ms fade + 6pt rise, staggered 20ms, capped at 6 rows | optional |
+
+`.accessibilityReduceMotion` → all of the above become 150ms opacity
+cross-fades; the sweep becomes a static `signal` @ 40% bar; the pull fill becomes
+a static state change. No exceptions.
+
+---
+
+## 9. Accessibility constraints (all must-have)
+
+1. Body and secondary text ≥ 4.5:1; `ink-faint` only at ≥17pt or decorative;
+   `ink-ghost` never carries text.
+2. No state encoded by color alone — sync always names itself in words; search
+   matches carry weight as well as fill.
+3. **The row is one accessibility element.**
+   `label`: `"<title>, <workspace>, updated <full relative date>"` + `", pinned"`.
+   `value`: excerpt. `traits`: `.isButton`.
+   The rail stamp is `.accessibilityHidden(true)` — `8·25` and `MON` are display
+   abbreviations and must never reach VoiceOver.
+4. Dynamic Type through AX5 with the §4 collapse. No text truncated below its
+   stated line allowance at any size.
+5. Every tap target ≥ 44×44pt, including the visually-34pt sync rule.
+6. The instrument header keeps its combined a11y label
+   (`"Launch, 7 notes"`) — the `LOG / … / 7 REC` construction is visual only.
+7. Reader keeps `.textSelection(.enabled)` and `.isHeader` traits on headings.
+8. Mono tracking ≤ 1.2 anywhere it exceeds 3 words — tracked uppercase is a label
+   device, not a text device.
+
+---
+
+## 10. The three details that make it unmistakable
+
+1. **The rail.** A 44pt graphite gutter running unbroken down the whole list,
+   holding the time, the pin, and the day perforations, and turning signal-blue
+   as you pull to refresh. No other notes app has one. It is why the screen reads
+   as a *tape* rather than a table, and it is what lets the paper column stay
+   completely clean.
+
+2. **The two-type-worlds law.** Everything a human wrote is set in system text
+   and New York serif on paper. Everything the machine knows — times, counts,
+   workspaces, tags, sync state, `MARKDOWN / READ ONLY` — is SF Mono, uppercase,
+   tracked, in the graphite tier. There is no third register and nothing crosses
+   over. One glance tells you which words are yours.
+
+3. **Sync as a line, not a badge.** The peer-sync state is a 2pt rule spanning the
+   full width under the title — quiet ink when you are offline (because that is
+   the promise being kept), signal when a Mac is linked, a traveling sweep while
+   it syncs, amber only when the data is stale. It occupies 34pt instead of 110pt
+   and it is the first thing your eye crosses on the way to the notes.
+
+---
+
+## 11. Must-have vs optional
+
+**Must-have — the direction does not exist without these**
+
+1. Dark palette re-alignment to graphite; forest green removed.
+2. Amber demoted to degraded-data-only; offline rendered neutral.
+3. Header collapse — workspace as large title, sync as a rule.
+4. The rail, with static (non-ticking) stamps.
+5. The two-type-worlds law.
+6. Signal rationed to one live thing per screen.
+7. Separators aligned to the plate leading edge (58pt).
+8. Search match highlighting, fill + weight, with match-centered excerpts.
+9. iPad reader as a floating sheet on the canvas.
+10. The full §9 accessibility set.
+
+**Optional flourish — cut freely under time pressure**
+
+1. Pull-to-refresh rail fill.
+2. Zoom navigation transition.
+3. Day-boundary perforation ticks in the rail.
+4. `TerminalGrid` dither on dark canvas / iPad detail canvas.
+5. Staggered row insertion after sync.
+6. The reader's leading rule echoing the rail.
+7. iPad hardware-keyboard navigation.
+
+---
+
+## 12. Notes for the study build
+
+- Register as `IOSPaperTapeStudy` in `design/studio/src/studio/studioRegistry.ts`,
+  alongside `MenubarPopoverStudy`.
+- Render three frames: iPhone list (light), iPhone list (dark), iPhone reader
+  (dark), plus one iPad split (either mode).
+- Drive both palettes off one token object so the light/dark flip is a single
+  prop — the study's job is to prove the two modes are the same design, which is
+  precisely what the current build cannot claim.
+- Reuse the landing site's mono stack for the machine tier; SF Mono is the
+  shipping equivalent.

--- a/design/studio/src/studio/StudioApp.tsx
+++ b/design/studio/src/studio/StudioApp.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { createElement } from "react";
+import { Eye, StickyNote } from "lucide-react";
+import { StudioHudsonApp } from "studio/app-shell";
+import { NextRouterProvider } from "studio/router/next";
+import { renderStudioPage } from "@/studio/StudioPages";
+import {
+  BUCKETS,
+  HOME_HREF,
+  STATUS_COLORS,
+  registry,
+  statusPalette,
+} from "@/studio/studioRegistry";
+
+export function StudioApp() {
+  return (
+    <StudioHudsonApp
+      app={{
+        id: "blink",
+        name: "Blink Studio",
+        description:
+          "Design studio for Blink across macOS and iOS — spatial note panels on the desk, offline-first recall in the pocket.",
+        icon: createElement(StickyNote, { size: 14 }),
+        leftPanel: {
+          title: "Blink",
+          icon: createElement(Eye, { size: 12 }),
+        },
+      }}
+      registry={registry}
+      buckets={BUCKETS}
+      statusColors={STATUS_COLORS}
+      renderStatusPill={(status) => statusPalette.StatusPill({ status })}
+      renderPage={renderStudioPage}
+      homeHref={HOME_HREF}
+      routerProvider={NextRouterProvider}
+      theme={{
+        storageKey: "blink.studio.theme",
+        defaultTheme: "dark",
+        defaultTemplate: "hudson",
+      }}
+    />
+  );
+}

--- a/design/studio/src/studio/StudioPages.tsx
+++ b/design/studio/src/studio/StudioPages.tsx
@@ -1,0 +1,563 @@
+"use client";
+
+import React, { type ReactNode } from "react";
+import { AppWindow, ArrowRight, Command, FileText, Grid3x3, Layers, MenuSquare } from "lucide-react";
+import {
+  AnnotatableDoc,
+  annotationsToDecisions,
+  DataRow,
+  EngDocSheet,
+  persistAnnotations,
+} from "studio/doc";
+import type { StudioHudsonRenderContext } from "studio/app-shell";
+import { useStudioRouter } from "studio/router";
+import { CommandPaletteStudy } from "@/studio/studies/CommandPaletteStudy";
+import { EditorModesStudy } from "@/studio/studies/EditorModesStudy";
+import { GridOverlayStudy } from "@/studio/studies/GridOverlayStudy";
+import { IOSDesignDirectionsStudy } from "@/studio/studies/IOSDesignDirectionsStudy";
+import { MenubarPopoverStudy } from "@/studio/studies/MenubarPopoverStudy";
+import { NotePanelStudy } from "@/studio/studies/NotePanelStudy";
+import { SettingsStudy } from "@/studio/studies/SettingsStudy";
+import { StacksStudy } from "@/studio/studies/StacksStudy";
+import { StylePermutationsStudy } from "@/studio/studies/StylePermutationsStudy";
+import {
+  HOME_HREF,
+  pages,
+  registry,
+  type BlinkStudioPage,
+  type Bucket,
+  type Status,
+  type Surface,
+} from "@/studio/studioRegistry";
+
+type RenderContext = StudioHudsonRenderContext<Bucket, Surface, Status>;
+
+/** Doc pages render the real files from blink/docs via /api/docs. */
+const DOC_PAGES: Record<string, string> = {
+  "/studio/foundations/functionality-v1": "functionality-v1",
+  "/studio/foundations/notes-representation": "notes-representation",
+  "/studio/plans/v2-plan": "v2-plan",
+  "/studio/plans/ui-map": "ui-map",
+};
+
+type Study = {
+  component: () => React.JSX.Element;
+  intent: string;
+  specs: Array<[string, string]>;
+  open: string[];
+};
+
+const STUDIES: Record<string, Study> = {
+  "/studio/studies/ios-design-directions": {
+    component: IOSDesignDirectionsStudy,
+    intent:
+      "Three independent visual systems for the same read-only iOS companion, authored through Scout by Opus, Grok, and Kimi. The fixture, product behavior, data state, and device frame are held constant so the comparison is about hierarchy, type, material, and density—not feature drift.",
+    specs: [
+      ["agents", "Opus · Grok · Kimi (fresh Scout sessions)"],
+      ["fixtures", "same notes · same sync state · same iPhone frame"],
+      ["controls", "log ↔ reader · light ↔ dark"],
+      ["target", "apps/ios/BlinkMobile/ContentView.swift"],
+      ["status", "studio-only · no production behavior changes"],
+    ],
+    open: [
+      "Which structural idea should anchor the production direction: Paper Tape's rail, Field Log's paper bands, or Ledger's ruled density?",
+      "Should Blink's dark app world remain botanical graphite, or align to the macOS popover's neutral graphite?",
+      "Is offline availability a neutral success state, or does it still need an amber distinction from a live peer?",
+    ],
+  },
+  "/studio/studies/note-panel": {
+    component: NotePanelStudy,
+    intent:
+      "The note is the window. At rest a panel is glass and text — no sidebar, no toolbar. The footer (word count, save state, edit/preview, dictate) appears on hover and recedes otherwise. Middle-click the title bar to shade down to the 28px bar.",
+    specs: [
+      ["window class", "NSPanel · nonactivating · HudVisualEffectView glass"],
+      ["title bar", "28px · drag region · auto-title (first line) · save pip"],
+      ["editor", "WKWebView · CodeMirror 6 · no gutters · word wrap"],
+      ["footer", "hover-revealed · words · save state · ✎/preview · 🎙"],
+      ["persistence", "geometry + shade per note · restore exact on relaunch"],
+    ],
+    open: [
+      "Does the resting panel keep the traffic lights, or do those also fade until hover?",
+      "Shade interaction: middle-click vs double-click the title bar (or both)?",
+    ],
+  },
+  "/studio/studies/menubar-popover": {
+    component: MenubarPopoverStudy,
+    intent:
+      "Home base. Capture in under a second: one field does search, create (⌘↵), and dictation. Recents open as panels — hover a row for ⤢ to fling it onto the desktop. Footer is palette + settings only: triad-only means no Library entry.",
+    specs: [
+      ["anchor", "NSStatusItem (eye glyph) + NSPopover, transient"],
+      ["field", "type = search · ⌘↵ = new note · 🎙 = dictate into new note"],
+      ["recents", "last ~6 notes · click = open panel (reuse if open) · ⤢ = place"],
+      ["identity", "one panel per note — opening an open note focuses it"],
+      ["footer", "⌘K palette · ⚙ settings (no Library — triad-only)"],
+    ],
+    open: [
+      "Row click: open panel at remembered position vs near the menubar?",
+      "Does drag-out of a recent row (drag-to-detach) start from the popover in v2.0, or M3+?",
+    ],
+  },
+  "/studio/studies/command-palette": {
+    component: CommandPaletteStudy,
+    intent:
+      "One input to reach any note or verb — and the palette is spatial: ⌘↵ opens the hit as a floating panel at its remembered spot. This is also the overflow story: with free placement and no Library, the palette is where the long tail of notes lives.",
+    specs: [
+      ["invoke", "⌘K in-app · Hyper+K global (tbd)"],
+      ["groups", "Notes (fuzzy over titles + content) · Actions (verb registry)"],
+      ["keys", "↵ open · ⌘↵ open as panel · ⌘⇧P toggle preview"],
+      ["kit", "HudsonShell command palette · Blink action registry"],
+    ],
+    open: [
+      "Global palette hotkey: reuse ⌘K only in-app, or claim a Hyper chord system-wide?",
+      "Should 'Deploy note → grid slot…' chain directly into the grid overlay?",
+    ],
+  },
+  "/studio/studies/grid-overlay": {
+    component: GridOverlayStudy,
+    intent:
+      "Make spatial legible. v1's grid deploys were invisible muscle memory; Hyper+B shows the 3×3 grid with slot occupancy and QWERTY chord keys, so a new user can see the system a power user feels. Free placement stays the default — the grid is opt-in per action.",
+    specs: [
+      ["invoke", "Hyper+B (deploy mode) · Ctrl⌥⇧1–9 direct"],
+      ["layout", "3×3 · QWERTY row mapping (Q W E / A S D / Z X C)"],
+      ["overlay", "transparent HUD NSPanel · dims desktop · Esc cancels"],
+      ["occupancy", "slots show resident note · deploy to occupied slot swaps focus"],
+    ],
+    open: [
+      "Multi-display: one grid per screen, or grid follows the active screen?",
+      "Should slots be resizable regions (thirds/halves) later, or stay fixed 3×3?",
+    ],
+  },
+  "/studio/studies/editor-modes": {
+    component: EditorModesStudy,
+    intent:
+      "Reading is the rest state of a note on your desktop; the flip must feel like turning a card, not opening an app. Read mode is rendered typography on the same glass, edit mode is the source — same webview, same panel, just the other face.",
+    specs: [
+      ["flip", "⌘⇧P both ways · double-click read→edit"],
+      ["renderer", "marked (GFM) in the same webview · same transparent glass"],
+      ["persistence", "per-note mode remembered · new notes always open in edit"],
+      ["scroll", "preserved proportionally across flips"],
+    ],
+    open: [
+      "Auto-flip to read when a panel loses focus?",
+      "Should double-click place the caret at the clicked paragraph?",
+      "Syntax highlighting inside read-mode code blocks?",
+    ],
+  },
+  "/studio/studies/settings": {
+    component: SettingsStudy,
+    intent:
+      "Settings restraint is a core v2 principle: every knob must justify existing. A small native window — not a panel — with three sections capped to one screen. The good-default rule kills most rows before they are drawn.",
+    specs: [
+      ["window", "small native window · not a panel · ⌘, / gear in popover"],
+      ["storage", "UserDefaults — no config file until sharing matters"],
+      ["sections", "General · Editor · Shortcuts — hard cap one screen"],
+      ["non-settings", "debounce, glass material, panel sizes: good defaults, no knobs"],
+    ],
+    open: [
+      "Launch at login in v2.0 or later?",
+      "Config file (portable/dotfile-able) vs UserDefaults?",
+      "Should shortcuts be rebindable and when?",
+    ],
+  },
+  "/studio/studies/style-permutations": {
+    component: StylePermutationsStudy,
+    intent:
+      "The whole style space in one place. Five sheet templates rendered side by side under a single set of theme controls — accent, tint, corner radius, type, and motion — so you compare permutations instead of catching them one at a time mid-build. Every change maps to a config.json snippet you can copy straight into the app.",
+    specs: [
+      ["axes", "5 sheets × read/edit tint × accent × radius × type × 4 entrances"],
+      ["controls", "grid the discrete (sheets, motion) · slider the continuous"],
+      ["fidelity", "browser backdrop-blur ≈ NSVisualEffectView · sheet chrome faithful"],
+      ["export", "live config.json — panel · editor · motion — copy to clipboard"],
+      ["real target", "~/Library/Application Support/Blink/config.json (hot-applies)"],
+    ],
+    open: [
+      "Export as a diff against defaults — emit only the non-default keys?",
+      "A 'Desk' mode: one full desktop with aged + pinned notes, not just the matrix?",
+      "Wallpaper switcher including plain white — the flat-sheet legibility torture test?",
+      "'Send to Blink': an API route that writes config.json live so the real desk repaints as you drag a slider?",
+    ],
+  },
+  "/studio/studies/stacks": {
+    component: StacksStudy,
+    intent:
+      "The triad has no Library, but idle notes still need somewhere to live that isn't a hidden archive list. This study puts a stacks zone inside a see-all view and asks what the pile should be: four metaphors — card pile, stacked sheets, shelf, messy desk — each keeping parked notes visible, countable, and leaf-through-able. The pile and the sheets tray are hoverable; here, feel is the argument.",
+    specs: [
+      ["context", "one see-all window: active notes grid + a stacks zone for the idle tail"],
+      ["variants", "01 card pile · 02 stacked sheets · 03 shelf · 04 messy desk"],
+      ["interactive", "pile fan-out + per-card lift · sheets accordion (both on hover)"],
+      ["principle", "parked ≠ archived — the count is always visible, never a hidden list"],
+      ["data", "fake notes · title = first line, as in the real store"],
+    ],
+    open: [
+      "Is a stack just 'the idle tail', or does it get identity (name, tag, age range)?",
+      "Primary gesture: drag a note onto the pile, or auto-park after N days idle?",
+      "Does the pile also exist on the desktop itself, or only inside the see-all?",
+    ],
+  },
+};
+
+export function renderStudioPage({ pathname, page }: RenderContext) {
+  if (pathname === HOME_HREF) return <HomePage />;
+  if (page?.href === "/studio/foundations/decisions") {
+    return <DecisionsPage page={page} />;
+  }
+  if (page && DOC_PAGES[page.href]) {
+    return <DocPage page={page} docId={DOC_PAGES[page.href]} />;
+  }
+  if (page && STUDIES[page.href]) {
+    return <StudyPage page={page} study={STUDIES[page.href]} />;
+  }
+  return <NotFoundPage />;
+}
+
+function HomePage() {
+  const { Link } = useStudioRouter();
+  const studyPages = pages.filter((p) => p.bucket === "studies");
+  const docPages = pages.filter(
+    (p) => p.bucket !== "studies" && p.href !== HOME_HREF,
+  );
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-10 lg:px-8">
+      <header className="grid gap-8 border-b border-studio-rule pb-8 lg:grid-cols-[1fr_320px]">
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-eyebrow text-studio-ink-faint">
+            blink / product studio
+          </div>
+          <h1 className="mt-4 max-w-[760px] text-[44px] font-medium leading-tight text-studio-ink-strong">
+            The note is the window. The phone is the pocket view.
+          </h1>
+          <p
+            className="mt-5 max-w-[64ch] text-[15px] leading-[1.7] text-studio-ink"
+            style={{ fontFamily: "var(--studio-font-serif)" }}
+          >
+            Blink keeps the desktop spatial: a menubar capture surface, a
+            command palette, and floating note panels. The iOS companion carries
+            the same Markdown truth as an offline-first, read-only recall surface.
+            This studio holds both worlds together before they move into Swift.
+          </p>
+        </div>
+
+        <EngDocSheet className="self-start">
+          <DataRow label="macOS">Swift / AppKit + HudsonKit</DataRow>
+          <DataRow label="iOS">SwiftUI · BlinkCore · BlinkPeer</DataRow>
+          <DataRow label="truth">frontmattered Markdown files</DataRow>
+          <DataRow label="transport">encrypted LAN · offline cache</DataRow>
+          <DataRow label="studio">shared shell · live studies</DataRow>
+        </EngDocSheet>
+      </header>
+
+      <section className="grid gap-8 py-8 lg:grid-cols-[1fr_320px]">
+        <div>
+          <SectionHeading icon={<AppWindow size={14} />} title="UI Studies" />
+          <ul className="mt-4 divide-y divide-studio-rule border-y border-studio-rule">
+            {studyPages.map((entry) => (
+              <li key={entry.href}>
+                <Link
+                  href={entry.href}
+                  className="group grid gap-3 py-4 transition-colors hover:bg-studio-chip-bg md:grid-cols-[32px_1fr_20px]"
+                >
+                  <span className="self-center text-studio-ink-faint">
+                    {studyIcon(entry.href)}
+                  </span>
+                  <span>
+                    <span className="block text-[15px] font-medium text-studio-ink-strong">
+                      {entry.label}
+                    </span>
+                    <span className="mt-1 block text-[12.5px] leading-relaxed text-studio-ink-faint">
+                      {entry.blurb}
+                    </span>
+                  </span>
+                  <ArrowRight
+                    size={15}
+                    className="self-center text-studio-ink-faint transition-transform group-hover:translate-x-1"
+                  />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <aside>
+          <SectionHeading icon={<FileText size={14} />} title="Foundations & Plans" />
+          <div className="mt-4 border-y border-studio-rule">
+            {docPages.map((entry) => (
+              <Link
+                key={entry.href}
+                href={entry.href}
+                className="block border-b border-studio-rule py-4 last:border-b-0 hover:bg-studio-chip-bg"
+              >
+                <span className="block text-[14px] font-medium text-studio-ink-strong">
+                  {entry.label}
+                </span>
+                <span className="mt-1 block text-[12.5px] leading-relaxed text-studio-ink-faint">
+                  {entry.blurb}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </aside>
+      </section>
+    </main>
+  );
+}
+
+function studyIcon(href: string) {
+  if (href.endsWith("menubar-popover")) return <MenuSquare size={16} />;
+  if (href.endsWith("command-palette")) return <Command size={16} />;
+  if (href.endsWith("grid-overlay")) return <Grid3x3 size={16} />;
+  if (href.endsWith("stacks")) return <Layers size={16} />;
+  return <AppWindow size={16} />;
+}
+
+function StudyPage({ page, study }: { page: BlinkStudioPage; study: Study }) {
+  const Scene = study.component;
+  return (
+    <main className="w-full px-6 py-10 lg:px-7">
+      <PageHeader page={page} />
+      <section className="max-w-[1060px] py-8">
+        <Scene />
+
+        <div className="mt-10 grid gap-10 lg:grid-cols-[1fr_360px]">
+          <div>
+            <SectionHeading icon={<FileText size={13} />} title="Design intent" />
+            <p
+              className="mt-3 max-w-[62ch] text-[14.5px] leading-[1.75] text-studio-ink"
+              style={{ fontFamily: "var(--studio-font-serif)" }}
+            >
+              {study.intent}
+            </p>
+
+            {study.open.length > 0 && (
+              <>
+                <div className="mt-8">
+                  <SectionHeading
+                    icon={<ArrowRight size={13} />}
+                    title="Open questions"
+                  />
+                </div>
+                <ul className="mt-3 space-y-2">
+                  {study.open.map((q) => (
+                    <li
+                      key={q}
+                      className="text-[13px] leading-relaxed text-studio-ink-faint"
+                    >
+                      — {q}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+          </div>
+
+          <EngDocSheet className="self-start">
+            {study.specs.map(([label, value]) => (
+              <DataRow key={label} label={label} labelWidth={104}>
+                {value}
+              </DataRow>
+            ))}
+          </EngDocSheet>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function DecisionsPage({ page }: { page: BlinkStudioPage }) {
+  const decisions: Array<[string, string]> = [
+    [
+      "New codebase",
+      "v1 (Tauri) is a donor of lessons and spec, not code. v2 is Swift/AppKit + WKWebView on HudsonKit.",
+    ],
+    [
+      "Triad only",
+      "Menubar popover + command palette + floating panels. No Library window at v2.0 — add later only if genuinely missed.",
+    ],
+    [
+      "One repo, v1 archived",
+      "v2 lives at the root of arach/blink; v1 (Tauri) under archive/v1, tag v1-final. Hudson via source path dep on ../hudson (Scout convention); HotkeyManager + status-item patterns transplanted from Scout.",
+    ],
+    [
+      "Free placement",
+      "Panels go exactly where you put them. The 3×3 grid is opt-in via Hyper+B. No magnetic snapping.",
+    ],
+    [
+      "Palette is the overflow",
+      "Only opened notes are panels; the long tail lives in recents + palette search. 'Gather panels' command in polish.",
+    ],
+  ];
+
+  const defaults: Array<[string, string]> = [
+    ["one panel per note", "opening an open note focuses it — duplicates impossible by construction"],
+    ["dictation target", "focused panel's caret; if none, a new capture panel. Audio kept until transcript committed"],
+    ["app presence", "LSUIElement menubar-only, no dock icon"],
+    ["editor bundle", "vanilla CodeMirror 6, no React — chrome is native now"],
+    ["repo", "arach/blink root — v1 archived at archive/v1 (tag v1-final)"],
+  ];
+
+  return (
+    <main className="w-full px-6 py-10 lg:px-7">
+      <PageHeader page={page} />
+      <section className="max-w-[860px] py-8">
+        <SectionHeading icon={<FileText size={13} />} title="Locked 2026-07-14" />
+        <ul className="mt-4 divide-y divide-studio-rule border-y border-studio-rule">
+          {decisions.map(([label, body]) => (
+            <li key={label} className="grid gap-2 py-4 md:grid-cols-[220px_1fr]">
+              <span className="text-[14px] font-medium text-studio-ink-strong">
+                {label}
+              </span>
+              <span className="text-[13px] leading-relaxed text-studio-ink-faint">
+                {body}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-10">
+          <SectionHeading
+            icon={<ArrowRight size={13} />}
+            title="Defaults — veto anytime"
+          />
+        </div>
+        <div className="mt-4 max-w-[720px]">
+          <EngDocSheet className="w-full">
+            {defaults.map(([label, value]) => (
+              <DataRow key={label} label={label} labelWidth={150}>
+                {value}
+              </DataRow>
+            ))}
+          </EngDocSheet>
+        </div>
+
+        <p className="mt-8 max-w-[62ch] text-[13px] leading-relaxed text-studio-ink-faint">
+          Hard requirements inherited from v1's bugs: flush saves on
+          note-switch/panel-close, atomic file writes (temp + fsync + rename),
+          metadata lives in the markdown file, sync is bidirectional from day
+          one, and spatial memory is never scrambled.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+function DocPage({ page, docId }: { page: BlinkStudioPage; docId: string }) {
+  const [body, setBody] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/docs/${docId}`)
+      .then((res) => res.json())
+      .then((json) => {
+        if (cancelled) return;
+        if (json.ok) setBody(json.body);
+        else setError(json.error ?? "failed to load doc");
+      })
+      .catch((err) => {
+        if (!cancelled) setError(String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [docId]);
+
+  const slugKey = page.href.replace(/^\//, "").replace(/\//g, "-");
+
+  const handleAnnotationsChange = React.useCallback(
+    async (anns: unknown[]) => {
+      const decisions = annotationsToDecisions
+        ? annotationsToDecisions(page.href, anns as never)
+        : [];
+      await persistAnnotations({
+        persistKey: page.href,
+        slug: page.href,
+        annotations: anns as never,
+        decisions,
+      });
+    },
+    [page.href],
+  );
+
+  return (
+    <main className="w-full px-6 py-10 lg:px-7">
+      <PageHeader page={page} />
+      <section className="max-w-[980px] py-8">
+        {error && (
+          <div className="rounded border border-studio-rule bg-studio-canvas p-3 text-sm text-studio-ink-faint">
+            Could not load <code>docs/{docId}.md</code>: {error}
+          </div>
+        )}
+        {!error && body === null && (
+          <div className="text-sm italic text-studio-ink-faint">Loading…</div>
+        )}
+        {body !== null && (
+          <>
+            <AnnotatableDoc
+              body={body}
+              slug={slugKey}
+              docTitle={page.label}
+              persistKey={page.href}
+              onAnnotationsChange={handleAnnotationsChange}
+            />
+            <p className="mt-6 text-[11px] leading-relaxed text-studio-ink-faint">
+              Annotate blocks or selections (🎤 for dictation, ★ to pin).
+              Everything persists to{" "}
+              <code>.studio/annotations/</code> sidecars — terminal agents read
+              them back directly. Source of truth: <code>blink/docs/{docId}.md</code>.
+            </p>
+          </>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function PageHeader({ page }: { page: BlinkStudioPage }) {
+  return (
+    <header className="max-w-[1060px] border-b border-studio-rule pb-7">
+      <div className="font-mono text-[10px] uppercase tracking-eyebrow text-studio-ink-faint">
+        {registry.bucketLabel(page.bucket)} /{" "}
+        {page.surface ? registry.surfaceLabel(page.surface) : "default"}
+      </div>
+      <h1 className="mt-4 text-[38px] font-medium leading-tight text-studio-ink-strong">
+        {page.label}
+      </h1>
+      {page.blurb ? (
+        <p
+          className="mt-4 max-w-[66ch] text-[15px] leading-[1.7] text-studio-ink"
+          style={{ fontFamily: "var(--studio-font-serif)" }}
+        >
+          {page.blurb}
+        </p>
+      ) : null}
+    </header>
+  );
+}
+
+function SectionHeading({ icon, title }: { icon: ReactNode; title: string }) {
+  return (
+    <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-eyebrow text-studio-ink-faint">
+      {icon}
+      {title}
+    </div>
+  );
+}
+
+function NotFoundPage() {
+  const { Link } = useStudioRouter();
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-16 lg:px-8">
+      <h1 className="text-[34px] font-medium text-studio-ink-strong">
+        Page not found.
+      </h1>
+      <Link
+        href={HOME_HREF}
+        className="mt-6 inline-flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-studio-ink-faint hover:text-studio-ink"
+      >
+        Back to Blink Studio
+        <ArrowRight size={13} />
+      </Link>
+    </main>
+  );
+}

--- a/design/studio/src/studio/studies/CommandPaletteStudy.tsx
+++ b/design/studio/src/studio/studies/CommandPaletteStudy.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { DesktopScene, glassHeavy } from "./DesktopScene";
+
+/**
+ * Study: the command palette — one input to reach any note or verb.
+ *
+ * The spatial twist: ⌘↵ opens the hit as a floating panel instead of just
+ * selecting it. The palette can *place* notes, not only find them.
+ */
+export function CommandPaletteStudy() {
+  return (
+    <DesktopScene height={560}>
+      <div className="pointer-events-none absolute inset-0 z-10 bg-black/35" />
+
+      <div
+        className={
+          "absolute left-1/2 top-[16%] z-30 w-[560px] -translate-x-1/2 rounded-xl " +
+          glassHeavy
+        }
+      >
+        {/* Input */}
+        <div className="flex items-center gap-3 border-b border-white/[0.1] px-4 py-3.5">
+          <span className="rounded border border-white/[0.15] bg-white/[0.06] px-1.5 py-0.5 font-mono text-[10px] text-white/50">
+            ⌘K
+          </span>
+          <span className="flex-1 text-[14px] text-white/50">
+            type a note or a command…
+            <span className="animate-pulse text-white/80">▏</span>
+          </span>
+        </div>
+
+        {/* Notes group */}
+        <div className="px-2 pt-2">
+          <GroupLabel>Notes</GroupLabel>
+          <Row selected icon="📄" label="Meeting notes" />
+          <Row icon="📄" label="Roadmap Q3" />
+        </div>
+
+        {/* Actions group */}
+        <div className="px-2 pb-2 pt-1">
+          <GroupLabel>Actions</GroupLabel>
+          <Row icon="✦" label="New note" kbd="⌘N" />
+          <Row icon="⤢" label="Deploy note → grid slot…" />
+          <Row icon="◧" label="Toggle preview" kbd="⌘⇧P" />
+          <Row icon="🎙" label="Dictate into current note" />
+        </div>
+
+        {/* Key legend */}
+        <div className="flex items-center gap-4 border-t border-white/[0.1] px-4 py-2.5 text-[11px] text-white/40">
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span className="text-white/60">⌘↵ open as panel</span>
+          <span className="ml-auto">esc dismiss</span>
+        </div>
+      </div>
+
+      {/* Caption chip */}
+      <div className="absolute bottom-4 left-4 z-30 rounded-md bg-black/40 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-white/60 backdrop-blur-sm">
+        ⌘↵ spawns a spatial panel — the palette places notes, not just finds them
+      </div>
+    </DesktopScene>
+  );
+}
+
+function GroupLabel({ children }: { children: string }) {
+  return (
+    <div className="px-2 pb-1 pt-1.5 font-mono text-[9px] uppercase tracking-[0.2em] text-white/35">
+      {children}
+    </div>
+  );
+}
+
+function Row({
+  icon,
+  label,
+  kbd,
+  selected = false,
+}: {
+  icon: string;
+  label: string;
+  kbd?: string;
+  selected?: boolean;
+}) {
+  return (
+    <div
+      className={
+        "flex cursor-default items-center gap-3 rounded-md px-2.5 py-[7px] " +
+        (selected ? "bg-white/[0.1]" : "hover:bg-white/[0.06]")
+      }
+    >
+      <span className="w-5 text-center text-[13px]">{icon}</span>
+      <span
+        className={
+          "flex-1 text-[13.5px] " + (selected ? "text-white" : "text-white/80")
+        }
+      >
+        {label}
+      </span>
+      {kbd && (
+        <span className="rounded border border-white/[0.12] bg-white/[0.05] px-1.5 py-0.5 font-mono text-[10px] text-white/45">
+          {kbd}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/design/studio/src/studio/studies/DesktopScene.tsx
+++ b/design/studio/src/studio/studies/DesktopScene.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+/**
+ * A simulated macOS desktop that every Blink study renders into. Self-contained
+ * dark wallpaper so glass materials read the same in both studio themes.
+ */
+export function DesktopScene({
+  children,
+  menubar = false,
+  dimmed = false,
+  height = 560,
+}: {
+  children: ReactNode;
+  menubar?: boolean;
+  dimmed?: boolean;
+  height?: number;
+}) {
+  return (
+    <div
+      className="relative w-full select-none overflow-hidden rounded-xl border border-studio-edge shadow-[0_30px_80px_rgba(0,0,0,0.35)]"
+      style={{
+        height,
+        background:
+          "radial-gradient(120% 90% at 15% 10%, #2b3a67 0%, transparent 55%)," +
+          "radial-gradient(100% 80% at 85% 20%, #4c2f63 0%, transparent 50%)," +
+          "radial-gradient(90% 90% at 70% 95%, #173f4e 0%, transparent 55%)," +
+          "radial-gradient(70% 70% at 30% 80%, #3d2b4f 0%, transparent 60%)," +
+          "#101322",
+      }}
+    >
+      {menubar && (
+        <div className="absolute inset-x-0 top-0 z-10 flex h-7 items-center justify-between border-b border-white/[0.06] bg-black/25 px-3 backdrop-blur-md">
+          <div className="flex items-center gap-4 text-[12px] text-white/80">
+            <span className="text-[13px]"></span>
+            <span className="font-semibold">Finder</span>
+            <span className="text-white/50">File</span>
+            <span className="text-white/50">Edit</span>
+            <span className="text-white/50">View</span>
+          </div>
+          <div className="flex items-center gap-3 text-[11px] text-white/70">
+            <BlinkStatusIcon active />
+            <span>􀙇</span>
+            <span>􀋦</span>
+            <span className="tabular-nums">Tue 9:41 AM</span>
+          </div>
+        </div>
+      )}
+
+      {children}
+
+      {dimmed && (
+        <div className="pointer-events-none absolute inset-0 z-20 bg-black/35" />
+      )}
+    </div>
+  );
+}
+
+/** The Blink status item — an eye glyph in the menubar. */
+export function BlinkStatusIcon({ active = false }: { active?: boolean }) {
+  return (
+    <span
+      className={
+        "flex h-5 items-center rounded px-1.5 " +
+        (active ? "bg-white/20" : "")
+      }
+      title="Blink"
+    >
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" className="text-white/90">
+        <path
+          d="M2 12s3.5-6.5 10-6.5S22 12 22 12s-3.5 6.5-10 6.5S2 12 2 12Z"
+          stroke="currentColor"
+          strokeWidth="1.6"
+        />
+        <circle cx="12" cy="12" r="2.6" fill="currentColor" />
+      </svg>
+    </span>
+  );
+}
+
+/** Standard glass material for mock Blink surfaces. */
+export const glass =
+  "border border-white/[0.14] bg-white/[0.08] shadow-[0_20px_60px_rgba(0,0,0,0.45)] backdrop-blur-2xl";
+
+/** Heavier glass for popover / palette surfaces that sit over content. */
+export const glassHeavy =
+  "border border-white/[0.12] bg-[#1a1d2e]/80 shadow-[0_24px_70px_rgba(0,0,0,0.55)] backdrop-blur-2xl";
+
+export function TrafficLights({ dim = false }: { dim?: boolean }) {
+  const base = "h-[10px] w-[10px] rounded-full";
+  return (
+    <div className={"flex items-center gap-[7px] " + (dim ? "opacity-40" : "")}>
+      <span className={base + " bg-[#ff5f57]"} />
+      <span className={base + " bg-[#febc2e]"} />
+      <span className={base + " bg-[#28c840]"} />
+    </div>
+  );
+}
+
+export function SavePip({ saved = true }: { saved?: boolean }) {
+  return (
+    <span
+      className={
+        "h-[7px] w-[7px] rounded-full " +
+        (saved ? "bg-emerald-400/90" : "bg-amber-400/90")
+      }
+      title={saved ? "saved" : "unsaved changes"}
+    />
+  );
+}

--- a/design/studio/src/studio/studies/EditorModesStudy.tsx
+++ b/design/studio/src/studio/studies/EditorModesStudy.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { DesktopScene, SavePip, TrafficLights, glass } from "./DesktopScene";
+
+/**
+ * Study: edit ↔ read mode — two faces of one surface.
+ *
+ * The same note rendered twice, side by side:
+ *  - edit mode: the markdown source with dimmed markers and a caret
+ *  - read mode: the same content rendered as typography on glass
+ *
+ * The flip happens in place — ⌘⇧P both ways, double-click read→edit — so it
+ * feels like turning a card, not opening a different app.
+ */
+export function EditorModesStudy() {
+  return (
+    <DesktopScene height={520}>
+      {/* Edit mode — the markdown source */}
+      <div
+        className={
+          "absolute left-[6%] top-[12%] flex w-[400px] flex-col rounded-xl " +
+          glass
+        }
+        style={{ height: 330 }}
+      >
+        <PanelTitleBar title="Panels spec" saved />
+        <div className="flex-1 overflow-hidden px-5 py-4 font-mono text-[12.5px] leading-[1.8] text-white/85">
+          <p>
+            <span className="text-white/30"># </span>
+            <span className="font-semibold text-white/95">Floating panels</span>
+          </p>
+          <p className="mt-2">
+            The note is the window —{" "}
+            <span className="text-white/30">**</span>glass and text
+            <span className="text-white/30">**</span>, nothing more.
+          </p>
+          <p className="mt-2">
+            <span className="text-white/30">- </span>chrome earned on hover
+          </p>
+          <p>
+            <span className="text-white/30">- </span>shade to a 28px bar
+            <span className="animate-pulse text-white">▏</span>
+          </p>
+          <p className="mt-2">
+            <span className="text-white/30">&gt; </span>free placement stays the
+            default
+          </p>
+          <p className="mt-2">
+            run <span className="text-white/30">`</span>Hyper+B
+            <span className="text-white/30">`</span> to deploy
+          </p>
+        </div>
+        <div className="flex h-8 items-center rounded-b-xl border-t border-white/[0.08] px-4 text-[11px] text-white/55">
+          <span>✎ editing · ⌘⇧P to read</span>
+        </div>
+      </div>
+
+      {/* Read mode — the same content rendered as typography */}
+      <div
+        className={
+          "absolute right-[6%] top-[12%] flex w-[400px] flex-col rounded-xl " +
+          glass
+        }
+        style={{ height: 330 }}
+      >
+        <PanelTitleBar title="Panels spec" saved dim />
+        <div className="flex-1 overflow-hidden px-6 py-5">
+          <h1 className="text-[20px] font-bold leading-tight text-white/96">
+            Floating panels
+          </h1>
+          <p className="mt-3 text-[13.5px] leading-[1.7] text-white/80">
+            The note is the window —{" "}
+            <span className="font-semibold text-white/95">glass and text</span>,
+            nothing more.
+          </p>
+          <ul className="mt-3 space-y-1 text-[13.5px] leading-[1.7] text-white/80">
+            <li className="flex gap-2">
+              <span className="text-white/30">•</span>chrome earned on hover
+            </li>
+            <li className="flex gap-2">
+              <span className="text-white/30">•</span>shade to a 28px bar
+            </li>
+          </ul>
+          <blockquote className="mt-3 border-l-2 border-white/20 pl-3 text-[13px] italic leading-[1.7] text-white/55">
+            free placement stays the default
+          </blockquote>
+          <p className="mt-3 text-[13.5px] leading-[1.7] text-white/80">
+            run{" "}
+            <code className="rounded-[3px] bg-white/[0.07] px-1.5 py-0.5 font-mono text-[12px] text-white/85">
+              Hyper+B
+            </code>{" "}
+            to deploy
+          </p>
+        </div>
+        <div className="flex h-8 items-center rounded-b-xl px-6 text-[11px] text-white/45">
+          <span>◧ reading · double-click to edit</span>
+        </div>
+      </div>
+
+      {/* Caption chip */}
+      <div className="absolute bottom-4 left-4 rounded-md bg-black/40 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-white/60 backdrop-blur-sm">
+        two faces of one surface — flips in place, scroll preserved
+      </div>
+    </DesktopScene>
+  );
+}
+
+function PanelTitleBar({
+  title,
+  saved,
+  dim = false,
+}: {
+  title: string;
+  saved: boolean;
+  dim?: boolean;
+}) {
+  return (
+    <div className="flex h-7 shrink-0 items-center justify-between border-b border-white/[0.08] px-3">
+      <TrafficLights dim={dim} />
+      <span
+        className={
+          "pointer-events-none absolute left-1/2 -translate-x-1/2 text-[11px] font-medium " +
+          (dim ? "text-white/40" : "text-white/55")
+        }
+      >
+        {title}
+      </span>
+      <SavePip saved={saved} />
+    </div>
+  );
+}

--- a/design/studio/src/studio/studies/GridOverlayStudy.tsx
+++ b/design/studio/src/studio/studies/GridOverlayStudy.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { DesktopScene } from "./DesktopScene";
+
+/**
+ * Study: the spatial grid overlay — Hyper+B makes the 3×3 deploy grid visible.
+ *
+ * v1 had grid deploys as invisible muscle memory. Showing slot occupancy and
+ * the QWERTY chord keys turns a power-user chord into something you can see
+ * and learn. Free placement stays the default; the grid is opt-in per action.
+ */
+
+const SLOTS = [
+  { n: 1, key: "Q", occupied: "Meeting notes" },
+  { n: 2, key: "W" },
+  { n: 3, key: "E" },
+  { n: 4, key: "A" },
+  { n: 5, key: "S", targeted: true },
+  { n: 6, key: "D" },
+  { n: 7, key: "Z" },
+  { n: 8, key: "X" },
+  { n: 9, key: "C", occupied: "Roadmap Q3" },
+] as const;
+
+export function GridOverlayStudy() {
+  return (
+    <DesktopScene height={580}>
+      <div className="pointer-events-none absolute inset-0 z-10 bg-black/40" />
+
+      <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-5 px-10 py-12">
+        <div className="grid h-full w-full max-w-[860px] grid-cols-3 grid-rows-3 gap-4">
+          {SLOTS.map((slot) => (
+            <div
+              key={slot.n}
+              className={
+                "relative rounded-lg border backdrop-blur-[2px] transition-colors " +
+                ("targeted" in slot && slot.targeted
+                  ? "border-white/70 bg-white/[0.12] shadow-[0_0_40px_rgba(255,255,255,0.15)]"
+                  : "border-dashed border-white/[0.22] bg-white/[0.03]")
+              }
+            >
+              <div className="absolute left-2.5 top-2 flex items-center gap-2">
+                <span className="font-mono text-[11px] text-white/45">{slot.n}</span>
+                <span className="rounded border border-white/[0.2] bg-white/[0.08] px-1.5 py-0.5 font-mono text-[11px] font-semibold text-white/80">
+                  {slot.key}
+                </span>
+              </div>
+
+              {"occupied" in slot && slot.occupied && (
+                <div className="absolute inset-x-3 bottom-3 top-9 rounded-md border border-white/[0.14] bg-white/[0.08] px-3 py-2 backdrop-blur-xl">
+                  <span className="text-[11px] text-white/70">
+                    ● {slot.occupied}
+                  </span>
+                </div>
+              )}
+
+              {"targeted" in slot && slot.targeted && (
+                <span className="absolute inset-x-0 bottom-3 text-center font-mono text-[10px] uppercase tracking-[0.2em] text-white/70">
+                  deploy here
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="rounded-md bg-black/45 px-4 py-2 font-mono text-[11px] text-white/65 backdrop-blur-sm">
+          Hyper+B → key to deploy · Esc to cancel
+        </div>
+      </div>
+    </DesktopScene>
+  );
+}

--- a/design/studio/src/studio/studies/IOSDesignDirectionsStudy.module.css
+++ b/design/studio/src/studio/studies/IOSDesignDirectionsStudy.module.css
@@ -1,0 +1,1260 @@
+.study {
+  --study-rule: color-mix(in srgb, var(--studio-ink-faint) 28%, transparent);
+  width: 100%;
+}
+
+.controlBar {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 26px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--study-rule);
+}
+
+.controlKicker,
+.agentLine {
+  margin: 0;
+  font-family: var(--studio-font-mono), ui-monospace, monospace;
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--studio-ink-faint);
+}
+
+.controlCopy {
+  max-width: 58ch;
+  margin: 6px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--studio-ink);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.segmented {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--study-rule);
+  border-radius: 10px;
+  background: var(--studio-canvas-alt);
+}
+
+.segmented button {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--studio-ink-faint);
+  font: 600 11px/1 var(--studio-font-sans), sans-serif;
+  cursor: pointer;
+}
+
+.segmented button:hover {
+  color: var(--studio-ink-strong);
+}
+
+.segmented button:focus-visible {
+  outline: 2px solid #2d5daf;
+  outline-offset: 2px;
+}
+
+.segmented button[aria-pressed="true"] {
+  background: var(--studio-surface);
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--studio-ink-strong) 10%, transparent);
+  color: var(--studio-ink-strong);
+}
+
+.matrix {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(280px, 1fr));
+  gap: 20px;
+  overflow-x: auto;
+  padding: 1px 1px 18px;
+  scroll-snap-type: x mandatory;
+}
+
+.direction {
+  min-width: 0;
+  scroll-snap-align: start;
+}
+
+.directionHeader {
+  min-height: 150px;
+  padding: 0 3px 16px;
+}
+
+.agentLine {
+  display: flex;
+  gap: 7px;
+}
+
+.directionHeader h3 {
+  margin: 10px 0 0;
+  color: var(--studio-ink-strong);
+  font-family: var(--studio-font-serif), ui-serif, serif;
+  font-size: clamp(25px, 2.4vw, 31px);
+  font-weight: 500;
+  letter-spacing: -0.025em;
+}
+
+.directionHeader p {
+  max-width: 33ch;
+  margin: 9px 0 0;
+  color: var(--studio-ink);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.signature {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.signature li {
+  padding: 5px 8px;
+  border: 1px solid var(--study-rule);
+  border-radius: 999px;
+  color: var(--studio-ink-faint);
+  font: 500 10px/1.1 var(--studio-font-mono), monospace;
+}
+
+.phone {
+  --canvas: #f2f0ec;
+  --surface: #fcfaf6;
+  --raised: #ffffff;
+  --rail: #ebe7df;
+  --rule: #dad5cb;
+  --ink: #17130f;
+  --secondary: #5c554f;
+  --faint: #6f695f;
+  --signal: #2d5daf;
+  --signal-soft: rgba(45, 93, 175, 0.1);
+  --amber: #7e6029;
+  position: relative;
+  width: min(100%, 304px);
+  aspect-ratio: 390 / 844;
+  margin: 0 auto;
+  padding: 7px;
+  border-radius: 42px;
+  background: #050607;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.18) inset,
+    0 24px 44px rgba(3, 5, 6, 0.25);
+}
+
+.paperTape[data-palette="dark"] {
+  --canvas: #0a0b0c;
+  --surface: #121416;
+  --raised: #17191c;
+  --rail: #0e1012;
+  --rule: #2a2e31;
+  --ink: #fbeee8;
+  --secondary: #9aa0a2;
+  --faint: #7a7f81;
+  --signal: #83b4ff;
+  --signal-soft: rgba(131, 180, 255, 0.14);
+  --amber: #d6b96c;
+}
+
+.fieldLog[data-palette="light"] {
+  --canvas: #f2ece0;
+  --surface: #f9f4e9;
+  --raised: #fffcf5;
+  --rail: #ede4d4;
+  --rule: #d1c5ae;
+  --ink: #181711;
+  --secondary: #5c5548;
+  --faint: #6d6452;
+  --signal: #2d5daf;
+  --signal-soft: rgba(45, 93, 175, 0.1);
+  --amber: #8b6b2f;
+}
+
+.fieldLog[data-palette="dark"] {
+  --canvas: #07100b;
+  --surface: #101c15;
+  --raised: #17271d;
+  --rail: #0c1710;
+  --rule: #2d4637;
+  --ink: #f4eddd;
+  --secondary: #b9b09f;
+  --faint: #918978;
+  --signal: #83b4ff;
+  --signal-soft: rgba(131, 180, 255, 0.12);
+  --amber: #d6b96c;
+}
+
+.ledger[data-palette="light"] {
+  --canvas: #f3eee2;
+  --surface: #faf6ec;
+  --raised: #fffaf0;
+  --rail: #ece5d7;
+  --rule: #d8cdb6;
+  --ink: #1a1915;
+  --secondary: #5a5446;
+  --faint: #6d6452;
+  --signal: #2d5daf;
+  --signal-soft: rgba(45, 93, 175, 0.08);
+  --amber: #8b6b2f;
+}
+
+.ledger[data-palette="dark"] {
+  --canvas: #0c0e10;
+  --surface: #131619;
+  --raised: #181b1e;
+  --rail: #101214;
+  --rule: #2f3438;
+  --ink: #e8e9e4;
+  --secondary: #a7aba8;
+  --faint: #7c8280;
+  --signal: #7fa9f5;
+  --signal-soft: rgba(127, 169, 245, 0.12);
+  --amber: #d6b96c;
+}
+
+/* Grok synthesis — Index Tape (Paper Tape × Ledger) */
+
+.indexTape[data-palette="light"] {
+  --canvas: #f2f0ec;
+  --surface: #fcfaf6;
+  --raised: #ffffff;
+  --rail: #ebe7df;
+  --rule: #dad5cb;
+  --ink: #17130f;
+  --secondary: #5c554f;
+  --faint: #6f695f;
+  --signal: #2d5daf;
+  --signal-soft: rgba(45, 93, 175, 0.1);
+  --amber: #7e6029;
+  --ghost: #ada79e;
+}
+
+.indexTape[data-palette="dark"] {
+  --canvas: #0a0b0c;
+  --surface: #121416;
+  --raised: #17191c;
+  --rail: #0e1012;
+  --rule: #2a2e31;
+  --ink: #fbeee8;
+  --secondary: #9aa0a2;
+  --faint: #7a7f81;
+  --signal: #83b4ff;
+  --signal-soft: rgba(131, 180, 255, 0.14);
+  --amber: #d6b96c;
+  --ghost: #3d4143;
+}
+
+.phoneScreen {
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+  border-radius: 35px;
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+}
+
+.fieldLog .phoneScreen {
+  background:
+    radial-gradient(circle at 92% 5%, color-mix(in srgb, var(--signal) 11%, transparent), transparent 28%),
+    linear-gradient(145deg, var(--raised) 0%, var(--canvas) 38%, var(--canvas) 100%);
+}
+
+.statusBar {
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: 5;
+  display: grid;
+  grid-template-columns: 1fr 76px 1fr;
+  align-items: center;
+  height: 28px;
+  padding: 0 15px;
+  color: var(--ink);
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.dynamicIsland {
+  width: 68px;
+  height: 18px;
+  justify-self: center;
+  border-radius: 999px;
+  background: #030404;
+}
+
+.statusIcons {
+  display: flex;
+  align-items: center;
+  justify-self: end;
+  gap: 4px;
+}
+
+.homeIndicator {
+  position: absolute;
+  z-index: 9;
+  bottom: 7px;
+  left: 50%;
+  width: 92px;
+  height: 4px;
+  transform: translateX(-50%);
+  border-radius: 99px;
+  background: var(--ink);
+  opacity: 0.82;
+}
+
+.logScreen,
+.readerScreen {
+  position: absolute;
+  inset: 28px 0 0;
+  overflow: hidden;
+}
+
+.toolbarGlyph,
+.workspaceButton,
+.iconWell {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink);
+}
+
+.mark,
+.markCompact {
+  position: relative;
+  display: inline-block;
+  width: 19px;
+  height: 19px;
+}
+
+.mark span,
+.markCompact span {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid currentColor;
+}
+
+.mark span:first-child,
+.markCompact span:first-child {
+  top: 1px;
+  left: 1px;
+}
+
+.mark span:last-child,
+.markCompact span:last-child {
+  right: 1px;
+  bottom: 1px;
+  background: currentColor;
+}
+
+.markCompact {
+  width: 15px;
+  height: 15px;
+}
+
+.markCompact span {
+  width: 8px;
+  height: 8px;
+  border-width: 1px;
+}
+
+/* Opus — Paper Tape */
+
+.tapeToolbar,
+.fieldToolbar,
+.ledgerToolbar,
+.indexToolbar {
+  display: flex;
+  height: 34px;
+  align-items: center;
+  gap: 3px;
+  padding: 0 13px;
+}
+
+.tapeToolbar .iconWell {
+  margin-right: auto;
+  color: var(--signal);
+}
+
+.tapeTitle,
+.fieldTitle,
+.ledgerTitle,
+.indexTitle {
+  padding: 2px 17px 7px;
+  font-size: 27px;
+  font-weight: 720;
+  letter-spacing: -0.03em;
+}
+
+.tapeStatusRule {
+  height: 2px;
+  background: var(--signal);
+}
+
+.tapeStatus {
+  padding: 7px 17px 6px;
+  color: var(--faint);
+  font: 600 8px/1.2 ui-monospace, "SF Mono", monospace;
+  letter-spacing: 0.085em;
+}
+
+.tapeSection,
+.fieldSection,
+.ledgerSection,
+.indexSection {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 17px 7px;
+  color: var(--faint);
+  font: 600 8px/1.2 ui-monospace, "SF Mono", monospace;
+  letter-spacing: 0.12em;
+}
+
+.tapeSection b,
+.fieldSection b,
+.ledgerSection b,
+.indexSection b {
+  color: var(--signal);
+  font-weight: 700;
+}
+
+.tapeList {
+  border-top: 1px solid var(--rule);
+}
+
+.tapeRow {
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  min-height: 86px;
+}
+
+.tapeRail {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  flex-direction: column;
+  gap: 9px;
+  padding: 13px 9px 0 0;
+  border-right: 1px solid var(--rule);
+  background: var(--rail);
+  color: var(--faint);
+  font: 600 8px/1 ui-monospace, "SF Mono", monospace;
+  letter-spacing: 0.03em;
+}
+
+.tapeRail i {
+  display: block;
+  width: 5px;
+  height: 5px;
+  margin-right: 8px;
+  background: var(--ink);
+}
+
+.notePlate {
+  min-width: 0;
+  padding: 11px 13px 10px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.notePlateTitle {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.notePlateTitle time {
+  flex: 0 0 auto;
+  color: var(--faint);
+  font: 500 8px/1 ui-monospace, "SF Mono", monospace;
+}
+
+.notePlate p {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: 4px 0 0;
+  color: var(--secondary);
+  font-size: 10px;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.notePlateMeta,
+.rowMeta {
+  margin-top: 5px;
+  overflow: hidden;
+  color: var(--faint);
+  font: 500 8px/1.2 ui-monospace, "SF Mono", monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tapeSearch,
+.fieldSearch {
+  position: absolute;
+  z-index: 4;
+  right: 14px;
+  bottom: 16px;
+  left: 14px;
+  display: flex;
+  height: 39px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 13px;
+  border: 1px solid var(--rule);
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--raised) 94%, transparent);
+  box-shadow: 0 9px 22px color-mix(in srgb, var(--ink) 12%, transparent);
+  color: var(--faint);
+}
+
+.tapeSearch span {
+  font: 600 8px/1 ui-monospace, "SF Mono", monospace;
+  letter-spacing: 0.1em;
+}
+
+/* Grok — Field Log */
+
+.fieldToolbar {
+  justify-content: flex-end;
+}
+
+.fieldToolbar .workspaceButton {
+  margin-right: auto;
+  border: 1px solid var(--rule);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--raised) 86%, transparent);
+}
+
+.fieldTitle {
+  padding-bottom: 8px;
+}
+
+.syncCapsule {
+  display: grid;
+  grid-template-columns: 35px 1fr 7px;
+  align-items: center;
+  gap: 9px;
+  margin: 0 14px 6px;
+  padding: 10px;
+  border: 1px solid var(--rule);
+  border-radius: 13px;
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+}
+
+.syncIcon {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  background: var(--signal-soft);
+  color: var(--signal);
+}
+
+.syncCapsule b,
+.syncCapsule small,
+.syncStrip b,
+.syncStrip small {
+  display: block;
+}
+
+.syncCapsule b,
+.syncStrip b {
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.syncCapsule small,
+.syncStrip small {
+  margin-top: 2px;
+  color: var(--faint);
+  font: 500 8px/1.2 ui-monospace, "SF Mono", monospace;
+}
+
+.syncCapsule i,
+.syncStrip i {
+  width: 7px;
+  height: 7px;
+  background: var(--amber);
+  border-radius: 50%;
+}
+
+.fieldRows {
+  margin: 0 10px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--rule) 78%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--surface) 91%, transparent);
+}
+
+.fieldRow {
+  position: relative;
+  min-height: 90px;
+  padding: 10px 27px 9px 13px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.fieldRow:last-child {
+  border-bottom: 0;
+}
+
+.rowTitleLine {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.rowTitleLine > span {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.rowTitleLine svg {
+  color: var(--signal);
+}
+
+.rowTitleLine time {
+  color: var(--faint);
+  font: 500 8px/1 ui-monospace, "SF Mono", monospace;
+}
+
+.fieldRow p {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: 4px 0 0;
+  color: var(--secondary);
+  font-size: 10px;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.rowChevron {
+  position: absolute;
+  top: 15px;
+  right: 9px;
+  color: var(--faint);
+}
+
+.fieldSearch {
+  height: 41px;
+  background: color-mix(in srgb, var(--raised) 95%, transparent);
+}
+
+.fieldSearch span {
+  font-size: 11px;
+}
+
+/* Kimi — Ledger */
+
+.ledgerToolbar {
+  justify-content: flex-end;
+}
+
+.ledgerTitle {
+  padding-bottom: 7px;
+}
+
+.ledgerSearch {
+  display: flex;
+  height: 34px;
+  align-items: center;
+  gap: 8px;
+  margin: 0 13px 7px;
+  padding: 0 11px;
+  background: var(--surface);
+  color: var(--faint);
+  font-size: 10px;
+}
+
+.syncStrip {
+  display: grid;
+  grid-template-columns: 8px 1fr;
+  min-height: 42px;
+  align-items: center;
+  gap: 9px;
+  padding: 6px 17px;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.syncStrip i {
+  width: 6px;
+  height: 6px;
+  border-radius: 0;
+}
+
+.ledgerSection {
+  padding-top: 10px;
+  padding-bottom: 6px;
+}
+
+.ledgerList {
+  border-top: 1px solid var(--rule);
+}
+
+.ledgerRow {
+  position: relative;
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  min-height: 89px;
+}
+
+.ledgerRow::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 2px;
+  background: transparent;
+  content: "";
+}
+
+.ledgerSelected {
+  background: var(--signal-soft);
+}
+
+.ledgerSelected::before {
+  background: var(--signal);
+}
+
+.ledgerIndex {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 13px;
+  color: var(--faint);
+  font: 600 8px/1 ui-monospace, "SF Mono", monospace;
+}
+
+.ledgerIndex svg {
+  color: var(--signal);
+}
+
+.ledgerRow .notePlate {
+  padding-left: 0;
+}
+
+/* Grok — Index Tape (Paper Tape × Ledger) */
+
+.indexToolbar .iconWell {
+  margin-right: auto;
+  color: var(--signal);
+}
+
+.indexTitle {
+  padding-bottom: 6px;
+}
+
+.indexStatusRule {
+  height: 2px;
+  background: var(--ghost, var(--rule));
+}
+
+.indexStatus {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 17px 5px;
+  color: var(--faint);
+  font: 600 8px/1.2 ui-monospace, "SF Mono", monospace;
+  letter-spacing: 0.085em;
+}
+
+.indexStatus i {
+  display: block;
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  background: var(--ghost, var(--faint));
+  border-radius: 0;
+}
+
+.indexSection {
+  padding-top: 10px;
+  padding-bottom: 6px;
+}
+
+.indexList {
+  border-top: 1px solid var(--rule);
+}
+
+.indexRow {
+  position: relative;
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  min-height: 86px;
+}
+
+.indexRow::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 2px;
+  background: transparent;
+  content: "";
+}
+
+.indexSelected {
+  background: var(--signal-soft);
+}
+
+.indexSelected::before {
+  background: var(--signal);
+}
+
+.indexRail {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  padding: 12px 8px 0 0;
+  border-right: 1px solid var(--rule);
+  background: var(--rail);
+}
+
+.indexNum {
+  color: var(--faint);
+  font: 700 9px/1 ui-monospace, "SF Mono", monospace;
+  letter-spacing: 0.04em;
+}
+
+.indexStamp {
+  color: var(--faint);
+  font: 600 7.5px/1 ui-monospace, "SF Mono", monospace;
+  letter-spacing: 0.02em;
+  opacity: 0.92;
+}
+
+.indexPin {
+  display: block;
+  width: 5px;
+  height: 5px;
+  margin-top: 2px;
+  margin-right: 2px;
+  background: var(--ink);
+  border-radius: 0;
+}
+
+.indexRow .notePlate {
+  padding-left: 11px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.indexSearch {
+  position: absolute;
+  z-index: 4;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  height: 42px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 14px 12px;
+  border-top: 1px solid var(--rule);
+  border-radius: 0;
+  background: var(--raised);
+  color: var(--faint);
+  box-shadow: none;
+}
+
+.indexSearch span {
+  font: 600 8px/1 ui-monospace, "SF Mono", monospace;
+  letter-spacing: 0.1em;
+}
+
+.indexReaderGutter {
+  position: absolute;
+  top: 38px;
+  bottom: 0;
+  left: 0;
+  width: 28px;
+  border-right: 1px solid var(--rule);
+  background: var(--rail);
+  color: var(--faint);
+  font: 700 8px/1 ui-monospace, "SF Mono", monospace;
+  text-align: center;
+}
+
+.indexReaderGutter span {
+  position: absolute;
+  top: 28px;
+  right: 0;
+  left: 0;
+}
+
+.indexReaderGutter small {
+  position: absolute;
+  top: 42px;
+  right: 0;
+  left: 0;
+  font: 600 7px/1 ui-monospace, "SF Mono", monospace;
+  letter-spacing: 0.02em;
+}
+
+.indexTapeReader .readerBody {
+  padding-left: 42px;
+  padding-top: 22px;
+}
+
+.indexTapeReader .readerTags span {
+  border-radius: 2px;
+}
+
+/* Reader fixture */
+
+.readerScreen {
+  background: var(--canvas);
+}
+
+.fieldLogReader {
+  background:
+    radial-gradient(circle at 90% 0%, color-mix(in srgb, var(--signal) 9%, transparent), transparent 26%),
+    var(--canvas);
+}
+
+.readerToolbar {
+  display: grid;
+  grid-template-columns: 24px 1fr 24px;
+  height: 38px;
+  align-items: center;
+  padding: 0 13px;
+  border-bottom: 1px solid color-mix(in srgb, var(--rule) 70%, transparent);
+  color: var(--signal);
+  font-size: 11px;
+}
+
+.readerToolbar span {
+  overflow: hidden;
+  color: var(--ink);
+  font-weight: 650;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.readerRail {
+  position: absolute;
+  top: 38px;
+  bottom: 0;
+  left: 0;
+  width: 20px;
+  border-right: 1px solid var(--rule);
+  background: var(--rail);
+  color: var(--faint);
+  font: 600 7px/1 ui-monospace, "SF Mono", monospace;
+  text-align: center;
+}
+
+.readerRail span {
+  position: absolute;
+  right: 3px;
+  left: 2px;
+}
+
+.readerRail span:first-child {
+  top: 29px;
+}
+
+.readerRail span:last-child {
+  top: 176px;
+}
+
+.readerRail i {
+  position: absolute;
+  top: 50px;
+  left: 8px;
+  width: 5px;
+  height: 5px;
+  background: var(--signal);
+}
+
+.readerRuleIndex {
+  position: absolute;
+  z-index: 1;
+  top: 38px;
+  bottom: 0;
+  left: 0;
+  width: 30px;
+  border-right: 1px solid var(--rule);
+  color: var(--faint);
+  font: 600 8.5px/1 ui-monospace, "SF Mono", monospace;
+  text-align: center;
+}
+
+.readerRuleIndex span {
+  position: absolute;
+  right: 0;
+  left: 0;
+}
+
+.readerRuleIndex span:nth-child(1) {
+  top: 29px;
+}
+
+.readerRuleIndex span:nth-child(2) {
+  top: 196px;
+}
+
+.readerRuleIndex span:nth-child(3) {
+  top: 329px;
+}
+
+.readerBody {
+  position: relative;
+  padding: 25px 20px 38px;
+}
+
+.paperTapeReader .readerBody {
+  padding-left: 37px;
+}
+
+.fieldLogReader .readerBody {
+  margin: 12px 9px 0;
+  padding: 18px 15px 32px;
+  border: 1px solid color-mix(in srgb, var(--rule) 75%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+}
+
+.ledgerReader .readerBody {
+  margin: 0;
+  padding-top: 20px;
+  padding-left: 46px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.ledger .ledgerSection,
+.ledger .syncStrip small,
+.ledger .ledgerIndex,
+.ledger .notePlateMeta,
+.ledger .notePlateTitle time,
+.ledger .readerKicker,
+.ledger .readerMeta {
+  font-size: 8.5px;
+}
+
+.readerKicker {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--signal);
+  font: 600 8px/1.2 ui-monospace, "SF Mono", monospace;
+  letter-spacing: 0.09em;
+}
+
+.readerBody h4 {
+  margin: 12px 0 0;
+  color: var(--ink);
+  font-family: "New York", Iowan Old Style, ui-serif, Georgia, serif;
+  font-size: 25px;
+  font-weight: 620;
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+}
+
+.readerMeta {
+  margin-top: 9px;
+  color: var(--faint);
+  font: 500 8px/1.2 ui-monospace, "SF Mono", monospace;
+  letter-spacing: 0.04em;
+}
+
+.readerBody hr {
+  height: 1px;
+  margin: 15px 0;
+  border: 0;
+  background: var(--rule);
+}
+
+.readerBody p,
+.readerBody li,
+.readerBody blockquote {
+  color: var(--ink);
+  font-size: 11px;
+  line-height: 1.58;
+}
+
+.readerBody p {
+  margin: 0;
+}
+
+.readerBody h5 {
+  margin: 17px 0 6px;
+  color: var(--ink);
+  font-family: "New York", Iowan Old Style, ui-serif, Georgia, serif;
+  font-size: 15px;
+}
+
+.readerBody ul {
+  margin: 0;
+  padding-left: 16px;
+}
+
+.readerBody li::marker {
+  color: var(--signal);
+}
+
+.readerBody blockquote {
+  margin: 17px 0 0;
+  padding: 8px 0 8px 12px;
+  border-left: 1px solid var(--signal);
+  color: var(--secondary);
+  font-family: "New York", Iowan Old Style, ui-serif, serif;
+  font-style: italic;
+}
+
+.readerTags {
+  display: flex;
+  gap: 6px;
+  margin-top: 17px;
+}
+
+.readerTags span {
+  padding: 4px 7px;
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  color: var(--faint);
+  font: 500 8px/1 ui-monospace, "SF Mono", monospace;
+}
+
+/* Comparison ledger */
+
+.comparisonLedger {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.72fr) minmax(620px, 2fr);
+  gap: 32px;
+  margin-top: 34px;
+  padding-top: 28px;
+  border-top: 1px solid var(--study-rule);
+}
+
+.ledgerIntro h3 {
+  margin: 9px 0 0;
+  color: var(--studio-ink-strong);
+  font-family: var(--studio-font-serif), ui-serif, serif;
+  font-size: 24px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+}
+
+.ledgerIntro > p:last-child {
+  margin: 10px 0 0;
+  color: var(--studio-ink-faint);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.ledgerRows {
+  border-top: 1px solid var(--study-rule);
+}
+
+.comparisonRow {
+  display: grid;
+  grid-template-columns: 100px repeat(4, minmax(0, 1fr));
+  border-bottom: 1px solid var(--study-rule);
+}
+
+.comparisonRow > * {
+  min-width: 0;
+  padding: 11px 10px;
+  border-left: 1px solid var(--study-rule);
+  color: var(--studio-ink-faint);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.comparisonRow > :first-child {
+  padding-left: 0;
+  border-left: 0;
+  color: var(--studio-ink-strong);
+  font-family: var(--studio-font-mono), ui-monospace, monospace;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 860px) {
+  .controlBar,
+  .comparisonLedger {
+    display: block;
+  }
+
+  .controls {
+    justify-content: flex-start;
+    margin-top: 16px;
+  }
+
+  .matrix {
+    grid-template-columns: repeat(4, minmax(292px, 1fr));
+  }
+
+  .directionHeader {
+    min-height: 135px;
+  }
+
+  .ledgerRows {
+    margin-top: 20px;
+    min-width: 780px;
+  }
+
+  .comparisonLedger {
+    overflow-x: auto;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .segmented button {
+    transition: background-color 140ms ease-out, color 140ms ease-out, box-shadow 140ms ease-out;
+  }
+
+  .phoneScreen {
+    animation: palette-settle 220ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+}
+
+@keyframes palette-settle {
+  from {
+    filter: blur(1.5px);
+    opacity: 0.92;
+  }
+
+  to {
+    filter: blur(0);
+    opacity: 1;
+  }
+}

--- a/design/studio/src/studio/studies/IOSDesignDirectionsStudy.tsx
+++ b/design/studio/src/studio/studies/IOSDesignDirectionsStudy.tsx
@@ -1,0 +1,578 @@
+"use client";
+
+import { useState } from "react";
+import {
+  BatteryMedium,
+  ChevronLeft,
+  ChevronRight,
+  Grid2X2,
+  Link2,
+  LockKeyhole,
+  Moon,
+  Pin,
+  Search,
+  SlidersHorizontal,
+  Sun,
+  Wifi,
+} from "lucide-react";
+import styles from "./IOSDesignDirectionsStudy.module.css";
+
+type Palette = "light" | "dark";
+type Surface = "log" | "reader";
+type DirectionId = "paperTape" | "fieldLog" | "ledger" | "indexTape";
+
+const directions: Array<{
+  id: DirectionId;
+  agent: string;
+  name: string;
+  thesis: string;
+  signature: string[];
+  scoutRef: string;
+}> = [
+  {
+    id: "paperTape",
+    agent: "Opus",
+    name: "Paper Tape",
+    thesis:
+      "Human ink on paper; machine knowledge on one continuous graphite rail.",
+    signature: [
+      "44 pt time rail",
+      "workspace as title",
+      "sync reduced to a rule",
+    ],
+    scoutRef: "ref:f-5c5sbf",
+  },
+  {
+    id: "fieldLog",
+    agent: "Grok",
+    name: "Field Log",
+    thesis:
+      "A warm pocket instrument: status, scope, paper bands, then search at the thumb.",
+    signature: [
+      "paper-band rows",
+      "trust capsule",
+      "floating search dock",
+    ],
+    scoutRef: "ref:z-a8x57g",
+  },
+  {
+    id: "ledger",
+    agent: "Kimi",
+    name: "Ledger",
+    thesis:
+      "The macOS popover made native: numbered rows, square state, sharp ruled geometry.",
+    signature: [
+      "numbered entries",
+      "square sync pip",
+      "zero-radius rules",
+    ],
+    scoutRef: "ref:0-4qjlsi",
+  },
+  {
+    id: "indexTape",
+    agent: "Grok",
+    name: "Index Tape",
+    thesis:
+      "Chronology is the structure; ledger is the discipline — one carbon tape, machine-indexed and sharp-ruled.",
+    signature: [
+      "indexed machine rail",
+      "sync rule + square",
+      "zero-radius carbon geometry",
+    ],
+    scoutRef: "ref:r-p0f0u9",
+  },
+];
+
+const notes = [
+  {
+    title: "Launch checklist",
+    excerpt:
+      "Verify the encrypted LAN handshake — read notes after the Mac disconnects.",
+    meta: "launch · #release",
+    time: "14:22",
+    relative: "2h",
+    index: "01",
+    pinned: true,
+  },
+  {
+    title: "Pairing notes",
+    excerpt:
+      "Each snapshot payload is sealed end to end inside the encrypted peer session.",
+    meta: "hudson · #security",
+    time: "MON",
+    relative: "1d",
+    index: "02",
+    pinned: false,
+  },
+  {
+    title: "Design review",
+    excerpt:
+      "Keep note recall calm, direct, and recognizably connected to the desktop.",
+    meta: "blink · #ios",
+    time: "4 AUG",
+    relative: "3d",
+    index: "03",
+    pinned: false,
+  },
+];
+
+export function IOSDesignDirectionsStudy() {
+  const [palette, setPalette] = useState<Palette>("light");
+  const [surface, setSurface] = useState<Surface>("log");
+
+  return (
+    <div className={styles.study}>
+      <header className={styles.controlBar}>
+        <div>
+          <p className={styles.controlKicker}>Controlled comparison</p>
+          <p className={styles.controlCopy}>
+            Same notes, state, frame, and product behavior. Only the visual
+            system changes.
+          </p>
+        </div>
+
+        <div className={styles.controls} aria-label="Study controls">
+          <div className={styles.segmented} aria-label="Surface">
+            <button
+              type="button"
+              aria-pressed={surface === "log"}
+              onClick={() => setSurface("log")}
+            >
+              Log
+            </button>
+            <button
+              type="button"
+              aria-pressed={surface === "reader"}
+              onClick={() => setSurface("reader")}
+            >
+              Reader
+            </button>
+          </div>
+
+          <div className={styles.segmented} aria-label="Palette">
+            <button
+              type="button"
+              aria-label="Light palette"
+              aria-pressed={palette === "light"}
+              onClick={() => setPalette("light")}
+            >
+              <Sun size={14} aria-hidden="true" />
+              Light
+            </button>
+            <button
+              type="button"
+              aria-label="Dark palette"
+              aria-pressed={palette === "dark"}
+              onClick={() => setPalette("dark")}
+            >
+              <Moon size={14} aria-hidden="true" />
+              Dark
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className={styles.matrix}>
+        {directions.map((direction) => (
+          <article className={styles.direction} key={direction.id}>
+            <header className={styles.directionHeader}>
+              <div className={styles.agentLine}>
+                <span>{direction.agent}</span>
+                <span aria-hidden="true">/</span>
+                <span>{direction.scoutRef}</span>
+              </div>
+              <h3>{direction.name}</h3>
+              <p>{direction.thesis}</p>
+            </header>
+
+            <PhoneShell
+              direction={direction.id}
+              palette={palette}
+              surface={surface}
+              label={`${direction.agent} — ${direction.name}, ${palette} ${surface}`}
+            />
+
+            <ul className={styles.signature} aria-label="Direction signatures">
+              {direction.signature.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+
+      <section className={styles.comparisonLedger} aria-labelledby="comparison-ledger">
+        <div className={styles.ledgerIntro}>
+          <p className={styles.controlKicker}>Design disposition</p>
+          <h3 id="comparison-ledger">What each direction is arguing for</h3>
+          <p>
+            These are alternatives, not a vote. Index Tape is an intentional
+            merge of Paper Tape and Ledger under one thesis — not a bag of both.
+          </p>
+        </div>
+        <div className={styles.ledgerRows}>
+          <ComparisonRow
+            label="Projected density"
+            values={["≈6 rows", "≈4 paper bands", "≈5 ruled entries", "≈6 indexed rows"]}
+          />
+          <ComparisonRow
+            label="Search"
+            values={[
+              "bottom tape dock",
+              "floating thumb dock",
+              "native top field",
+              "sharp bottom index field",
+            ]}
+          />
+          <ComparisonRow
+            label="Offline"
+            values={[
+              "neutral success",
+              "amber retained copy",
+              "amber state pip",
+              "neutral + square pip",
+            ]}
+          />
+          <ComparisonRow
+            label="Dark world"
+            values={[
+              "neutral graphite",
+              "botanical graphite",
+              "neutral graphite",
+              "neutral graphite",
+            ]}
+          />
+          <ComparisonRow
+            label="iPad"
+            values={[
+              "tape + floating sheet",
+              "paper split view",
+              "flat ruled split",
+              "indexed tape + flat reader",
+            ]}
+          />
+          <ComparisonRow
+            label="Machine gutter"
+            values={[
+              "time + pin rail",
+              "none (meta in plate)",
+              "numbered index column",
+              "index over stamp + pin",
+            ]}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function ComparisonRow({ label, values }: { label: string; values: string[] }) {
+  return (
+    <div className={styles.comparisonRow}>
+      <strong>{label}</strong>
+      {values.map((value, index) => (
+        <span key={`${label}-${directions[index].id}`}>{value}</span>
+      ))}
+    </div>
+  );
+}
+
+function PhoneShell({
+  direction,
+  palette,
+  surface,
+  label,
+}: {
+  direction: DirectionId;
+  palette: Palette;
+  surface: Surface;
+  label: string;
+}) {
+  return (
+    <div
+      className={`${styles.phone} ${styles[direction]}`}
+      data-palette={palette}
+      role="img"
+      aria-label={label}
+    >
+      <div className={styles.phoneScreen}>
+        <StatusBar />
+        {surface === "log" ? (
+          <LogScreen direction={direction} />
+        ) : (
+          <ReaderScreen direction={direction} />
+        )}
+        <div className={styles.homeIndicator} />
+      </div>
+    </div>
+  );
+}
+
+function StatusBar() {
+  return (
+    <div className={styles.statusBar} aria-hidden="true">
+      <span>9:41</span>
+      <span className={styles.dynamicIsland} />
+      <span className={styles.statusIcons}>
+        <Wifi size={11} strokeWidth={2.4} />
+        <BatteryMedium size={14} strokeWidth={2.2} />
+      </span>
+    </div>
+  );
+}
+
+function BlinkMark({ compact = false }: { compact?: boolean }) {
+  return (
+    <span className={compact ? styles.markCompact : styles.mark} aria-hidden="true">
+      <span />
+      <span />
+    </span>
+  );
+}
+
+function LogScreen({ direction }: { direction: DirectionId }) {
+  if (direction === "paperTape") return <PaperTapeLog />;
+  if (direction === "fieldLog") return <FieldLog />;
+  if (direction === "ledger") return <LedgerLog />;
+  return <IndexTapeLog />;
+}
+
+function PaperTapeLog() {
+  return (
+    <div className={styles.logScreen}>
+      <div className={styles.tapeToolbar}>
+        <span className={styles.iconWell}><BlinkMark compact /></span>
+        <span className={styles.toolbarGlyph}><Grid2X2 size={15} /></span>
+        <span className={styles.toolbarGlyph}><Link2 size={15} /></span>
+      </div>
+      <div className={styles.tapeTitle}>Launch</div>
+      <div className={styles.tapeStatusRule} />
+      <div className={styles.tapeStatus}>OFFLINE COPY · UPDATED 2H AGO</div>
+      <div className={styles.tapeSection}>
+        <span><b>LOG</b> / LAUNCH</span>
+        <span>3 REC</span>
+      </div>
+      <div className={styles.tapeList}>
+        {notes.map((note) => (
+          <div className={styles.tapeRow} key={note.title}>
+            <div className={styles.tapeRail}>
+              <span>{note.time}</span>
+              {note.pinned ? <i /> : null}
+            </div>
+            <NotePlate note={note} />
+          </div>
+        ))}
+      </div>
+      <div className={styles.tapeSearch}>
+        <Search size={14} />
+        <span>SEARCH · LAUNCH</span>
+      </div>
+    </div>
+  );
+}
+
+function FieldLog() {
+  return (
+    <div className={styles.logScreen}>
+      <div className={styles.fieldToolbar}>
+        <span className={styles.workspaceButton}><Grid2X2 size={14} /></span>
+        <span className={styles.toolbarGlyph}><SlidersHorizontal size={15} /></span>
+        <span className={styles.toolbarGlyph}><Link2 size={15} /></span>
+      </div>
+      <div className={styles.fieldTitle}>blink</div>
+      <div className={styles.syncCapsule}>
+        <span className={styles.syncIcon}><LockKeyhole size={15} /></span>
+        <span>
+          <b>Available offline</b>
+          <small>Updated 2 hours ago</small>
+        </span>
+        <i />
+      </div>
+      <div className={styles.fieldSection}>
+        <span><b>LOG</b> / LAUNCH</span>
+        <span>3 REC</span>
+      </div>
+      <div className={styles.fieldRows}>
+        {notes.map((note) => (
+          <div className={styles.fieldRow} key={note.title}>
+            <div className={styles.rowTitleLine}>
+              <span>{note.pinned ? <Pin size={10} fill="currentColor" /> : null}{note.title}</span>
+              <time>{note.relative}</time>
+            </div>
+            <p>{note.excerpt}</p>
+            <div className={styles.rowMeta}>{note.meta}</div>
+            <ChevronRight className={styles.rowChevron} size={13} />
+          </div>
+        ))}
+      </div>
+      <div className={styles.fieldSearch}>
+        <Search size={14} />
+        <span>Search notes</span>
+      </div>
+    </div>
+  );
+}
+
+function LedgerLog() {
+  return (
+    <div className={styles.logScreen}>
+      <div className={styles.ledgerToolbar}>
+        <span className={styles.toolbarGlyph}><Grid2X2 size={15} /></span>
+        <span className={styles.toolbarGlyph}><Link2 size={15} /></span>
+      </div>
+      <div className={styles.ledgerTitle}>blink</div>
+      <div className={styles.ledgerSearch}>
+        <Search size={14} />
+        <span>Search notes</span>
+      </div>
+      <div className={styles.syncStrip}>
+        <i />
+        <span>
+          <b>Available offline</b>
+          <small>UPDATED 2H AGO</small>
+        </span>
+      </div>
+      <div className={styles.ledgerSection}>
+        <span><b>LOG</b> / LAUNCH</span>
+        <span>3 REC</span>
+      </div>
+      <div className={styles.ledgerList}>
+        {notes.map((note, index) => (
+          <div
+            className={`${styles.ledgerRow} ${index === 0 ? styles.ledgerSelected : ""}`}
+            key={note.title}
+          >
+            <span className={styles.ledgerIndex}>
+              {note.pinned ? <Pin size={10} fill="currentColor" /> : note.index}
+            </span>
+            <NotePlate note={note} relative />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IndexTapeLog() {
+  return (
+    <div className={styles.logScreen}>
+      <div className={styles.indexToolbar}>
+        <span className={styles.iconWell}>
+          <BlinkMark compact />
+        </span>
+        <span className={styles.toolbarGlyph}>
+          <Link2 size={15} />
+        </span>
+      </div>
+      <div className={styles.indexTitle}>Launch</div>
+      <div className={styles.indexStatusRule} />
+      <div className={styles.indexStatus}>
+        <i />
+        <span>OFFLINE COPY · UPDATED 2H AGO</span>
+      </div>
+      <div className={styles.indexSection}>
+        <span>
+          <b>LOG</b> / LAUNCH
+        </span>
+        <span>3 REC</span>
+      </div>
+      <div className={styles.indexList}>
+        {notes.map((note, index) => (
+          <div
+            className={`${styles.indexRow} ${index === 0 ? styles.indexSelected : ""}`}
+            key={note.title}
+          >
+            <div className={styles.indexRail}>
+              {note.pinned ? (
+                <i className={styles.indexPin} />
+              ) : (
+                <span className={styles.indexNum}>{note.index}</span>
+              )}
+              <span className={styles.indexStamp}>{note.time}</span>
+            </div>
+            <NotePlate note={note} />
+          </div>
+        ))}
+      </div>
+      <div className={styles.indexSearch}>
+        <Search size={13} />
+        <span>SEARCH · LAUNCH</span>
+      </div>
+    </div>
+  );
+}
+
+function NotePlate({
+  note,
+  relative = false,
+}: {
+  note: (typeof notes)[number];
+  relative?: boolean;
+}) {
+  return (
+    <div className={styles.notePlate}>
+      <div className={styles.notePlateTitle}>
+        <span>{note.title}</span>
+        {relative ? <time>{note.relative}</time> : null}
+      </div>
+      <p>{note.excerpt}</p>
+      <div className={styles.notePlateMeta}>{note.meta}</div>
+    </div>
+  );
+}
+
+function ReaderScreen({ direction }: { direction: DirectionId }) {
+  return (
+    <div className={`${styles.readerScreen} ${styles[`${direction}Reader`]}`}>
+      <div className={styles.readerToolbar}>
+        <ChevronLeft size={18} />
+        <span>Notes</span>
+        <Link2 size={15} />
+      </div>
+      {direction === "paperTape" ? (
+        <div className={styles.readerRail} aria-hidden="true">
+          <span>14:22</span>
+          <i />
+          <span>MON</span>
+        </div>
+      ) : null}
+      {direction === "ledger" ? (
+        <div className={styles.readerRuleIndex} aria-hidden="true">
+          <span>01</span>
+          <span>02</span>
+          <span>03</span>
+        </div>
+      ) : null}
+      {direction === "indexTape" ? (
+        <div className={styles.indexReaderGutter} aria-hidden="true">
+          <span>01</span>
+          <small>14:22</small>
+        </div>
+      ) : null}
+      <article className={styles.readerBody}>
+        <div className={styles.readerKicker}>
+          <BlinkMark compact />
+          <span>MARKDOWN / READ ONLY</span>
+        </div>
+        <h4>Launch checklist</h4>
+        <div className={styles.readerMeta}>AUG 1, 2026 · 17:20 · LAUNCH</div>
+        <hr />
+        <p>
+          Verify the encrypted LAN handshake, then read these notes after the
+          Mac disconnects. The durable truth stays in the Markdown file.
+        </p>
+        <h5>Offline first</h5>
+        <ul>
+          <li>The last good snapshot remains readable.</li>
+          <li>Unknown frontmatter survives every round trip.</li>
+          <li>The companion never edits the source note.</li>
+        </ul>
+        <blockquote>Capture on the desk. Recall from anywhere nearby.</blockquote>
+        <div className={styles.readerTags}>
+          <span>#release</span>
+          <span>#ios</span>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/design/studio/src/studio/studies/MenubarPopoverStudy.tsx
+++ b/design/studio/src/studio/studies/MenubarPopoverStudy.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { DesktopScene, glassHeavy } from "./DesktopScene";
+
+/**
+ * Study: the menubar popover — home base for the triad.
+ *
+ * One field does everything: type = search, ⌘↵ = create, mic = dictate into a
+ * new note. Recents can be flung onto the desktop as panels (⤢ on hover).
+ * Footer is palette + settings only — triad-only means no Library entry.
+ */
+export function MenubarPopoverStudy() {
+  return (
+    <DesktopScene menubar height={560}>
+      {/* Anchor caret under the status item */}
+      <div className="absolute right-[104px] top-[26px] z-30 h-3 w-3 rotate-45 border-l border-t border-white/[0.12] bg-[#1a1d2e]/80" />
+
+      <div
+        className={
+          "absolute right-[16px] top-[32px] z-30 w-[312px] rounded-xl " + glassHeavy
+        }
+      >
+        {/* Capture / search field */}
+        <div className="flex items-center gap-2 border-b border-white/[0.08] px-3.5 py-3">
+          <span className="text-[13px] text-white/40">⌕</span>
+          <span className="flex-1 text-[13px] text-white/45">
+            Search or capture…
+            <span className="animate-pulse text-white/80">▏</span>
+          </span>
+          <span className="cursor-default rounded p-1 text-[13px] text-white/60 hover:bg-white/10 hover:text-white/90">
+            🎙
+          </span>
+        </div>
+
+        {/* Recents */}
+        <div className="px-2 py-2">
+          <div className="px-2 pb-1.5 pt-1 font-mono text-[9px] uppercase tracking-[0.2em] text-white/35">
+            Recent
+          </div>
+          {[
+            { title: "Meeting notes", when: "2m" },
+            { title: "Roadmap Q3", when: "1h" },
+            { title: "Grocery", when: "3h" },
+            { title: "Ideas parking lot", when: "1d" },
+          ].map((note) => (
+            <div
+              key={note.title}
+              className="group flex cursor-default items-center gap-2 rounded-md px-2 py-[7px] hover:bg-white/[0.07]"
+            >
+              <span className="text-[11px] text-white/35">▸</span>
+              <span className="flex-1 truncate text-[13px] text-white/85">
+                {note.title}
+              </span>
+              <span className="text-[11px] tabular-nums text-white/35">
+                {note.when}
+              </span>
+              <span
+                className="text-[12px] text-white/0 transition-colors group-hover:text-white/60 hover:!text-white/95"
+                title="Open as floating panel"
+              >
+                ⤢
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer — palette + settings only (triad-only: no Library) */}
+        <div className="flex items-center justify-between border-t border-white/[0.08] px-3.5 py-2.5 text-[11px] text-white/45">
+          <span className="cursor-default hover:text-white/80">⌘K palette</span>
+          <span className="cursor-default text-[12px] hover:text-white/80">⚙</span>
+        </div>
+      </div>
+
+      {/* Caption chip */}
+      <div className="absolute bottom-4 left-4 rounded-md bg-black/40 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-white/60 backdrop-blur-sm">
+        one field: type = search · ⌘↵ = new note · mic = dictate
+      </div>
+    </DesktopScene>
+  );
+}

--- a/design/studio/src/studio/studies/NotePanelStudy.tsx
+++ b/design/studio/src/studio/studies/NotePanelStudy.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { DesktopScene, SavePip, TrafficLights, glass } from "./DesktopScene";
+
+/**
+ * Study: the floating note panel — Blink v2's atomic unit.
+ *
+ * Three states on one desktop:
+ *  - focused panel (hover it: the footer chrome appears — chrome is earned)
+ *  - resting panel (no chrome at all, just glass + text)
+ *  - shaded panel (the 28px title bar is all that remains)
+ */
+export function NotePanelStudy() {
+  return (
+    <DesktopScene height={580}>
+      {/* Focused panel — hover to reveal footer chrome */}
+      <div
+        className={
+          "group absolute left-[6%] top-[10%] flex w-[420px] flex-col rounded-xl " +
+          glass
+        }
+        style={{ height: 340 }}
+      >
+        <PanelTitleBar title="Meeting notes" saved />
+        <div className="flex-1 overflow-hidden px-5 py-4 text-[13px] leading-[1.75] text-white/85">
+          <p className="font-semibold text-white/95">## Standup</p>
+          <p className="mt-2">- shipped panel drag</p>
+          <p>- PanelKit geometry persistence is in</p>
+          <p>
+            - dictation next<span className="animate-pulse text-white">▏</span>
+          </p>
+          <p className="mt-3 text-white/60">
+            &gt; decision: bridge stays four messages wide until M2
+          </p>
+        </div>
+        <div className="flex h-8 items-center justify-between rounded-b-xl border-t border-white/[0.08] px-4 text-[11px] text-white/60 opacity-0 transition-opacity duration-150 group-hover:opacity-100">
+          <span>142 words · saved</span>
+          <span className="flex items-center gap-3">
+            <span className="cursor-default hover:text-white/90">✎ edit</span>
+            <span className="cursor-default hover:text-white/90">🎙</span>
+          </span>
+        </div>
+      </div>
+
+      {/* Resting panel — chrome fully at rest */}
+      <div
+        className={
+          "absolute right-[7%] top-[8%] flex w-[300px] flex-col rounded-xl opacity-[0.93] " +
+          glass
+        }
+        style={{ height: 210 }}
+      >
+        <PanelTitleBar title="Roadmap Q3" saved dim />
+        <div className="flex-1 px-5 py-3 text-[12.5px] leading-[1.7] text-white/75">
+          <p>1. PanelKit → upstream to HudsonKit</p>
+          <p>2. dictation polish</p>
+          <p>3. themes: keep it to five</p>
+        </div>
+      </div>
+
+      {/* Shaded panel — middle-click the title bar and this is all that remains */}
+      <div
+        className={"absolute bottom-[12%] right-[10%] w-[260px] rounded-lg " + glass}
+      >
+        <PanelTitleBar title="Grocery" saved dim shaded />
+      </div>
+
+      {/* Caption chip */}
+      <div className="absolute bottom-4 left-4 rounded-md bg-black/40 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-white/60 backdrop-blur-sm">
+        hover the focused panel — chrome is earned, not given
+      </div>
+    </DesktopScene>
+  );
+}
+
+function PanelTitleBar({
+  title,
+  saved,
+  dim = false,
+  shaded = false,
+}: {
+  title: string;
+  saved: boolean;
+  dim?: boolean;
+  shaded?: boolean;
+}) {
+  return (
+    <div
+      className={
+        "flex h-7 shrink-0 items-center justify-between px-3 " +
+        (shaded ? "" : "border-b border-white/[0.08]")
+      }
+    >
+      <TrafficLights dim={dim} />
+      <span
+        className={
+          "pointer-events-none absolute left-1/2 -translate-x-1/2 text-[11px] font-medium " +
+          (dim ? "text-white/40" : "text-white/55")
+        }
+      >
+        {title}
+      </span>
+      <SavePip saved={saved} />
+    </div>
+  );
+}

--- a/design/studio/src/studio/studies/SettingsStudy.tsx
+++ b/design/studio/src/studio/studies/SettingsStudy.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { DesktopScene, TrafficLights, glassHeavy } from "./DesktopScene";
+
+/**
+ * Study: settings — deliberately tiny.
+ *
+ * One small native window, three grouped sections, one screen. No duplicated
+ * controls: if it has a good default, it isn't a setting. The antidote to v1's
+ * 1,600-line settings panel.
+ */
+export function SettingsStudy() {
+  return (
+    <DesktopScene height={520}>
+      <div
+        className={
+          "absolute left-1/2 top-1/2 flex w-[420px] -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl " +
+          glassHeavy
+        }
+        style={{ height: 400 }}
+      >
+        {/* Title bar */}
+        <div className="flex h-7 shrink-0 items-center justify-between border-b border-white/[0.08] px-3">
+          <TrafficLights />
+          <span className="pointer-events-none absolute left-1/2 -translate-x-1/2 text-[11px] font-medium text-white/40">
+            Settings
+          </span>
+          <span className="w-[38px]" />
+        </div>
+
+        <div className="flex-1 overflow-hidden px-5 py-3">
+          {/* General */}
+          <SectionLabel>General</SectionLabel>
+          <Row label="Notes folder">
+            <span className="truncate font-mono text-[10.5px] text-white/40">
+              ~/Library/Application Support/Blink/Notes
+            </span>
+            <Chip>Reveal</Chip>
+          </Row>
+          <Row label="Restore panels at launch">
+            <Pill on />
+          </Row>
+
+          {/* Editor */}
+          <div className="mt-3 border-t border-white/[0.08] pt-3">
+            <SectionLabel>Editor</SectionLabel>
+            <Row label="Open notes in">
+              <Segmented options={["Read", "Edit"]} selected="Read" />
+            </Row>
+            <Row label="Typewriter mode" dim>
+              <span className="rounded border border-white/[0.1] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.15em] text-white/35">
+                later
+              </span>
+              <Pill on={false} />
+            </Row>
+          </div>
+
+          {/* Shortcuts */}
+          <div className="mt-3 border-t border-white/[0.08] pt-3">
+            <SectionLabel>Shortcuts</SectionLabel>
+            <ShortcutRow label="New note" keys="Hyper+N" />
+            <ShortcutRow label="Command palette" keys="⌘K (soon)" />
+            <ShortcutRow label="Flip mode" keys="⌘⇧P" />
+          </div>
+        </div>
+      </div>
+
+      {/* Caption chip */}
+      <div className="absolute bottom-4 left-4 rounded-md bg-black/40 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-white/60 backdrop-blur-sm">
+        three sections, one screen — if it has a good default, it isn't a setting
+      </div>
+    </DesktopScene>
+  );
+}
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <div className="px-1 pb-1 font-mono text-[9px] uppercase tracking-[0.2em] text-white/35">
+      {children}
+    </div>
+  );
+}
+
+function Row({
+  label,
+  children,
+  dim = false,
+}: {
+  label: string;
+  children: ReactNode;
+  dim?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-1 py-[7px]">
+      <span
+        className={
+          "shrink-0 text-[12.5px] " + (dim ? "text-white/45" : "text-white/80")
+        }
+      >
+        {label}
+      </span>
+      <span className="ml-auto flex items-center gap-2 overflow-hidden">
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function ShortcutRow({ label, keys }: { label: string; keys: string }) {
+  return (
+    <div className="flex items-center gap-3 px-1 py-[7px]">
+      <span className="text-[12.5px] text-white/80">{label}</span>
+      <span className="ml-auto rounded border border-white/[0.12] bg-white/[0.05] px-1.5 py-0.5 font-mono text-[10px] text-white/45">
+        {keys}
+      </span>
+    </div>
+  );
+}
+
+function Chip({ children }: { children: string }) {
+  return (
+    <span className="shrink-0 cursor-default rounded border border-white/[0.15] bg-white/[0.06] px-2 py-0.5 text-[10.5px] text-white/60 hover:text-white/90">
+      {children}
+    </span>
+  );
+}
+
+function Pill({ on }: { on: boolean }) {
+  return (
+    <span
+      className={
+        "flex h-[16px] w-[28px] items-center rounded-full px-[2px] " +
+        (on ? "justify-end bg-emerald-400/80" : "justify-start bg-white/[0.12]")
+      }
+    >
+      <span className="h-[12px] w-[12px] rounded-full bg-white shadow-sm" />
+    </span>
+  );
+}
+
+function Segmented({
+  options,
+  selected,
+}: {
+  options: string[];
+  selected: string;
+}) {
+  return (
+    <span className="flex items-center rounded-md border border-white/[0.12] bg-white/[0.04] p-[2px]">
+      {options.map((opt) => (
+        <span
+          key={opt}
+          className={
+            "cursor-default rounded px-2.5 py-[3px] text-[11px] " +
+            (opt === selected
+              ? "bg-white/[0.14] text-white"
+              : "text-white/45 hover:text-white/70")
+          }
+        >
+          {opt}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/design/studio/src/studio/studies/StacksStudy.tsx
+++ b/design/studio/src/studio/studies/StacksStudy.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import { useState } from "react";
+import { TrafficLights, glass } from "./DesktopScene";
+
+/**
+ * Study: stacks in the see-all view — where idle notes go to be left alone.
+ *
+ * The triad has no Library, but older notes need a home that isn't a hidden
+ * archive list. The stack is the desk-corner pile made digital: parked notes
+ * stay visible, countable, and leaf-through-able. Four metaphors for what
+ * that pile could be, each rendered in the same see-all context:
+ *
+ *  01 card pile       — rotated offset pile + count badge; hover fans it out
+ *  02 stacked sheets  — inbox-tray edges, titles peeking; hover expands
+ *  03 shelf           — spined bundles on a ledge, grouped by age
+ *  04 messy desk      — loose cluster, front note readable, the rest peeking
+ */
+
+type FakeNote = { title: string; snippet: string; age: string };
+
+const ACTIVE_NOTES: FakeNote[] = [
+  { title: "Meeting notes", snippet: "standup — panel drag shipped, dictation next", age: "2m" },
+  { title: "Roadmap Q3", snippet: "PanelKit → HudsonKit · dictation polish · themes", age: "1h" },
+  { title: "Grocery", snippet: "miso, scallions, tofu, sesame oil…", age: "3h" },
+  { title: "Blink release checklist", snippet: "notarize → DMG → update feed → tag", age: "1d" },
+  { title: "Ideas parking lot", snippet: "shade-to-bar on idle? gather-all command…", age: "2d" },
+  { title: "Reading — spatial interfaces", snippet: "cards on the table; piles as metadata…", age: "4d" },
+];
+
+/** The parked tail — oldest first, most recently parked last. */
+const STACK_NOTES: FakeNote[] = [
+  { title: "2019 tax scans", snippet: "W-2, 1099, receipts — keep until 2027", age: "6y" },
+  { title: "Moving checklist", snippet: "deposit returned ✓ · keys handed over ✓", age: "2y" },
+  { title: "Conference talk draft", snippet: "notes as windows — the 20-min version", age: "14mo" },
+  { title: "Recipe — miso ramen", snippet: "broth 20 min, tare first, egg 6:30", age: "9mo" },
+  { title: "App icon sketches", snippet: "eye + lid variants; v3 exported", age: "7mo" },
+  { title: "Gift ideas — mum", snippet: "ceramic class? the blue scarf?", age: "5mo" },
+  { title: "Old standup notes", snippet: "weeks 34–41, kept for the retro", age: "3mo" },
+];
+
+export function StacksStudy() {
+  return (
+    <div className="space-y-14">
+      <Variant
+        index="01"
+        name="Card pile"
+        interaction="Hover fans the pile into a row you can leaf through; a card lifts on hover."
+        tradeoff="Best feel and count-at-a-glance — but the fan-out needs width and order is implied, not shown."
+        hint="hover the pile →"
+        interactive
+      >
+        <CardPile />
+      </Variant>
+
+      <Variant
+        index="02"
+        name="Stacked sheets"
+        interaction="Inbox-tray edges with titles peeking out; hover expands the tray accordion-style."
+        tradeoff="Every title is one hover away and the rest state is tiny — but expanded it reads as a list, not a pile."
+        hint="hover the tray →"
+        interactive
+      >
+        <SheetTray />
+      </Variant>
+
+      <Variant
+        index="03"
+        name="Shelf"
+        interaction="Stacks stand on a ledge at the bottom of the view, grouped by age; each is a spined bundle with a count."
+        tradeoff="Tidiest and most scalable — but spines are abstract: no titles peek, you trust the grouping."
+        hint="grouped by age"
+      >
+        <Shelf />
+      </Variant>
+
+      <Variant
+        index="04"
+        name="Messy desk"
+        interaction="A loose cluster, as you left it — front note fully readable, the rest peeking at angles."
+        tradeoff="Most personality, closest to the real desk-corner pile — but the organic layout costs scannability."
+        hint="as you left it"
+      >
+        <MessyDesk />
+      </Variant>
+    </div>
+  );
+}
+
+/* ——— variant frame ———————————————————————————————————————— */
+
+function Variant({
+  index,
+  name,
+  interaction,
+  tradeoff,
+  hint,
+  interactive = false,
+  children,
+}: {
+  index: string;
+  name: string;
+  interaction: string;
+  tradeoff: string;
+  hint: string;
+  interactive?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <header className="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <span className="font-mono text-[10px] uppercase tracking-eyebrow text-studio-ink-faint">
+          {index}
+        </span>
+        <h3 className="text-[17px] font-medium text-studio-ink-strong">{name}</h3>
+        {interactive && (
+          <span className="rounded border border-studio-rule px-1.5 py-px font-mono text-[9px] uppercase tracking-[0.16em] text-studio-ink-faint">
+            hover me
+          </span>
+        )}
+        <span className="max-w-[62ch] text-[12.5px] leading-relaxed text-studio-ink-faint">
+          {interaction}
+        </span>
+      </header>
+
+      <SeeAllWindow hint={hint}>{children}</SeeAllWindow>
+
+      <p className="mt-2.5 text-[12px] leading-relaxed text-studio-ink-faint">
+        tradeoff — {tradeoff}
+      </p>
+    </section>
+  );
+}
+
+/** The see-all context every variant lives in: active grid + a stacks zone. */
+function SeeAllWindow({
+  hint,
+  children,
+}: {
+  hint: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="flex h-[470px] w-full select-none flex-col overflow-hidden rounded-xl border border-white/[0.1] shadow-[0_30px_80px_rgba(0,0,0,0.35)]"
+      style={{ background: "linear-gradient(180deg, #151827 0%, #101321 100%)" }}
+    >
+      {/* title bar */}
+      <div className="flex h-9 shrink-0 items-center gap-3 border-b border-white/[0.08] px-3.5">
+        <TrafficLights dim />
+        <span className="text-[11.5px] font-medium text-white/55">
+          Library — 31 notes
+        </span>
+        <span className="ml-auto w-[180px] rounded-md bg-white/[0.06] px-2.5 py-1 text-[11px] text-white/40">
+          ⌕ Search notes…
+        </span>
+      </div>
+
+      {/* active notes grid */}
+      <div className="shrink-0 px-5 pt-3.5">
+        <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-white/35">
+          Active — 6
+        </div>
+        <div className="mt-2 grid grid-cols-3 gap-2.5">
+          {ACTIVE_NOTES.map((note) => (
+            <div
+              key={note.title}
+              className="h-[64px] cursor-default overflow-hidden rounded-lg border border-white/[0.09] bg-white/[0.05] p-2.5 hover:bg-white/[0.09]"
+            >
+              <div className="truncate text-[11.5px] font-medium text-white/85">
+                {note.title}
+              </div>
+              <div className="mt-1 line-clamp-2 text-[10px] leading-snug text-white/40">
+                {note.snippet}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* stacks zone */}
+      <div className="flex shrink-0 items-baseline justify-between px-5 pt-3.5">
+        <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-white/35">
+          Stacks — parked notes
+        </div>
+        <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-white/25">
+          {hint}
+        </div>
+      </div>
+      <div className="relative mx-5 mb-4 flex-1">{children}</div>
+    </div>
+  );
+}
+
+/* ——— 01 · card pile (interactive) ————————————————————————— */
+
+const PILE_ROT = [-7, 4, -3, 6, -5, 2, 8];
+
+function CardPile() {
+  const [fanned, setFanned] = useState(false);
+  const [hovered, setHovered] = useState<number | null>(null);
+  const n = STACK_NOTES.length;
+  const mid = (n - 1) / 2;
+
+  return (
+    <div
+      className="absolute bottom-0 left-1/2 h-[160px] w-[920px] -translate-x-1/2"
+      onMouseEnter={() => setFanned(true)}
+      onMouseLeave={() => {
+        setFanned(false);
+        setHovered(null);
+      }}
+    >
+      {STACK_NOTES.map((note, i) => {
+        const isTop = i === n - 1;
+        const isHovered = fanned && hovered === i;
+        const transform = fanned
+          ? `translateX(${(i - mid) * 112}px) translateY(${isHovered ? -12 : 0}px) rotate(0deg) scale(${isHovered ? 1.06 : 1})`
+          : `translateX(${(i - mid) * 4}px) translateY(${-i * 2}px) rotate(${PILE_ROT[i]}deg)`;
+        return (
+          <div
+            key={note.title}
+            onMouseEnter={() => setHovered(i)}
+            className={
+              "absolute bottom-0 left-1/2 ml-[-75px] h-[96px] w-[150px] cursor-default rounded-lg p-3 " +
+              glass +
+              (fanned ? " bg-[#171a29]/95" : "")
+            }
+            style={{
+              transform,
+              zIndex: isHovered ? 40 : fanned ? 20 + i : i,
+              transition: "transform 340ms cubic-bezier(0.22, 1, 0.36, 1)",
+            }}
+          >
+            <div className="truncate text-[11.5px] font-medium text-white/90">
+              {note.title}
+            </div>
+            <div className="mt-1 line-clamp-2 text-[10px] leading-snug text-white/45">
+              {note.snippet}
+            </div>
+            <div className="absolute bottom-2 left-3 text-[9.5px] tabular-nums text-white/35">
+              {note.age}
+            </div>
+            {isTop && (
+              <span
+                className={
+                  "absolute -right-2 -top-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-white px-1 text-[10px] font-semibold text-black shadow transition-opacity duration-200 " +
+                  (fanned ? "opacity-0" : "opacity-100")
+                }
+              >
+                {n}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ——— 02 · stacked sheets (interactive) ———————————————————— */
+
+function SheetTray() {
+  const sheets = STACK_NOTES.slice(1); // drop the oldest; most recently parked on top
+  return (
+    <div className="group absolute bottom-0 left-4 w-[460px]">
+      {[...sheets].reverse().map((note, i) => {
+        const open = i === 0; // most recently parked sits on top, readable
+        return (
+          <div
+            key={note.title}
+            className={
+              "flex cursor-default items-center gap-3 overflow-hidden border border-b-0 border-white/[0.1] bg-white/[0.06] px-3 backdrop-blur-xl transition-all duration-300 first:rounded-t-lg last:rounded-b-lg last:border-b hover:bg-white/[0.12] " +
+              (open ? "h-[54px]" : "h-[15px] group-hover:h-[34px]")
+            }
+          >
+            <span className="h-2 w-[3px] shrink-0 rounded-full bg-white/20" />
+            {open ? (
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[11.5px] font-medium text-white/90">
+                  {note.title}
+                </span>
+                <span className="mt-0.5 block truncate text-[10px] text-white/45">
+                  {note.snippet}
+                </span>
+              </span>
+            ) : (
+              <>
+                <span className="min-w-0 flex-1 truncate text-[10.5px] text-white/75">
+                  {note.title}
+                </span>
+                <span className="hidden max-w-[45%] truncate text-[9.5px] text-white/40 group-hover:block">
+                  {note.snippet}
+                </span>
+              </>
+            )}
+            <span className="shrink-0 text-[9.5px] tabular-nums text-white/35">
+              {note.age}
+            </span>
+          </div>
+        );
+      })}
+      <span className="absolute -right-2 -top-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-white px-1 text-[10px] font-semibold text-black shadow">
+        {sheets.length}
+      </span>
+    </div>
+  );
+}
+
+/* ——— 03 · shelf ——————————————————————————————————————————— */
+
+const SHELF_GROUPS = [
+  { label: "last month", count: 3, h: 58 },
+  { label: "this year", count: 8, h: 76 },
+  { label: "older", count: 14, h: 92 },
+];
+
+function Shelf() {
+  return (
+    <div className="absolute inset-0">
+      {/* the ledge */}
+      <div className="absolute inset-x-2 bottom-[20px] h-[3px] rounded-full bg-white/[0.12] shadow-[0_4px_14px_rgba(0,0,0,0.5)]" />
+      <div className="absolute inset-x-0 bottom-[23px] flex items-end justify-center gap-16">
+        {SHELF_GROUPS.map((g) => (
+          <div key={g.label} className="flex flex-col items-center gap-1.5">
+            <div
+              className="relative w-[52px] cursor-default rounded-t-[5px] border border-white/[0.12] hover:border-white/[0.25]"
+              style={{
+                height: g.h,
+                background:
+                  "repeating-linear-gradient(to top, rgba(255,255,255,0.10) 0 1px, transparent 1px 5px)," +
+                  "rgba(255,255,255,0.05)",
+              }}
+              title={`${g.count} notes · ${g.label}`}
+            >
+              <span className="absolute inset-x-0 bottom-1 text-center text-[10px] font-medium tabular-nums text-white/60">
+                {g.count}
+              </span>
+            </div>
+            <span className="h-[14px] font-mono text-[9px] uppercase tracking-[0.18em] text-white/40">
+              {g.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ——— 04 · messy desk —————————————————————————————————————— */
+
+const SCATTER: Array<{ note: number; x: string; y: string; r: number; o: number; z: number; w: number }> = [
+  { note: 0, x: "5%", y: "10%", r: -9, o: 0.55, z: 1, w: 148 },
+  { note: 1, x: "19%", y: "50%", r: 6, o: 0.65, z: 2, w: 150 },
+  { note: 2, x: "73%", y: "6%", r: 10, o: 0.55, z: 1, w: 146 },
+  { note: 3, x: "61%", y: "46%", r: -5, o: 0.7, z: 3, w: 152 },
+  { note: 4, x: "37%", y: "4%", r: 3, o: 0.8, z: 4, w: 156 },
+];
+
+function MessyDesk() {
+  const front = STACK_NOTES[6];
+  return (
+    <div className="absolute inset-0">
+      {SCATTER.map(({ note, x, y, r, o, z, w }) => {
+        const n = STACK_NOTES[note];
+        return (
+          <div
+            key={n.title}
+            className={"absolute h-[88px] cursor-default rounded-lg p-2.5 " + glass}
+            style={{
+              left: x,
+              top: y,
+              width: w,
+              opacity: o,
+              zIndex: z,
+              transform: `rotate(${r}deg)`,
+            }}
+          >
+            <div className="truncate text-[10.5px] font-medium text-white/80">
+              {n.title}
+            </div>
+            <div className="mt-1 text-[9.5px] tabular-nums text-white/35">{n.age}</div>
+          </div>
+        );
+      })}
+
+      {/* front card — fully readable */}
+      <div
+        className={"absolute h-[104px] w-[210px] cursor-default rounded-lg p-3 " + glass + " bg-[#171a29]/90"}
+        style={{ left: "38%", top: "32%", zIndex: 10, transform: "rotate(-2deg)" }}
+      >
+        <div className="truncate text-[12px] font-semibold text-white/95">
+          {front.title}
+        </div>
+        <div className="mt-1 line-clamp-2 text-[10.5px] leading-snug text-white/50">
+          {front.snippet}
+        </div>
+        <div className="absolute bottom-2 left-3 text-[9.5px] tabular-nums text-white/35">
+          parked {front.age} ago
+        </div>
+        <span className="absolute -right-2 -top-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-white px-1 text-[10px] font-semibold text-black shadow">
+          {STACK_NOTES.length}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/design/studio/src/studio/studies/StylePermutationsStudy.tsx
+++ b/design/studio/src/studio/studies/StylePermutationsStudy.tsx
@@ -1,0 +1,553 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+/**
+ * Study: every note style in one place.
+ *
+ * The five sheet templates rendered side by side, all reacting to one shared
+ * set of theme controls (accent, tint, radius, type, font, mode) — plus a
+ * motion lab (eight entrances, duration/stagger/loop) so you can watch notes
+ * fall into place and dial the feel, and a live config.json that mirrors what
+ * the app reads. The "see all the permutations, tweak them" surface.
+ */
+
+type Sheet = "glass" | "card" | "dotted" | "bracket" | "marginalia";
+type Mode = "read" | "edit";
+type Entrance =
+  | "none"
+  | "shimmer"
+  | "drop"
+  | "rise"
+  | "pop"
+  | "slide"
+  | "draw"
+  | "blur";
+
+const SHEETS: { key: Sheet; note: string }[] = [
+  { key: "glass", note: "HUD blur — the default" },
+  { key: "card", note: "Opaque paper, no blur" },
+  { key: "dotted", note: "Dotted notebook margin" },
+  { key: "bracket", note: "Corner brackets only" },
+  { key: "marginalia", note: "Ruled annotation margin" },
+];
+
+const ACCENTS: { label: string; value: string }[] = [
+  { label: "Ice", value: "rgba(158,203,255,0.95)" },
+  { label: "Warm", value: "rgba(255,200,150,0.95)" },
+  { label: "Mint", value: "rgba(150,230,190,0.95)" },
+  { label: "Rose", value: "rgba(255,170,190,0.95)" },
+  { label: "Violet", value: "rgba(200,170,255,0.95)" },
+];
+
+const FONTS: { label: string; value: string }[] = [
+  { label: "System sans", value: '-apple-system, "SF Pro Text", system-ui, sans-serif' },
+  { label: "Serif", value: '"Iowan Old Style", Charter, Georgia, serif' },
+  { label: "Mono", value: 'ui-monospace, "SF Mono", Menlo, monospace' },
+  { label: "Rounded", value: 'ui-rounded, "SF Pro Rounded", "Nunito", sans-serif' },
+  { label: "Grotesk", value: 'Inter, "Helvetica Neue", Arial, sans-serif' },
+];
+
+const ENTRANCES: Entrance[] = [
+  "none",
+  "shimmer",
+  "drop",
+  "rise",
+  "pop",
+  "slide",
+  "draw",
+  "blur",
+];
+
+const deskBg =
+  "radial-gradient(120% 90% at 15% 10%, #2b3a67 0%, transparent 55%)," +
+  "radial-gradient(100% 80% at 85% 20%, #4c2f63 0%, transparent 50%)," +
+  "radial-gradient(90% 90% at 70% 95%, #173f4e 0%, transparent 55%),#101322";
+
+// Fractal-noise grain, as an inline SVG — the faint tooth that keeps glass and
+// paper from reading as flat fills.
+const grain =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")";
+
+export function StylePermutationsStudy() {
+  // Defaults are the look the owner settled on — baked in.
+  const [accent, setAccent] = useState(ACCENTS[1].value); // warm
+  const [tintRead, setTintRead] = useState(0.36);
+  const [tintEdit, setTintEdit] = useState(0.28);
+  const [radius, setRadius] = useState(7);
+  const [fontSize, setFontSize] = useState(11);
+  const [lineHeight, setLineHeight] = useState(1.4);
+  const [font, setFont] = useState(FONTS[2].value); // mono
+  const [mode, setMode] = useState<Mode>("read");
+
+  const [entrance, setEntrance] = useState<Entrance>("slide");
+  const [duration, setDuration] = useState(200);
+  const [stagger, setStagger] = useState(50);
+  const [loop, setLoop] = useState(false);
+
+  const [playKey, setPlayKey] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  const theme = { accent, radius, fontSize, lineHeight, font };
+  const tint = mode === "edit" ? tintEdit : tintRead;
+
+  // Loop: re-drop the whole matrix on an interval so you can just watch.
+  useEffect(() => {
+    if (!loop) return;
+    const period = duration + SHEETS.length * stagger + 900;
+    const id = setInterval(() => setPlayKey((k) => k + 1), period);
+    return () => clearInterval(id);
+  }, [loop, duration, stagger]);
+
+  const configJson = useMemo(
+    () =>
+      JSON.stringify(
+        {
+          panel: {
+            cornerRadius: radius,
+            tintRead: round(tintRead),
+            tintEdit: round(tintEdit),
+          },
+          editor: {
+            fontFamily: font,
+            accentColor: accent,
+            fontSize,
+            lineHeight: round(lineHeight),
+          },
+          motion: { entrance, durationMs: duration, staggerMs: stagger },
+        },
+        null,
+        2,
+      ),
+    [radius, tintRead, tintEdit, font, accent, fontSize, lineHeight, entrance, duration, stagger],
+  );
+
+  const replay = () => setPlayKey((k) => k + 1);
+
+  const copyConfig = async () => {
+    try {
+      await navigator.clipboard.writeText(configJson);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    } catch {
+      /* clipboard blocked — no-op */
+    }
+  };
+
+  return (
+    <div className="w-full">
+      <style>{ENTRANCE_CSS}</style>
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+        {/* Gallery */}
+        <div
+          className="relative overflow-hidden rounded-xl border border-studio-edge p-5 shadow-[0_30px_80px_rgba(0,0,0,0.35)]"
+          style={{ background: deskBg }}
+        >
+          {/* overhead light */}
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              background:
+                "radial-gradient(80% 55% at 50% -10%, rgba(255,255,255,0.10), transparent 60%)",
+            }}
+          />
+          {/* grain over the desk */}
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{ backgroundImage: grain, backgroundSize: "140px 140px", opacity: 0.05, mixBlendMode: "overlay" }}
+          />
+          <div className="relative grid grid-cols-1 gap-5 md:grid-cols-2">
+            {SHEETS.map((s, i) => (
+              <SheetTile
+                key={`${s.key}-${entrance}-${playKey}`}
+                sheet={s.key}
+                caption={s.note}
+                theme={theme}
+                tint={tint}
+                mode={mode}
+                entrance={entrance}
+                duration={duration}
+                stagger={stagger}
+                index={i}
+              />
+            ))}
+            <div className="hidden flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-white/10 md:flex">
+              <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-white/45">
+                {mode} · {entrance}
+              </span>
+              <button
+                onClick={replay}
+                className="mt-1 rounded-md border border-white/15 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-white/60 hover:bg-white/10"
+              >
+                ▶ fall into place
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Controls */}
+        <aside className="space-y-5">
+          <Control label="Mode">
+            <Segmented options={["read", "edit"]} value={mode} onChange={(v) => setMode(v as Mode)} />
+          </Control>
+
+          <Control label="Accent">
+            <div className="flex gap-2">
+              {ACCENTS.map((a) => (
+                <button
+                  key={a.value}
+                  onClick={() => setAccent(a.value)}
+                  title={a.label}
+                  className={
+                    "h-6 w-6 rounded-full border transition-transform hover:scale-110 " +
+                    (accent === a.value
+                      ? "border-studio-ink-strong ring-2 ring-studio-ink-strong/30"
+                      : "border-studio-rule")
+                  }
+                  style={{ background: a.value }}
+                />
+              ))}
+            </div>
+          </Control>
+
+          <Control label="Font">
+            <select
+              value={font}
+              onChange={(e) => setFont(e.target.value)}
+              className="w-full rounded-md border border-studio-rule bg-studio-canvas px-2 py-1.5 text-[12px] text-studio-ink-strong"
+              style={{ fontFamily: font }}
+            >
+              {FONTS.map((f) => (
+                <option key={f.value} value={f.value} style={{ fontFamily: f.value }}>
+                  {f.label}
+                </option>
+              ))}
+            </select>
+          </Control>
+
+          <Slider
+            label={`Tint · ${mode}`}
+            value={mode === "edit" ? tintEdit : tintRead}
+            min={0}
+            max={0.6}
+            step={0.02}
+            onChange={(v) => (mode === "edit" ? setTintEdit(v) : setTintRead(v))}
+            display={round(mode === "edit" ? tintEdit : tintRead).toString()}
+          />
+          <Slider label="Corner radius" value={radius} min={0} max={22} step={1} onChange={setRadius} display={`${radius}px`} />
+          <Slider label="Font size" value={fontSize} min={10} max={17} step={0.5} onChange={setFontSize} display={`${fontSize}px`} />
+          <Slider label="Line height" value={lineHeight} min={1.3} max={2.1} step={0.05} onChange={setLineHeight} display={round(lineHeight).toString()} />
+
+          {/* Motion lab */}
+          <div className="rounded-lg border border-studio-rule p-3">
+            <div className="mb-2 font-mono text-[10px] uppercase tracking-eyebrow text-studio-ink-faint">
+              Motion
+            </div>
+            <Chips
+              options={ENTRANCES}
+              value={entrance}
+              onChange={(v) => {
+                setEntrance(v as Entrance);
+                setPlayKey((k) => k + 1);
+              }}
+            />
+            <div className="mt-3 space-y-3">
+              <Slider label="Duration" value={duration} min={120} max={900} step={20} onChange={setDuration} display={`${duration}ms`} />
+              <Slider label="Stagger" value={stagger} min={0} max={180} step={10} onChange={setStagger} display={`${stagger}ms`} />
+            </div>
+            <div className="mt-3 flex gap-2">
+              <button
+                onClick={replay}
+                className="flex-1 rounded-md bg-studio-ink-strong py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-studio-canvas hover:opacity-90"
+              >
+                ▶ fall into place
+              </button>
+              <button
+                onClick={() => setLoop((l) => !l)}
+                className={
+                  "rounded-md border px-3 py-2 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors " +
+                  (loop
+                    ? "border-studio-ink-strong bg-studio-chip-bg text-studio-ink-strong"
+                    : "border-studio-rule text-studio-ink-faint hover:bg-studio-chip-bg")
+                }
+              >
+                {loop ? "loop ⏸" : "loop ↻"}
+              </button>
+            </div>
+          </div>
+
+          {/* config.json export */}
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <span className="font-mono text-[10px] uppercase tracking-eyebrow text-studio-ink-faint">
+                config.json
+              </span>
+              <button
+                onClick={copyConfig}
+                className="rounded border border-studio-rule px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-studio-ink-faint hover:bg-studio-chip-bg"
+              >
+                {copied ? "copied ✓" : "copy"}
+              </button>
+            </div>
+            <pre className="overflow-x-auto rounded-lg border border-white/10 bg-[#0c0e14] p-3 text-[11px] leading-[1.7] text-white/70">
+              {configJson}
+            </pre>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function SheetTile({
+  sheet,
+  caption,
+  theme,
+  tint,
+  mode,
+  entrance,
+  duration,
+  stagger,
+  index,
+}: {
+  sheet: Sheet;
+  caption: string;
+  theme: { accent: string; radius: number; fontSize: number; lineHeight: number; font: string };
+  tint: number;
+  mode: Mode;
+  entrance: Entrance;
+  duration: number;
+  stagger: number;
+  index: number;
+}) {
+  const surface: Record<Sheet, string> = {
+    glass: "bg-white/[0.08] border border-white/[0.14] backdrop-blur-2xl",
+    card: "bg-[#15171c] border border-white/10",
+    dotted: "bg-white/[0.03] border border-white/10",
+    bracket: "bg-white/[0.02] border border-transparent",
+    marginalia: "bg-white/[0.04] border border-white/10",
+  };
+
+  const pad = sheet === "dotted" || sheet === "marginalia" ? "pl-8 pr-4 py-3.5" : "px-4 py-3.5";
+  // Brackets are a square frame — they read wrong under a corner radius.
+  const tileRadius = sheet === "bracket" ? 0 : theme.radius;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        className={`sp-anim sp-anim-${entrance} relative h-[200px] overflow-hidden shadow-[0_16px_44px_rgba(0,0,0,0.45)] ${surface[sheet]}`}
+        style={{
+          borderRadius: tileRadius,
+          animationDuration: `${duration}ms`,
+          animationDelay: `${index * stagger}ms`,
+        }}
+      >
+        {/* sheet-specific decoration */}
+        {sheet === "dotted" && (
+          <div className="pointer-events-none absolute left-0 top-0 bottom-0 w-7 border-r border-dashed border-white/15" />
+        )}
+        {sheet === "marginalia" && (
+          <div className="pointer-events-none absolute left-7 top-0 bottom-0 w-px bg-rose-300/30" />
+        )}
+        {sheet === "bracket" && <Brackets />}
+
+        {/* tint overlay (contrast floor) */}
+        <div className="pointer-events-none absolute inset-0 bg-black" style={{ opacity: tint }} />
+        {/* lighting — a soft top sheen and a hairline highlight along the top edge */}
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 h-1/2"
+          style={{ background: "linear-gradient(to bottom, rgba(255,255,255,0.08), transparent)" }}
+        />
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 h-px"
+          style={{ background: "linear-gradient(to right, transparent, rgba(255,255,255,0.30), transparent)" }}
+        />
+        {/* grain texture on the sheet itself */}
+        <div
+          className="pointer-events-none absolute inset-0"
+          style={{ backgroundImage: grain, backgroundSize: "120px 120px", opacity: 0.05, mixBlendMode: "overlay" }}
+        />
+        {/* shimmer sweep */}
+        {entrance === "shimmer" && <div className="sp-sweep pointer-events-none absolute inset-0" />}
+
+        {/* content */}
+        <div
+          className={`relative ${pad}`}
+          style={{ fontSize: theme.fontSize, lineHeight: theme.lineHeight, fontFamily: theme.font }}
+        >
+          <div className="font-semibold text-white/95" style={{ fontSize: theme.fontSize + 4 }}>
+            Weekly review
+          </div>
+          <div className="mt-1 text-white/55">## Friday</div>
+          <div className="text-white/75">- ship the studio gallery</div>
+          <div className="text-white/75">
+            - see <span style={{ color: theme.accent }}>[[roadmap]]</span>
+            {mode === "edit" && <span className="sp-caret" style={{ background: theme.accent }} />}
+          </div>
+          <div className="text-white/75">
+            -{" "}
+            <code
+              className="rounded px-1 py-0.5"
+              style={{ background: "rgba(255,255,255,0.08)", fontFamily: "ui-monospace, Menlo, monospace" }}
+            >
+              blink append
+            </code>{" "}
+            typed live
+          </div>
+          <div className="mt-2 border-l-2 border-white/15 pl-2 text-white/45">
+            notes land where you leave them
+          </div>
+        </div>
+      </div>
+      <div className="flex items-baseline justify-between px-0.5">
+        <span className="font-mono text-[12px] text-studio-ink-strong">{sheet}</span>
+        <span className="text-[11px] text-studio-ink-faint">{caption}</span>
+      </div>
+    </div>
+  );
+}
+
+function Brackets() {
+  const c = "pointer-events-none absolute h-4 w-4 border-white/35";
+  return (
+    <>
+      <span className={`${c} left-0 top-0 border-l-2 border-t-2`} />
+      <span className={`${c} right-0 top-0 border-r-2 border-t-2`} />
+      <span className={`${c} left-0 bottom-0 border-l-2 border-b-2`} />
+      <span className={`${c} right-0 bottom-0 border-r-2 border-b-2`} />
+    </>
+  );
+}
+
+function Control({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="mb-2 font-mono text-[10px] uppercase tracking-eyebrow text-studio-ink-faint">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Slider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  display,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+  display: string;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between font-mono text-[10px] uppercase tracking-eyebrow text-studio-ink-faint">
+        <span>{label}</span>
+        <span className="text-studio-ink-strong">{display}</span>
+      </div>
+      <input
+        type="range"
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="h-1 w-full cursor-pointer appearance-none rounded-full bg-studio-rule accent-studio-ink-strong"
+      />
+    </div>
+  );
+}
+
+function Segmented({
+  options,
+  value,
+  onChange,
+}: {
+  options: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex rounded-md border border-studio-rule p-0.5">
+      {options.map((o) => (
+        <button
+          key={o}
+          onClick={() => onChange(o)}
+          className={
+            "flex-1 rounded px-2 py-1 font-mono text-[10px] uppercase tracking-[0.1em] transition-colors " +
+            (value === o
+              ? "bg-studio-ink-strong text-studio-canvas"
+              : "text-studio-ink-faint hover:bg-studio-chip-bg")
+          }
+        >
+          {o}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Chips({
+  options,
+  value,
+  onChange,
+}: {
+  options: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="grid grid-cols-4 gap-1">
+      {options.map((o) => (
+        <button
+          key={o}
+          onClick={() => onChange(o)}
+          className={
+            "rounded px-1.5 py-1 font-mono text-[10px] uppercase tracking-[0.08em] transition-colors " +
+            (value === o
+              ? "bg-studio-ink-strong text-studio-canvas"
+              : "border border-studio-rule text-studio-ink-faint hover:bg-studio-chip-bg")
+          }
+        >
+          {o}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function round(n: number) {
+  return Math.round(n * 100) / 100;
+}
+
+const ENTRANCE_CSS = `
+.sp-anim { animation-fill-mode: both; animation-timing-function: cubic-bezier(0.22,1,0.36,1); }
+.sp-anim-none { animation-name: none; }
+.sp-anim-shimmer { animation-name: sp-fade; }
+.sp-anim-drop { animation-name: sp-drop; }
+.sp-anim-rise { animation-name: sp-rise; }
+.sp-anim-pop { animation-name: sp-pop; }
+.sp-anim-slide { animation-name: sp-slide; }
+.sp-anim-draw { animation-name: sp-draw; }
+.sp-anim-blur { animation-name: sp-blur; }
+@keyframes sp-fade { 0% { opacity: 0; } 100% { opacity: 1; } }
+@keyframes sp-drop { 0% { opacity: 0; transform: translateY(-14px); } 72% { transform: translateY(3px); } 100% { opacity: 1; transform: translateY(0); } }
+@keyframes sp-rise { 0% { opacity: 0; transform: translateY(16px); } 100% { opacity: 1; transform: translateY(0); } }
+@keyframes sp-pop { 0% { opacity: 0; transform: scale(0.9); } 70% { transform: scale(1.02); } 100% { opacity: 1; transform: scale(1); } }
+@keyframes sp-slide { 0% { opacity: 0; transform: translateX(-22px); } 100% { opacity: 1; transform: translateX(0); } }
+@keyframes sp-draw { 0% { opacity: 0; clip-path: inset(0 100% 0 0); } 100% { opacity: 1; clip-path: inset(0 0 0 0); } }
+@keyframes sp-blur { 0% { opacity: 0; filter: blur(10px); } 100% { opacity: 1; filter: blur(0); } }
+.sp-sweep { background: linear-gradient(105deg, transparent 30%, rgba(255,255,255,0.18) 50%, transparent 70%); transform: translateX(-120%); animation: sp-sweep 900ms ease-out both; }
+@keyframes sp-sweep { 0% { transform: translateX(-120%); } 100% { transform: translateX(160%); } }
+.sp-caret { display: inline-block; width: 2px; height: 1em; margin-left: 2px; vertical-align: text-bottom; animation: sp-blink 1.05s steps(1) infinite; }
+@keyframes sp-blink { 0%,49% { opacity: 1; } 50%,100% { opacity: 0; } }
+`;

--- a/design/studio/src/studio/studioRegistry.ts
+++ b/design/studio/src/studio/studioRegistry.ts
@@ -1,0 +1,202 @@
+import { defineStudio, type StudioPage } from "studio/registry";
+
+/**
+ * Blink product studio registry.
+ *
+ * Buckets follow the recommended split:
+ * - foundations — North Star, locked decisions, the v1 spec (scope contract)
+ * - plans      — the build plan and the design pass it came from
+ * - studies    — live UI studies for the v2.0 triad surfaces
+ */
+
+export type Bucket = "foundations" | "plans" | "studies";
+export type Surface = "vision" | "doc" | "ios" | "macos";
+export type Status = "locked" | "study" | "open";
+
+export type BlinkStudioPage = StudioPage<Bucket, Surface, Status>;
+
+export const HOME_HREF = "/studio";
+
+export const pages: readonly BlinkStudioPage[] = [
+  {
+    href: HOME_HREF,
+    label: "North Star",
+    bucket: "foundations",
+    surface: "vision",
+    status: "locked",
+    blurb:
+      "The note is the window. The desktop stays spatial; the iOS companion is the offline-first pocket view over the same Markdown truth.",
+  },
+  {
+    href: "/studio/foundations/decisions",
+    label: "Decisions & defaults",
+    bucket: "foundations",
+    surface: "vision",
+    status: "locked",
+    blurb:
+      "Everything locked on 2026-07-14: surface set, repo strategy, spatial feel, overflow story — plus the veto-able defaults.",
+    source: ["docs/v2-plan.md"],
+  },
+  {
+    href: "/studio/foundations/functionality-v1",
+    label: "v1 spec (scope contract)",
+    bucket: "foundations",
+    surface: "doc",
+    status: "locked",
+    blurb:
+      "The accurate inventory of everything v1 shipped. v2's guard against rewrite creep — if it's not here or in the plan, it waits.",
+    source: ["docs/functionality-v1.md"],
+  },
+  {
+    href: "/studio/foundations/notes-representation",
+    label: "Notes representation",
+    bucket: "foundations",
+    surface: "doc",
+    status: "open",
+    blurb:
+      "The bigger conversation: files as truth, a disposable .blink/ cache, JSON index, and the agent surface (conventions → CLI → MCP). Annotate to decide.",
+    source: ["docs/notes-representation.md"],
+  },
+  {
+    href: "/studio/plans/v2-plan",
+    label: "Build plan (M0–M5)",
+    bucket: "plans",
+    surface: "doc",
+    status: "locked",
+    blurb:
+      "Architecture, milestones with exit criteria, v1 lessons as hard requirements, risks. The working contract for the Swift build.",
+    source: ["docs/v2-plan.md"],
+  },
+  {
+    href: "/studio/plans/ui-map",
+    label: "UI map (design pass)",
+    bucket: "plans",
+    surface: "doc",
+    status: "study",
+    blurb:
+      "The design-studio pass: surface inventory, wireframes, key interactions, principles. Feeds the studies; superseded where decisions moved on.",
+    source: ["docs/v2-ui-map.md"],
+  },
+  {
+    href: "/studio/studies/ios-design-directions",
+    label: "iOS design directions",
+    bucket: "studies",
+    surface: "ios",
+    status: "study",
+    blurb:
+      "Opus, Grok, and Kimi design the same notes companion independently; Grok then synthesizes Paper Tape × Ledger into Index Tape. One controlled matrix compares four directions across list, reader, light, and dark.",
+    source: [
+      "apps/ios/BlinkMobile/ContentView.swift",
+      "design/studio/specs/ios-paper-tape.md",
+      "design/studio/specs/ios-field-log.md",
+      "design/studio/specs/ios-ledger.md",
+      "design/studio/specs/ios-index-tape.md",
+    ],
+  },
+  {
+    href: "/studio/studies/note-panel",
+    label: "Floating note panel",
+    bucket: "studies",
+    surface: "macos",
+    status: "study",
+    blurb:
+      "The atomic unit: a glass NSPanel that is nothing but the note. Chrome earned on hover; shade to a 28px bar.",
+  },
+  {
+    href: "/studio/studies/menubar-popover",
+    label: "Menubar popover",
+    bucket: "studies",
+    surface: "macos",
+    status: "study",
+    blurb:
+      "Home base. One field that searches, creates, and dictates; recents you can fling onto the desktop as panels.",
+  },
+  {
+    href: "/studio/studies/command-palette",
+    label: "Command palette",
+    bucket: "studies",
+    surface: "macos",
+    status: "study",
+    blurb:
+      "⌘K over notes and verbs. ⌘↵ opens the hit as a spatial panel, not just a selection.",
+  },
+  {
+    href: "/studio/studies/grid-overlay",
+    label: "Grid overlay HUD",
+    bucket: "studies",
+    surface: "macos",
+    status: "study",
+    blurb:
+      "Hyper+B: the 3×3 deploy grid made visible — slot occupancy, QWERTY chord keys, teachable spatial placement.",
+  },
+  {
+    href: "/studio/studies/editor-modes",
+    label: "Edit ↔ read mode",
+    bucket: "studies",
+    surface: "macos",
+    status: "study",
+    blurb:
+      "Reading and writing are two faces of one surface: read mode is rendered typography on glass, edit mode is the source. Double-click or ⌘⇧P flips in place.",
+  },
+  {
+    href: "/studio/studies/settings",
+    label: "Settings",
+    bucket: "studies",
+    surface: "macos",
+    status: "study",
+    blurb:
+      "Deliberately tiny. Three sections, one screen, no duplicated controls — the antidote to v1's 1,600-line settings panel.",
+  },
+  {
+    href: "/studio/studies/style-permutations",
+    label: "Style permutations",
+    bucket: "studies",
+    surface: "macos",
+    status: "study",
+    blurb:
+      "Every sheet under one set of controls — accent, tint, radius, type, motion — with a live config.json you can copy straight into the app.",
+  },
+  {
+    href: "/studio/studies/stacks",
+    label: "Stacks in see-all",
+    bucket: "studies",
+    surface: "macos",
+    status: "study",
+    blurb:
+      "Where idle notes go to be left alone: four metaphors for the pile on the corner of the desk — card pile, stacked sheets, shelf, messy desk. Visible, countable, leaf-through-able.",
+  },
+];
+
+const defined = defineStudio({
+  pages,
+  surfaceOrder: ["vision", "doc", "ios", "macos"],
+  defaultSurface: "macos",
+  buckets: [
+    { key: "foundations" },
+    { key: "plans" },
+    { key: "studies" },
+  ],
+  statuses: {
+    locked: { tone: "ok", label: "LOCKED" },
+    study: { tone: "info", label: "STUDY" },
+    open: { tone: "warn", label: "OPEN" },
+  },
+  // Full human + local-agent iteration loop (annotations, pins, dictation →
+  // sidecars under .studio/annotations that terminal agents read back).
+  iteration: {},
+});
+
+export const {
+  registry,
+  buckets: BUCKETS,
+  statusColors: STATUS_COLORS,
+  StatusPill,
+  renderStatusPill,
+  palette: statusPalette,
+  createIterationCommands,
+  persistAnnotations,
+  annotationsToDecisions,
+  createWinnerDecision,
+  createTurnDecision,
+  getActiveTreatment,
+} = defined;

--- a/design/studio/tsconfig.json
+++ b/design/studio/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "studio": ["../../../studio/src/index.ts"],
+      "studio/*": ["../../../studio/src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Summary
- track the shared-Studio app and its macOS/iOS study registry as a durable product-design surface
- retain the four controlled iOS direction records and align their pairing fixture with the shipped sealed-channel contract
- add the screenshot and terminal peers required by HudsonKit app-shell bundling
- update repository guidance so agents can discover and run the Studio

Verification
- clean shared-workspace bun install — passed
- bun run typecheck — passed
- bun run build — passed with Next 16.2.6 Turbopack
- named agent-browser smoke check of Studio home and iOS direction matrix — passed; session closed

Scope
- excludes live-checkout Review Bench work and all other post-snapshot files