### PR TITLE
✨ Add read-only source companions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,10 +92,12 @@ Other useful references:
 ## Where changes belong
 
 - `Sources/BlinkApp` — AppDelegate/status item/popover, command palette,
-  AppModel, PanelManager, NotePanel, config hot reload, and WebBridge.
+  AppModel, PanelManager, NotePanel, read-only SourcePanel companions, config hot
+  reload, and the note/source web bridges.
 - `Sources/BlinkCore` — pure Swift with no AppKit: note model and identity,
   frontmatter, atomic file storage, NoteStore, treatments, workspaces, and grid
-  math / panel physics.
+  math / panel physics. Portable `blink.companions` source references and their
+  contained, device-local root resolution also live here.
 - `Sources/BlinkCLI` — `swift-argument-parser` CLI over BlinkCore. `BlinkPaths`
   keeps the app and CLI on the same locations.
 - `Sources/BlinkPeer` — encrypted Multipeer Connectivity discovery, pairing,
@@ -110,10 +112,12 @@ Other useful references:
 - `Tests/BlinkCoreTests` — narrow tests for storage, frontmatter, identity,
   workspaces, grid placement, and panel physics; run the matching suite for
   domain changes.
-- `web/editor` — vanilla CodeMirror 6 (no React), bundled into one
-  `dist/editor.html` and hosted by each note panel. Load-bearing bridge contract:
+- `web/editor` — vanilla CodeMirror 6 (no React), bundled into
+  `dist/editor.html` for note panels and `dist/source-viewer.html` for read-only
+  source panels. Load-bearing note bridge contract:
   `ready` / user-only `contentChanged` / `saveRequested` → native;
-  `setContent` / `getContent` / `focus` ← native.
+  `setContent` / `getContent` / `focus` ← native. The source bridge has no
+  getter, change message, save request, or native write callback.
 - Generic panel or web-bridge primitives should be shaped for eventual
   HudsonKit upstreaming once proven here.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,10 +92,12 @@ Other useful references:
 ## Where changes belong
 
 - `Sources/BlinkApp` — AppDelegate/status item/popover, command palette,
-  AppModel, PanelManager, NotePanel, config hot reload, and WebBridge.
+  AppModel, PanelManager, NotePanel, read-only SourcePanel companions, config hot
+  reload, and the note/source web bridges.
 - `Sources/BlinkCore` — pure Swift with no AppKit: note model and identity,
   frontmatter, atomic file storage, NoteStore, treatments, workspaces, and grid
-  math / panel physics.
+  math / panel physics. Portable `blink.companions` source references and their
+  contained, device-local root resolution also live here.
 - `Sources/BlinkCLI` — `swift-argument-parser` CLI over BlinkCore. `BlinkPaths`
   keeps the app and CLI on the same locations.
 - `Sources/BlinkPeer` — encrypted Multipeer Connectivity discovery, pairing,
@@ -110,10 +112,12 @@ Other useful references:
 - `Tests/BlinkCoreTests` — narrow tests for storage, frontmatter, identity,
   workspaces, grid placement, and panel physics; run the matching suite for
   domain changes.
-- `web/editor` — vanilla CodeMirror 6 (no React), bundled into one
-  `dist/editor.html` and hosted by each note panel. Load-bearing bridge contract:
+- `web/editor` — vanilla CodeMirror 6 (no React), bundled into
+  `dist/editor.html` for note panels and `dist/source-viewer.html` for read-only
+  source panels. Load-bearing note bridge contract:
   `ready` / user-only `contentChanged` / `saveRequested` → native;
-  `setContent` / `getContent` / `focus` ← native.
+  `setContent` / `getContent` / `focus` ← native. The source bridge has no
+  getter, change message, save request, or native write callback.
 - Generic panel or web-bridge primitives should be shaped for eventual
   HudsonKit upstreaming once proven here.
 

--- a/Sources/BlinkApp/AppDelegate.swift
+++ b/Sources/BlinkApp/AppDelegate.swift
@@ -11,6 +11,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var popover: NSPopover?
     private var contextMenu: NSMenu!
     private var store: NoteStore!
+    private var sourcePanelManager: SourcePanelManager!
     private var panelManager: PanelManager!
     private var model: AppModel!
     private var settingsWindow: NSWindow?
@@ -39,7 +40,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             tombstoneStore: BlinkTombstoneStore(fileURL: BlinkPaths.tombstones())
         )
         startPeerServer()
-        panelManager = PanelManager(store: store)
+        sourcePanelManager = SourcePanelManager()
+        panelManager = PanelManager(store: store, sourcePanels: sourcePanelManager)
         model = AppModel(store: store, panelManager: panelManager)
         panelManager.onWorkspaceScopeRequested = { [weak self] scope in
             self?.model.selectWorkspace(scope)
@@ -147,6 +149,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
 
         appItem("Commands…", action: #selector(menuCommands), keyEquivalent: "k")
+        appItem("Open Source File…", action: #selector(menuOpenSourceFile), keyEquivalent: "o")
         appItem(
             "Help & Shortcuts",
             action: #selector(menuGuide),
@@ -541,6 +544,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         newNoteItem.target = self
         menu.addItem(newNoteItem)
 
+        let sourceItem = NSMenuItem(
+            title: "Open Source File…",
+            action: #selector(menuOpenSourceFile),
+            keyEquivalent: ""
+        )
+        sourceItem.target = self
+        menu.addItem(sourceItem)
+
         menu.addItem(.separator())
 
         // Background: quick control over the drape (the full-screen blur/dim
@@ -678,6 +689,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         toggleCommandPalette(from: NSApp.keyWindow)
     }
 
+    @objc private func menuOpenSourceFile() {
+        popover?.performClose(nil)
+        commandPaletteController?.dismiss()
+        sourcePanelManager.chooseAndOpenFile()
+    }
+
     @objc private func menuGuide() {
         openGuide()
     }
@@ -810,6 +827,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             openConfigFile: {
                 NSWorkspace.shared.open(BlinkConfigStore.shared.fileURL)
             },
+            openSourceFile: { [weak self] in self?.menuOpenSourceFile() },
             toggleCurrentNoteMode: { [weak self] in self?.panelManager.toggleCommandNoteMode() },
             toggleCurrentNoteFocus: { [weak self] in self?.panelManager.toggleCommandNoteFocus() },
             chooseCurrentNoteStyle: { [weak self] in self?.panelManager.chooseCommandNoteStyle() },

--- a/Sources/BlinkApp/BlinkActivityCatalog.swift
+++ b/Sources/BlinkApp/BlinkActivityCatalog.swift
@@ -14,6 +14,7 @@ enum BlinkActivityID: String, CaseIterable, Identifiable {
 
     case searchNotes = "popover.search"
     case openSelectedNote = "popover.open-selected-note"
+    case openSourceFile = "files.open-source"
     case createFromCapture = "popover.create-from-capture"
     case dictateCapture = "popover.dictate"
 
@@ -165,6 +166,7 @@ struct BlinkActivityCatalog {
         var openGuide: Action?
         var revealNotesFolder: Action?
         var openConfigFile: Action?
+        var openSourceFile: Action?
 
         var toggleCurrentNoteMode: Action?
         var toggleCurrentNoteFocus: Action?
@@ -188,6 +190,7 @@ struct BlinkActivityCatalog {
             openGuide: Action? = nil,
             revealNotesFolder: Action? = nil,
             openConfigFile: Action? = nil,
+            openSourceFile: Action? = nil,
             toggleCurrentNoteMode: Action? = nil,
             toggleCurrentNoteFocus: Action? = nil,
             chooseCurrentNoteStyle: Action? = nil,
@@ -207,6 +210,7 @@ struct BlinkActivityCatalog {
             self.openGuide = openGuide
             self.revealNotesFolder = revealNotesFolder
             self.openConfigFile = openConfigFile
+            self.openSourceFile = openSourceFile
             self.toggleCurrentNoteMode = toggleCurrentNoteMode
             self.toggleCurrentNoteFocus = toggleCurrentNoteFocus
             self.chooseCurrentNoteStyle = chooseCurrentNoteStyle
@@ -344,6 +348,18 @@ private extension BlinkActivityCatalog {
                 scope: .panel,
                 keywords: ["wiki", "backlink", "click"],
                 shortcut: fixed("Click [[link]]")
+            ),
+            BlinkActivity(
+                id: .openSourceFile,
+                title: "Open Source File",
+                description: "Inspect a local code or text file in a read-only floating panel.",
+                symbolName: "chevron.left.forwardslash.chevron.right",
+                group: .findAndOpen,
+                scope: .application,
+                keywords: ["code", "file", "source", "viewer", "read only"],
+                shortcut: fixed("⌘O"),
+                availability: actionAvailability(h.openSourceFile),
+                execution: h.openSourceFile
             ),
             BlinkActivity(
                 id: .openSettings,

--- a/Sources/BlinkApp/BlinkConfig.swift
+++ b/Sources/BlinkApp/BlinkConfig.swift
@@ -238,6 +238,29 @@ struct BlinkConfig: Codable, Equatable {
         }
     }
 
+    /// Local source-viewer authority. Notes carry only `root/path`; each device
+    /// maps the root name to an absolute directory it has explicitly approved.
+    struct Sources: Codable, Equatable {
+        var roots: [String: String] = [:]
+        var maxPreviewBytes: Int = SourceFileResolver.defaultMaxByteSize
+        var autoOpenCompanions = true
+
+        init() {}
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            roots = try container.decodeIfPresent([String: String].self, forKey: .roots) ?? [:]
+            maxPreviewBytes = max(
+                1,
+                try container.decodeIfPresent(Int.self, forKey: .maxPreviewBytes)
+                    ?? SourceFileResolver.defaultMaxByteSize
+            )
+            autoOpenCompanions = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .autoOpenCompanions
+            ) ?? true
+        }
+    }
+
     /// A named, reusable presentation preset — a *partial* overlay onto the
     /// panel/editor defaults, every field optional. A note references one by name
     /// via its `blink.style`, and a workspace brands every one of its notes with
@@ -265,6 +288,7 @@ struct BlinkConfig: Codable, Equatable {
     var motion = Motion()
     var physics = Physics()
     var editor = Editor()
+    var sources = Sources()
     /// Named presentation presets, referenced by a note's `blink.style` and
     /// reusable as a workspace's brand base.
     var styles: [String: Treatment]?
@@ -284,6 +308,7 @@ struct BlinkConfig: Codable, Equatable {
         motion = try c.decodeIfPresent(Motion.self, forKey: .motion) ?? Motion()
         physics = try c.decodeIfPresent(Physics.self, forKey: .physics) ?? Physics()
         editor = try c.decodeIfPresent(Editor.self, forKey: .editor) ?? Editor()
+        sources = try c.decodeIfPresent(Sources.self, forKey: .sources) ?? Sources()
         styles = try c.decodeIfPresent([String: Treatment].self, forKey: .styles)
         workspaces = try c.decodeIfPresent([String: Workspace].self, forKey: .workspaces)
     }

--- a/Sources/BlinkApp/ConfigStore.swift
+++ b/Sources/BlinkApp/ConfigStore.swift
@@ -8,4 +8,5 @@ enum ConfigKeys {
     static let defaultMode = "blink.defaultMode"        // legacy; migrated into config.json
     static let activeWorkspaceScope = "blink.activeWorkspaceScope"
     static func noteMode(_ id: String) -> String { "blink.noteMode.\(id)" }
+    static func noteCompanionsHidden(_ id: String) -> String { "blink.noteCompanionsHidden.\(id)" }
 }

--- a/Sources/BlinkApp/NotePanel.swift
+++ b/Sources/BlinkApp/NotePanel.swift
@@ -87,6 +87,12 @@ final class NotePanel: NSPanel {
     /// panel asks rather than reading a potentially stale file from disk.
     var markdownProvider: (() -> String?)?
 
+    /// Note-declared code cast. The panel only exposes the local visibility
+    /// control; SourcePanelManager owns resolving, placement, and windows.
+    private var sourceCompanionCount = 0
+    private var sourceCompanionsVisible = true
+    var onToggleSourceCompanions: (() -> Void)?
+
     let modeState = PanelModeState()
     var currentMode: String { modeState.mode }
 
@@ -587,6 +593,11 @@ final class NotePanel: NSPanel {
         applyTheme(BlinkConfigStore.shared.config)
     }
 
+    func configureSourceCompanions(count: Int, visible: Bool) {
+        sourceCompanionCount = count
+        sourceCompanionsVisible = visible
+    }
+
     private func updateMetadata(_ theme: BlinkConfig) {
         modeState.sheet = theme.panel.sheet
         modeState.style = notePresentation.style
@@ -675,6 +686,16 @@ final class NotePanel: NSPanel {
         styleItem.image = NSImage(systemSymbolName: "paintpalette", accessibilityDescription: nil)
         styleItem.submenu = makeStyleMenu()
         menu.addItem(styleItem)
+
+        if sourceCompanionCount > 0 {
+            menu.addItem(contextItem(
+                sourceCompanionsVisible ? "Hide Code Companions" : "Show Code Companions",
+                symbol: sourceCompanionsVisible
+                    ? "eye.slash"
+                    : "chevron.left.forwardslash.chevron.right",
+                action: #selector(contextToggleSourceCompanions(_:))
+            ))
+        }
 
         menu.addItem(.separator())
         menu.addItem(contextItem(
@@ -795,6 +816,11 @@ final class NotePanel: NSPanel {
 
     @objc private func contextToggleFocus(_ sender: NSMenuItem) {
         toggleFocus()
+    }
+
+    @objc private func contextToggleSourceCompanions(_ sender: NSMenuItem) {
+        sourceCompanionsVisible.toggle()
+        onToggleSourceCompanions?()
     }
 
     /// Soft hide: tuck the panel away but keep it in the session, so clicking

--- a/Sources/BlinkApp/PanelManager.swift
+++ b/Sources/BlinkApp/PanelManager.swift
@@ -18,6 +18,7 @@ struct DeskFrameRequest: Sendable {
 @MainActor
 final class PanelManager: NSObject, NSWindowDelegate {
     private let store: NoteStore
+    private let sourcePanels: SourcePanelManager
     private var panels: [String: NotePanel] = [:]
     private var pendingText: [String: String] = [:]
     /// What each open panel currently displays — the tell between "our own
@@ -27,6 +28,9 @@ final class PanelManager: NSObject, NSWindowDelegate {
     /// `blink.slot` (e.g. `blink present --slot`) can move the panel live and an
     /// unchanged one never re-snaps. Absent = the note declares no slot.
     private var panelSlot: [String: Int] = [:]
+    /// Detects metadata-only source-cast changes without reloading every
+    /// companion after ordinary body saves.
+    private var panelCompanionSignatures: [String: String] = [:]
     private var observers: [NSObjectProtocol] = []
     private var saveTasks: [String: Task<Void, Never>] = [:]
     private var revealCompletionTasks: [String: Task<Void, Never>] = [:]
@@ -62,8 +66,9 @@ final class PanelManager: NSObject, NSWindowDelegate {
         let wasKey: Bool
     }
 
-    init(store: NoteStore) {
+    init(store: NoteStore, sourcePanels: SourcePanelManager) {
         self.store = store
+        self.sourcePanels = sourcePanels
     }
 
     // MARK: - Lifecycle
@@ -138,6 +143,7 @@ final class PanelManager: NSObject, NSWindowDelegate {
     /// A note is being deleted: drop any pending edits for it (so the close
     /// flush doesn't resurrect them against a missing id) and close its panel.
     func handleNoteDeleted(id: String) {
+        sourcePanels.dismissCompanions(for: id)
         discardTypedReveal(id: id)
         saveTasks[id]?.cancel()
         saveTasks[id] = nil
@@ -184,6 +190,19 @@ final class PanelManager: NSObject, NSWindowDelegate {
             presentation.sheet = legacy
         }
         panel.applyPresentation(presentation)
+        panel.configureSourceCompanions(
+            count: presentation.companions?.sources.count ?? 0,
+            visible: sourcePanels.companionsVisible(for: id)
+        )
+        let companionSignature = Self.companionSignature(presentation.companions)
+        if panelCompanionSignatures[id] != companionSignature {
+            panelCompanionSignatures[id] = companionSignature
+            if presentation.companions?.sources.isEmpty != false {
+                sourcePanels.dismissCompanions(for: id)
+            } else if !blinkHidden, panel.isVisible, panelMatchesWorkspace(noteID: id) {
+                sourcePanels.activateCompanions(for: note, relativeTo: panel.frame)
+            }
+        }
 
         // Presentation intent must reach an open panel even when the body is
         // unchanged: `blink present --slot N` moves the panel into its grid cell.
@@ -395,6 +414,14 @@ final class PanelManager: NSObject, NSWindowDelegate {
         // next Hyper+B should hide everything again.
         if shouldPresent { blinkHidden = false }
         if let existing = panels[note.id] {
+            let companionCount = note.presentation.companions?.sources.count ?? 0
+            panelCompanionSignatures[note.id] = Self.companionSignature(
+                note.presentation.companions
+            )
+            existing.configureSourceCompanions(
+                count: companionCount,
+                visible: sourcePanels.companionsVisible(for: note.id)
+            )
             if let deskFrame {
                 applyDeskFrame(noteID: note.id, request: deskFrame, animated: false)
             }
@@ -405,6 +432,11 @@ final class PanelManager: NSObject, NSWindowDelegate {
             } else {
                 workspaceSuppressedPanelIDs.insert(note.id)
                 existing.orderOut(nil)
+            }
+            if shouldPresent, companionCount > 0 {
+                sourcePanels.activateCompanions(for: note, relativeTo: existing.frame)
+            } else {
+                sourcePanels.dismissCompanions(for: note.id)
             }
             return existing
         }
@@ -425,6 +457,9 @@ final class PanelManager: NSObject, NSWindowDelegate {
         panel.delegate = self
         panels[note.id] = panel
         panelContent[note.id] = note.content
+        panelCompanionSignatures[note.id] = Self.companionSignature(
+            note.presentation.companions
+        )
 
         // The panel's context menu copies the truthful in-memory document,
         // including edits that have not reached the debounced disk save yet.
@@ -452,7 +487,25 @@ final class PanelManager: NSObject, NSWindowDelegate {
 
         // Hiding a note from its context menu changes how many notes are on
         // screen, which the drape depends on — re-evaluate its backdrops.
-        panel.onVisibilityChanged = { [weak self] in self?.updateFocusOverlay() }
+        panel.onVisibilityChanged = { [weak self] in
+            self?.sourcePanels.dismissCompanions(for: note.id)
+            self?.updateFocusOverlay()
+        }
+        panel.configureSourceCompanions(
+            count: note.presentation.companions?.sources.count ?? 0,
+            visible: sourcePanels.companionsVisible(for: note.id)
+        )
+        panel.onToggleSourceCompanions = { [weak self, weak panel] in
+            guard let self, let panel else { return }
+            Task { @MainActor in
+                guard let current = await self.store.note(id: note.id) else { return }
+                self.sourcePanels.toggleCompanions(for: current, relativeTo: panel.frame)
+                panel.configureSourceCompanions(
+                    count: current.presentation.companions?.sources.count ?? 0,
+                    visible: self.sourcePanels.companionsVisible(for: note.id)
+                )
+            }
+        }
 
         panel.editor.onContentChanged = { [weak self] text in
             // User input is the reveal's hard stop. Web already unmasks its
@@ -544,6 +597,9 @@ final class PanelManager: NSObject, NSWindowDelegate {
         persistOpenList()
         updateFocusOverlay()
         gridOverlay?.refresh()
+        if shouldPresent, playEntrance {
+            sourcePanels.activateCompanions(for: note, relativeTo: panel.frame)
+        }
         return panel
     }
 
@@ -605,6 +661,19 @@ final class PanelManager: NSObject, NSWindowDelegate {
     func windowDidBecomeKey(_ notification: Notification) {
         if let panel = notification.object as? NotePanel {
             mostRecentKeyPanelID = panel.noteID
+            Task { [weak self, weak panel] in
+                guard let self, let panel,
+                      !self.blinkHidden,
+                      self.panelMatchesWorkspace(noteID: panel.noteID),
+                      panel.isKeyWindow,
+                      let note = await self.store.note(id: panel.noteID)
+                else { return }
+                self.sourcePanels.activateCompanions(for: note, relativeTo: panel.frame)
+                panel.configureSourceCompanions(
+                    count: note.presentation.companions?.sources.count ?? 0,
+                    visible: self.sourcePanels.companionsVisible(for: note.id)
+                )
+            }
         }
         updateFocusOverlay()
     }
@@ -754,9 +823,12 @@ final class PanelManager: NSObject, NSWindowDelegate {
 
         let matching = panels.filter { panelMatchesWorkspace(noteID: $0.key) }
         let outgoing = panels.filter { !panelMatchesWorkspace(noteID: $0.key) }
-        for (id, panel) in outgoing where panel.isVisible {
-            workspaceSuppressedPanelIDs.insert(id)
-            panel.orderOut(nil)
+        for (id, panel) in outgoing {
+            sourcePanels.dismissCompanions(for: id)
+            if panel.isVisible {
+                workspaceSuppressedPanelIDs.insert(id)
+                panel.orderOut(nil)
+            }
         }
 
         guard !blinkHidden else {
@@ -869,6 +941,7 @@ final class PanelManager: NSObject, NSWindowDelegate {
         for panel in panels.values {
             panel.applyTheme(config)
         }
+        sourcePanels.applyTheme(config)
         focusOverlay.applyTheme(dim: config.focus.dim)
         drapeOverlay.applyTheme(
             dim: config.drape.dim,
@@ -910,6 +983,9 @@ final class PanelManager: NSObject, NSWindowDelegate {
         let motion = BlinkConfigStore.shared.config.motion
         let animate = motion.enabled && !NotePanel.reduceMotion
         if blinkHidden {
+            for id in panels.keys where panelMatchesWorkspace(noteID: id) {
+                sourcePanels.dismissCompanions(for: id)
+            }
             if animate {
                 // Synchronized exhale: every panel fades + drifts 6px outward
                 // together over ~180ms, THEN orderOut. The state is already
@@ -995,6 +1071,7 @@ final class PanelManager: NSObject, NSWindowDelegate {
     /// and persists an EMPTY open-notes list — killing session restore.
     func prepareForTermination() {
         isTerminating = true
+        sourcePanels.closeAll()
         for id in Array(revealCompletionTasks.keys) { discardTypedReveal(id: id) }
         gridOverlay?.hide()
         focusOverlay.hide()
@@ -1036,16 +1113,24 @@ final class PanelManager: NSObject, NSWindowDelegate {
         }
     }
 
+    private static func companionSignature(_ companions: NoteCompanions?) -> String {
+        guard let companions else { return "" }
+        return ([companions.layout ?? ""] + companions.sources.map(\.locator))
+            .joined(separator: "\u{1F}")
+    }
+
     // MARK: - NSWindowDelegate
 
     func windowWillClose(_ notification: Notification) {
         guard let panel = notification.object as? NotePanel else { return }
         let id = panel.noteID
+        sourcePanels.dismissCompanions(for: id)
         discardTypedReveal(id: id)
         panel.editor.teardown()
         panels[id] = nil
         panelContent[id] = nil
         panelSlot[id] = nil
+        panelCompanionSignatures[id] = nil
         panelWorkspaces[id] = nil
         workspaceSuppressedPanelIDs.remove(id)
         if mostRecentKeyPanelID == id {

--- a/Sources/BlinkApp/SourcePanel.swift
+++ b/Sources/BlinkApp/SourcePanel.swift
@@ -1,0 +1,302 @@
+// THESIS: A source file should read as a first-class Blink object without pretending to be a note or an IDE.
+// OWN-WORLD: Deep translucent glass, compact native provenance chrome, cool signal blue, and CodeMirror ink.
+// STORY: Identify the file and trust boundary, inspect anchored code, search or select it, then hand off to the expert editor.
+// FIRST VIEWPORT: Path and filename lead; READ ONLY is persistent; anchored lines appear immediately in a spacious line-numbered source plane.
+// FORM: A floating resizable companion panel that inherits Blink geometry and material while keeping a distinct renderer-only bridge.
+
+import AppKit
+import BlinkCore
+import SwiftUI
+
+@MainActor
+final class SourcePanel: NSPanel {
+    let sourceIdentity: String
+    let viewer = SourceViewerWebView()
+    private(set) var document: SourceDocument
+    private(set) var restoredLocalFrame = false
+
+    private let container = NSView()
+    private let glass = NSVisualEffectView()
+    private let tint = NSView()
+    private let header = SourceDragView()
+    private let footer = NSView()
+    private let titleField = NSTextField(labelWithString: "")
+    private let pathField = NSTextField(labelWithString: "")
+    private let languageField = NSTextField(labelWithString: "")
+    private let provenanceField = NSTextField(labelWithString: "")
+    private let readOnlyField = NSTextField(labelWithString: "READ ONLY")
+
+    init(document: SourceDocument) {
+        self.document = document
+        sourceIdentity = document.url.path
+        let config = BlinkConfigStore.shared.config
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 460),
+            styleMask: [.borderless, .resizable, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        title = document.displayName
+        isFloatingPanel = true
+        level = .floating
+        hidesOnDeactivate = false
+        acceptsMouseMovedEvents = true
+        isMovableByWindowBackground = true
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        minSize = NSSize(width: 390, height: 240)
+        collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary]
+
+        buildSurface(config)
+        update(document)
+
+        let autosaveName = "blink.source.\(uuidFromSlug("source:\(sourceIdentity)").uuidString.lowercased())"
+        restoredLocalFrame = setFrameUsingName(autosaveName)
+        if !restoredLocalFrame { center() }
+        setFrameAutosaveName(autosaveName)
+
+        viewer.load()
+        viewer.setDocument(document)
+        applyTheme(config)
+    }
+
+    override var canBecomeKey: Bool { true }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let key = event.charactersIgnoringModifiers?.lowercased()
+        if flags == [.command], key == "w" {
+            close()
+            return true
+        }
+        if flags == [.command], key == "f" {
+            viewer.showFind()
+            return true
+        }
+        if flags == [.command], key == "k" {
+            NotificationCenter.default.post(name: .blinkCommandPaletteRequested, object: self)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    override func cancelOperation(_ sender: Any?) {
+        close()
+    }
+
+    func update(_ next: SourceDocument) {
+        document = next
+        title = next.displayName
+        titleField.stringValue = next.displayName
+        pathField.stringValue = next.displayPath
+        languageField.stringValue = next.language.uppercased()
+        provenanceField.stringValue = Self.provenance(for: next)
+        viewer.setDocument(next)
+    }
+
+    func applyTheme(_ config: BlinkConfig) {
+        let scheme = AppearanceManager.shared.scheme
+        appearance = NSAppearance(named: scheme.nsAppearanceName)
+        glass.material = NotePanel.glassMaterial(config, scheme)
+        let radius = min(max(config.panel.cornerRadius, 8), 22)
+        container.layer?.cornerRadius = radius
+        glass.layer?.cornerRadius = radius
+        tint.layer?.backgroundColor = NotePanel.tintColor(scheme)
+        tint.alphaValue = scheme.isDark ? 0.42 : 0.58
+        hasShadow = config.panel.shadow
+
+        let strong = scheme.isDark ? NSColor.white.withAlphaComponent(0.94) : NSColor.black.withAlphaComponent(0.88)
+        let muted = scheme.isDark ? NSColor.white.withAlphaComponent(0.48) : NSColor.black.withAlphaComponent(0.50)
+        titleField.textColor = strong
+        pathField.textColor = muted
+        languageField.textColor = muted
+        provenanceField.textColor = muted
+        readOnlyField.textColor = scheme.isDark
+            ? NSColor(calibratedRed: 0.62, green: 0.76, blue: 0.97, alpha: 0.8)
+            : NSColor(calibratedRed: 0.14, green: 0.33, blue: 0.62, alpha: 0.9)
+
+        var variables = config.editorThemeVars(scheme: scheme)
+        variables["--blink-source-font-size"] = "12px"
+        variables["--blink-source-line-height"] = "1.62"
+        variables["--blink-source-color-scheme"] = scheme.isDark ? "dark" : "light"
+        if scheme.isDark {
+            variables["--blink-source-anchor"] = "rgba(89,137,211,0.16)"
+            variables["--blink-source-match"] = "rgba(214,174,91,0.24)"
+            variables["--blink-source-panel"] = "rgba(12,17,28,0.96)"
+            variables["--blink-source-rule"] = "rgba(255,255,255,0.12)"
+            variables["--blink-source-keyword"] = "#8db8ff"
+            variables["--blink-source-type"] = "#7fd7d0"
+            variables["--blink-source-function"] = "#d8b5ff"
+            variables["--blink-source-string"] = "#9bd49b"
+            variables["--blink-source-literal"] = "#e7bd86"
+            variables["--blink-source-meta"] = "#b8c7df"
+        } else {
+            variables["--blink-source-anchor"] = "rgba(45,93,175,0.12)"
+            variables["--blink-source-match"] = "rgba(161,112,25,0.18)"
+            variables["--blink-source-panel"] = "rgba(248,247,244,0.98)"
+            variables["--blink-source-rule"] = "rgba(24,22,20,0.14)"
+            variables["--blink-source-keyword"] = "#245ba7"
+            variables["--blink-source-type"] = "#16756f"
+            variables["--blink-source-function"] = "#7650a5"
+            variables["--blink-source-string"] = "#39743d"
+            variables["--blink-source-literal"] = "#9a5a19"
+            variables["--blink-source-meta"] = "#4e607a"
+        }
+        viewer.setTheme(variables)
+    }
+
+    private func buildSurface(_ config: BlinkConfig) {
+        container.wantsLayer = true
+        container.layer?.masksToBounds = true
+        contentView = container
+
+        glass.blendingMode = .behindWindow
+        glass.state = .active
+        glass.wantsLayer = true
+        glass.layer?.masksToBounds = true
+        pin(glass, to: container)
+
+        tint.wantsLayer = true
+        pin(tint, to: container)
+
+        header.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(header)
+        footer.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(footer)
+
+        let separatorTop = separator()
+        header.addSubview(separatorTop)
+        let separatorBottom = separator()
+        footer.addSubview(separatorBottom)
+
+        let close = symbolButton("xmark", help: "Close source", action: #selector(closeSource))
+        let open = symbolButton("arrow.up.forward.app", help: "Open in default editor", action: #selector(openInEditor))
+        let reveal = symbolButton("folder", help: "Reveal in Finder", action: #selector(revealInFinder))
+        for button in [close, open, reveal] { header.addSubview(button) }
+
+        titleField.font = .systemFont(ofSize: 12, weight: .semibold)
+        titleField.lineBreakMode = .byTruncatingMiddle
+        pathField.font = .monospacedSystemFont(ofSize: 10, weight: .medium)
+        pathField.lineBreakMode = .byTruncatingMiddle
+        readOnlyField.font = .monospacedSystemFont(ofSize: 10, weight: .semibold)
+        readOnlyField.alignment = .right
+        for field in [titleField, pathField, readOnlyField] {
+            field.translatesAutoresizingMaskIntoConstraints = false
+            header.addSubview(field)
+        }
+
+        languageField.font = .monospacedSystemFont(ofSize: 10, weight: .semibold)
+        provenanceField.font = .monospacedSystemFont(ofSize: 10, weight: .medium)
+        provenanceField.alignment = .right
+        for field in [languageField, provenanceField] {
+            field.translatesAutoresizingMaskIntoConstraints = false
+            footer.addSubview(field)
+        }
+
+        let webView = viewer.webView
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(webView)
+
+        NSLayoutConstraint.activate([
+            header.topAnchor.constraint(equalTo: container.topAnchor),
+            header.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            header.heightAnchor.constraint(equalToConstant: 49),
+            footer.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            footer.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            footer.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            footer.heightAnchor.constraint(equalToConstant: 25),
+            webView.topAnchor.constraint(equalTo: header.bottomAnchor),
+            webView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: footer.topAnchor),
+
+            close.leadingAnchor.constraint(equalTo: header.leadingAnchor, constant: 11),
+            close.centerYAnchor.constraint(equalTo: header.centerYAnchor),
+            close.widthAnchor.constraint(equalToConstant: 25),
+            close.heightAnchor.constraint(equalToConstant: 25),
+            titleField.leadingAnchor.constraint(equalTo: close.trailingAnchor, constant: 10),
+            titleField.topAnchor.constraint(equalTo: header.topAnchor, constant: 9),
+            titleField.trailingAnchor.constraint(lessThanOrEqualTo: readOnlyField.leadingAnchor, constant: -10),
+            pathField.leadingAnchor.constraint(equalTo: titleField.leadingAnchor),
+            pathField.topAnchor.constraint(equalTo: titleField.bottomAnchor, constant: 3),
+            pathField.trailingAnchor.constraint(lessThanOrEqualTo: readOnlyField.leadingAnchor, constant: -10),
+            readOnlyField.centerYAnchor.constraint(equalTo: header.centerYAnchor),
+            readOnlyField.trailingAnchor.constraint(equalTo: reveal.leadingAnchor, constant: -9),
+            reveal.trailingAnchor.constraint(equalTo: open.leadingAnchor, constant: -3),
+            reveal.centerYAnchor.constraint(equalTo: header.centerYAnchor),
+            reveal.widthAnchor.constraint(equalToConstant: 25),
+            reveal.heightAnchor.constraint(equalToConstant: 25),
+            open.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -10),
+            open.centerYAnchor.constraint(equalTo: header.centerYAnchor),
+            open.widthAnchor.constraint(equalToConstant: 25),
+            open.heightAnchor.constraint(equalToConstant: 25),
+
+            separatorTop.leadingAnchor.constraint(equalTo: header.leadingAnchor),
+            separatorTop.trailingAnchor.constraint(equalTo: header.trailingAnchor),
+            separatorTop.bottomAnchor.constraint(equalTo: header.bottomAnchor),
+            separatorTop.heightAnchor.constraint(equalToConstant: 1),
+            separatorBottom.leadingAnchor.constraint(equalTo: footer.leadingAnchor),
+            separatorBottom.trailingAnchor.constraint(equalTo: footer.trailingAnchor),
+            separatorBottom.topAnchor.constraint(equalTo: footer.topAnchor),
+            separatorBottom.heightAnchor.constraint(equalToConstant: 1),
+            languageField.leadingAnchor.constraint(equalTo: footer.leadingAnchor, constant: 13),
+            languageField.centerYAnchor.constraint(equalTo: footer.centerYAnchor, constant: 1),
+            provenanceField.trailingAnchor.constraint(equalTo: footer.trailingAnchor, constant: -13),
+            provenanceField.centerYAnchor.constraint(equalTo: footer.centerYAnchor, constant: 1),
+            provenanceField.leadingAnchor.constraint(greaterThanOrEqualTo: languageField.trailingAnchor, constant: 12),
+        ])
+    }
+
+    private func pin(_ view: NSView, to parent: NSView) {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        parent.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: parent.topAnchor),
+            view.leadingAnchor.constraint(equalTo: parent.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: parent.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: parent.bottomAnchor),
+        ])
+    }
+
+    private func separator() -> NSView {
+        let view = NSView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.11).cgColor
+        return view
+    }
+
+    private func symbolButton(_ symbol: String, help: String, action: Selector) -> NSButton {
+        let image = NSImage(systemSymbolName: symbol, accessibilityDescription: help) ?? NSImage()
+        let button = NSButton(image: image, target: self, action: action)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.isBordered = false
+        button.imageScaling = .scaleProportionallyDown
+        button.contentTintColor = .secondaryLabelColor
+        button.toolTip = help
+        button.setAccessibilityLabel(help)
+        return button
+    }
+
+    @objc private func closeSource() { close() }
+    @objc private func openInEditor() { NSWorkspace.shared.open(document.url) }
+    @objc private func revealInFinder() {
+        NSWorkspace.shared.activateFileViewerSelecting([document.url])
+    }
+
+    private static func provenance(for document: SourceDocument) -> String {
+        var pieces: [String] = []
+        if let lines = document.lines {
+            pieces.append(lines.start == lines.end ? "L\(lines.start)" : "L\(lines.start)–\(lines.end)")
+        }
+        if let revision = document.revision { pieces.append(revision) }
+        return pieces.joined(separator: " · ")
+    }
+}
+
+private final class SourceDragView: NSView {
+    override var mouseDownCanMoveWindow: Bool { true }
+}

--- a/Sources/BlinkApp/SourcePanelManager.swift
+++ b/Sources/BlinkApp/SourcePanelManager.swift
@@ -1,0 +1,293 @@
+import AppKit
+import BlinkCore
+import HudsonObservability
+
+private enum SourceResolutionOutcome: Sendable {
+    case document(SourceDocument)
+    case failure(SourceReference, SourceFileError)
+}
+
+/// Owns source windows as a domain parallel to note windows. Source panels have
+/// one canonical-path identity, local frame autosave, and no save pipeline.
+@MainActor
+final class SourcePanelManager: NSObject, NSWindowDelegate {
+    private var panels: [String: SourcePanel] = [:]
+    private var standalonePanelIDs: Set<String> = []
+    private var companionPanelIDs: [String: Set<String>] = [:]
+    private var activeCompanionNoteID: String?
+    private var activationToken = UUID()
+    private let log = HudLogger(category: "blink.sources")
+
+    var hasOpenPanels: Bool { !panels.isEmpty }
+
+    func chooseAndOpenFile() {
+        let picker = NSOpenPanel()
+        picker.title = "Open Source File"
+        picker.message = "Choose a source, data, configuration, patch, or text file to inspect."
+        picker.prompt = "Open"
+        picker.canChooseFiles = true
+        picker.canChooseDirectories = false
+        picker.allowsMultipleSelection = false
+        picker.resolvesAliases = true
+        guard picker.runModal() == .OK, let url = picker.url else { return }
+        openPickedFile(url)
+    }
+
+    func openPickedFile(_ url: URL) {
+        let resolver = makeResolver()
+        Task { [weak self] in
+            let outcome = await Task.detached(priority: .userInitiated) {
+                do { return Result<SourceDocument, SourceFileError>.success(try resolver.resolvePickedFile(url)) }
+                catch let error as SourceFileError { return .failure(error) }
+                catch { return .failure(.missingFile(url.path)) }
+            }.value
+            guard let self else { return }
+            switch outcome {
+            case .success(let document):
+                self.show(document, frame: nil, activate: true, standalone: true)
+            case .failure(let error): self.present(error)
+            }
+        }
+    }
+
+    func companionsVisible(for noteID: String) -> Bool {
+        !UserDefaults.standard.bool(forKey: ConfigKeys.noteCompanionsHidden(noteID))
+    }
+
+    func toggleCompanions(for note: Note, relativeTo noteFrame: NSRect) {
+        let visible = companionsVisible(for: note.id)
+        UserDefaults.standard.set(visible, forKey: ConfigKeys.noteCompanionsHidden(note.id))
+        if visible {
+            dismissCompanions(for: note.id)
+        } else {
+            activateCompanions(for: note, relativeTo: noteFrame, force: true)
+        }
+    }
+
+    func activateCompanions(for note: Note, relativeTo noteFrame: NSRect, force: Bool = false) {
+        if let prior = activeCompanionNoteID, prior != note.id {
+            dismissCompanions(for: prior)
+        }
+        guard let companions = note.presentation.companions,
+              !companions.sources.isEmpty,
+              (force || BlinkConfigStore.shared.config.sources.autoOpenCompanions),
+              companionsVisible(for: note.id)
+        else {
+            dismissCompanions(for: note.id)
+            return
+        }
+
+        activeCompanionNoteID = note.id
+        activationToken = UUID()
+        let token = activationToken
+        let resolver = makeResolver()
+        let references = Array(companions.sources.prefix(NoteCompanions.maximumSources))
+
+        Task { [weak self] in
+            let outcomes = await Task.detached(priority: .userInitiated) {
+                references.map { reference -> SourceResolutionOutcome in
+                    do { return .document(try resolver.resolve(reference)) }
+                    catch let error as SourceFileError { return .failure(reference, error) }
+                    catch { return .failure(reference, .missingFile(reference.path)) }
+                }
+            }.value
+            guard let self, self.activationToken == token else { return }
+
+            if let missingRoot = outcomes.compactMap({ outcome -> String? in
+                guard case .failure(_, .unknownRoot(let root)) = outcome else { return nil }
+                return root
+            }).first {
+                self.dismissCompanions(for: note.id)
+                if self.locateRoot(named: missingRoot) {
+                    self.activateCompanions(for: note, relativeTo: noteFrame, force: true)
+                }
+                return
+            }
+
+            let documents = outcomes.compactMap { outcome -> SourceDocument? in
+                guard case .document(let document) = outcome else { return nil }
+                return document
+            }
+            let nextIDs = Set(documents.map { $0.url.path })
+            let staleIDs = (self.companionPanelIDs[note.id] ?? []).subtracting(nextIDs)
+            self.releaseCompanionPanels(staleIDs, from: note.id)
+            let frames = self.frames(
+                count: documents.count,
+                layout: companions.layout,
+                relativeTo: noteFrame
+            )
+            var ids: Set<String> = []
+            for (index, document) in documents.enumerated() {
+                let id = document.url.path
+                ids.insert(id)
+                self.show(
+                    document,
+                    frame: frames.indices.contains(index) ? frames[index] : nil,
+                    activate: false,
+                    standalone: false
+                )
+            }
+            self.companionPanelIDs[note.id] = ids
+
+            if let failure = outcomes.compactMap({ outcome -> SourceFileError? in
+                guard case .failure(_, let error) = outcome else { return nil }
+                return error
+            }).first {
+                self.present(failure)
+            }
+        }
+    }
+
+    func dismissCompanions(for noteID: String) {
+        if activeCompanionNoteID == noteID {
+            activationToken = UUID()
+            activeCompanionNoteID = nil
+        }
+        let ids = companionPanelIDs.removeValue(forKey: noteID) ?? []
+        releaseCompanionPanels(ids, from: noteID)
+    }
+
+    func applyTheme(_ config: BlinkConfig) {
+        for panel in panels.values { panel.applyTheme(config) }
+    }
+
+    func closeAll() {
+        activationToken = UUID()
+        for panel in Array(panels.values) { panel.close() }
+        panels.removeAll()
+        standalonePanelIDs.removeAll()
+        companionPanelIDs.removeAll()
+        activeCompanionNoteID = nil
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        guard let panel = notification.object as? SourcePanel else { return }
+        panel.viewer.teardown()
+        panels[panel.sourceIdentity] = nil
+        standalonePanelIDs.remove(panel.sourceIdentity)
+        for noteID in Array(companionPanelIDs.keys) {
+            companionPanelIDs[noteID]?.remove(panel.sourceIdentity)
+            if companionPanelIDs[noteID]?.isEmpty == true { companionPanelIDs[noteID] = nil }
+        }
+    }
+
+    private func show(
+        _ document: SourceDocument,
+        frame: NSRect?,
+        activate: Bool,
+        standalone: Bool
+    ) {
+        let id = document.url.path
+        if standalone { standalonePanelIDs.insert(id) }
+        let panel: SourcePanel
+        if let existing = panels[id] {
+            panel = existing
+            panel.update(document)
+        } else {
+            panel = SourcePanel(document: document)
+            panel.delegate = self
+            panels[id] = panel
+            if !panel.restoredLocalFrame, let frame {
+                panel.setFrame(frame, display: false)
+                panel.saveFrame(usingName: panel.frameAutosaveName)
+            }
+        }
+        panel.applyTheme(BlinkConfigStore.shared.config)
+        if activate {
+            NSApp.activate(ignoringOtherApps: true)
+            panel.makeKeyAndOrderFront(nil)
+            panel.makeFirstResponder(panel.viewer.webView)
+            panel.viewer.focus()
+        } else {
+            panel.orderFront(nil)
+        }
+    }
+
+    private func releaseCompanionPanels(_ ids: Set<String>, from noteID: String) {
+        for id in ids {
+            let ownedByAnotherNote = companionPanelIDs.contains { owner, panelIDs in
+                owner != noteID && panelIDs.contains(id)
+            }
+            if !standalonePanelIDs.contains(id), !ownedByAnotherNote {
+                panels[id]?.close()
+            }
+        }
+    }
+
+    private func makeResolver() -> SourceFileResolver {
+        let config = BlinkConfigStore.shared.config.sources
+        let roots = config.roots.compactMapValues { raw -> URL? in
+            let expanded = (raw as NSString).expandingTildeInPath
+            guard expanded.hasPrefix("/") else { return nil }
+            return URL(fileURLWithPath: expanded, isDirectory: true)
+        }
+        return SourceFileResolver(roots: roots, maxByteSize: config.maxPreviewBytes)
+    }
+
+    private func locateRoot(named name: String) -> Bool {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = "Locate “\(name)”"
+        alert.informativeText = "This note references files under the “\(name)” source root. Choose its folder on this Mac. Blink will only read files contained by that folder."
+        alert.addButton(withTitle: "Choose Folder")
+        alert.addButton(withTitle: "Not Now")
+        guard alert.runModal() == .alertFirstButtonReturn else { return false }
+
+        let picker = NSOpenPanel()
+        picker.title = "Locate \(name)"
+        picker.prompt = "Use This Folder"
+        picker.canChooseFiles = false
+        picker.canChooseDirectories = true
+        picker.allowsMultipleSelection = false
+        guard picker.runModal() == .OK, let url = picker.url else { return false }
+        BlinkConfigStore.shared.update { config in
+            config.sources.roots[name] = url.standardizedFileURL.path
+        }
+        return true
+    }
+
+    private func present(_ error: SourceFileError) {
+        log.error("[BLINK] source preview failed", metadata: ["error": error.localizedDescription])
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Source unavailable"
+        alert.informativeText = error.localizedDescription
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private func frames(count: Int, layout: String?, relativeTo noteFrame: NSRect) -> [NSRect] {
+        guard count > 0 else { return [] }
+        let screen = NSScreen.screens.first(where: { $0.frame.intersects(noteFrame) })
+            ?? NSScreen.main
+            ?? NSScreen.screens[0]
+        let visible = screen.visibleFrame
+
+        if layout?.lowercased() == "review-bench" {
+            let columns = count == 1 ? 1 : 2
+            let rows = Int(ceil(Double(count) / Double(columns)))
+            return (0..<count).map { index in
+                BlinkGrid.frame(
+                    for: GridPlacement(
+                        columns: columns,
+                        rows: rows,
+                        col: index % columns,
+                        row: index / columns
+                    ),
+                    in: visible
+                )
+            }
+        }
+
+        let size = NSSize(width: min(640, visible.width * 0.56), height: min(460, visible.height * 0.56))
+        return (0..<count).map { index in
+            let offset = CGFloat(index) * 28
+            return NSRect(
+                x: min(max(visible.minX + 36 + offset, visible.minX), visible.maxX - size.width),
+                y: min(max(visible.maxY - size.height - 44 - offset, visible.minY), visible.maxY - size.height),
+                width: size.width,
+                height: size.height
+            )
+        }
+    }
+}

--- a/Sources/BlinkApp/SourceViewerWebView.swift
+++ b/Sources/BlinkApp/SourceViewerWebView.swift
@@ -1,0 +1,141 @@
+import AppKit
+import BlinkCore
+import Foundation
+import HudsonObservability
+import WebKit
+
+/// A renderer-only CodeMirror host. Its user-content controller registers one
+/// message (`ready`) and its JavaScript global exposes only presentation calls.
+/// There is no content-change callback, save request, or content getter for a
+/// caller to accidentally connect to Blink's note mutation path.
+@MainActor
+final class SourceViewerWebView: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
+    let webView: WKWebView
+
+    private var viewerURL: URL?
+    private var isReady = false
+    private var pendingDocument: SourceDocument?
+    private var pendingTheme: [String: String]?
+    private let log = HudLogger(category: "blink.source-bridge")
+
+    override init() {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        webView = WKWebView(frame: .zero, configuration: configuration)
+        super.init()
+        configuration.userContentController.add(self, name: "blinkSource")
+        webView.navigationDelegate = self
+        webView.setValue(false, forKey: "drawsBackground")
+    }
+
+    func load() {
+        guard let url = Self.viewerHTMLURL() else {
+            log.error("[BLINK] source-viewer.html not found — build web/editor")
+            return
+        }
+        viewerURL = url
+        webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+    }
+
+    func teardown() {
+        webView.stopLoading()
+        webView.navigationDelegate = nil
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "blinkSource")
+    }
+
+    func setDocument(_ document: SourceDocument) {
+        guard isReady else {
+            pendingDocument = document
+            return
+        }
+        var payload: [String: Any] = [
+            "text": document.text,
+            "language": document.language,
+        ]
+        if let lines = document.lines {
+            payload["lineStart"] = lines.start
+            payload["lineEnd"] = lines.end
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8)
+        else { return }
+        evaluate("window.blinkSource.setDocument(\(json))")
+    }
+
+    func setTheme(_ variables: [String: String]) {
+        guard isReady else {
+            pendingTheme = variables
+            return
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: variables),
+              let json = String(data: data, encoding: .utf8)
+        else { return }
+        evaluate("window.blinkSource.setTheme(\(json))")
+    }
+
+    func focus() {
+        guard isReady else { return }
+        evaluate("window.blinkSource.focus()")
+    }
+
+    func showFind() {
+        guard isReady else { return }
+        evaluate("window.blinkSource.showFind()")
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard message.name == "blinkSource",
+              let body = message.body as? [String: Any],
+              body["type"] as? String == "ready"
+        else { return }
+        isReady = true
+        if let theme = pendingTheme {
+            pendingTheme = nil
+            setTheme(theme)
+        }
+        if let document = pendingDocument {
+            pendingDocument = nil
+            setDocument(document)
+        }
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url,
+              url.isFileURL,
+              let viewerURL,
+              url.path == viewerURL.path
+        else {
+            decisionHandler(.cancel)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    private func evaluate(_ script: String) {
+        webView.evaluateJavaScript(script) { [weak self] _, error in
+            if let error {
+                self?.log.error("[BLINK] source bridge evaluation failed", metadata: ["error": "\(error)"])
+            }
+        }
+    }
+
+    private static func viewerHTMLURL() -> URL? {
+        if let bundled = Bundle.main.url(forResource: "source-viewer", withExtension: "html") {
+            return bundled
+        }
+        let executable = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0])
+        let repoRoot = executable
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let dev = repoRoot.appendingPathComponent("web/editor/dist/source-viewer.html")
+        return FileManager.default.fileExists(atPath: dev.path) ? dev : nil
+    }
+}

--- a/Sources/BlinkCore/Frontmatter.swift
+++ b/Sources/BlinkCore/Frontmatter.swift
@@ -86,6 +86,20 @@ public enum Frontmatter {
         if let v = p.tintEdit { lines.append("  tintEdit: \(formatDouble(v))") }
         if let v = p.radius { lines.append("  radius: \(formatDouble(v))") }
         if let v = p.slot { lines.append("  slot: \(v)") }
+        if let companions = p.companions, !companions.isEmpty {
+            lines.append("  companions:")
+            if let layout = companions.layout {
+                lines.append("    layout: \(quoteIfNeeded(layout))")
+            }
+            if !companions.sources.isEmpty || !companions.extraSourceLines.isEmpty {
+                lines.append("    sources:")
+                for source in companions.sources {
+                    lines.append("      - \(quoteYAMLString(source.locator))")
+                }
+                lines.append(contentsOf: companions.extraSourceLines)
+            }
+            lines.append(contentsOf: companions.extraLines)
+        }
         lines.append(contentsOf: note.extraBlink)
     }
 
@@ -201,8 +215,34 @@ public enum Frontmatter {
         into presentation: inout NotePresentation,
         unknown: inout [String]
     ) {
-        for raw in lines {
+        let fieldIndent = lines
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .map(indentation)
+            .min() ?? 0
+        var index = 0
+        while index < lines.count {
+            let raw = lines[index]
+            index += 1
             let trimmed = raw.trimmingCharacters(in: .whitespaces)
+            guard indentation(of: raw) == fieldIndent else {
+                unknown.append(raw)
+                continue
+            }
+            if trimmed == "companions:" {
+                let parentIndent = indentation(of: raw)
+                var block: [String] = []
+                while index < lines.count, indentation(of: lines[index]) > parentIndent {
+                    block.append(lines[index])
+                    index += 1
+                }
+                parseCompanionsBlock(
+                    block,
+                    parentLine: raw,
+                    into: &presentation,
+                    unknown: &unknown
+                )
+                continue
+            }
             guard let colon = trimmed.firstIndex(of: ":") else {
                 unknown.append(raw)
                 continue
@@ -227,6 +267,75 @@ public enum Frontmatter {
             case "slot": if let i = Int(value) { presentation.slot = i } else { unknown.append(raw) }
             default: unknown.append(raw)
             }
+        }
+    }
+
+    private static func parseCompanionsBlock(
+        _ lines: [String],
+        parentLine: String,
+        into presentation: inout NotePresentation,
+        unknown: inout [String]
+    ) {
+        var companions = NoteCompanions()
+        var recognized = false
+        let fieldIndent = lines
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .map(indentation)
+            .min() ?? 0
+        var index = 0
+
+        while index < lines.count {
+            let raw = lines[index]
+            index += 1
+            let trimmed = raw.trimmingCharacters(in: .whitespaces)
+            guard indentation(of: raw) == fieldIndent else {
+                companions.preserveExtraLine(raw)
+                continue
+            }
+            guard let colon = trimmed.firstIndex(of: ":") else {
+                companions.preserveExtraLine(raw)
+                continue
+            }
+            let key = String(trimmed[..<colon]).trimmingCharacters(in: .whitespaces)
+            let value = unquote(
+                String(trimmed[trimmed.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+            )
+
+            if key == "layout", !value.isEmpty {
+                companions.layout = value
+                recognized = true
+                continue
+            }
+            if key == "sources", value.isEmpty {
+                let sourcesIndent = indentation(of: raw)
+                while index < lines.count, indentation(of: lines[index]) > sourcesIndent {
+                    let item = lines[index]
+                    index += 1
+                    let itemValue = item.trimmingCharacters(in: .whitespaces)
+                    guard itemValue.hasPrefix("-") else {
+                        companions.preserveExtraSourceLine(item)
+                        continue
+                    }
+                    let locator = unquote(
+                        String(itemValue.dropFirst()).trimmingCharacters(in: .whitespaces)
+                    )
+                    if let reference = SourceReference(locator: unescapeYAMLString(locator)),
+                       companions.append(reference) {
+                        recognized = true
+                    } else {
+                        companions.preserveExtraSourceLine(item)
+                    }
+                }
+                continue
+            }
+            companions.preserveExtraLine(raw)
+        }
+
+        if recognized {
+            presentation.companions = companions
+        } else {
+            unknown.append(parentLine)
+            unknown.append(contentsOf: lines)
         }
     }
 
@@ -256,6 +365,25 @@ public enum Frontmatter {
             || v.hasPrefix("#") || v.hasPrefix(" ") || v.hasSuffix(" ")
             || v.contains(":") || v.contains("#")
         return needsQuote ? "\"\(v)\"" : v
+    }
+
+    private static func quoteYAMLString(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+
+    private static func unescapeYAMLString(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\\"", with: "\"")
+            .replacingOccurrences(of: "\\\\", with: "\\")
+    }
+
+    private static func indentation(of line: String) -> Int {
+        line.prefix { $0 == " " || $0 == "\t" }.reduce(into: 0) { count, character in
+            count += character == "\t" ? 2 : 1
+        }
     }
 
     /// Render a Double without a trailing `.0` (so `11.0` → `11`, `1.4` → `1.4`).

--- a/Sources/BlinkCore/Note.swift
+++ b/Sources/BlinkCore/Note.swift
@@ -32,6 +32,10 @@ public struct NotePresentation: Equatable, Sendable, Codable {
     public var radius: Double?
     /// Durable grid-slot intent, 1...9 (not pixels — pixels are device state).
     public var slot: Int?
+    /// Portable source cast associated with this note. Paths resolve through
+    /// device-local named roots; visibility and exact source-panel frames do not
+    /// travel in Markdown.
+    public var companions: NoteCompanions?
 
     public init() {}
 
@@ -40,6 +44,7 @@ public struct NotePresentation: Equatable, Sendable, Codable {
         workspace == nil && style == nil && sheet == nil && accent == nil && font == nil
             && fontSize == nil && lineHeight == nil && tint == nil
             && tintRead == nil && tintEdit == nil && radius == nil && slot == nil
+            && (companions == nil || companions?.isEmpty == true)
     }
 }
 

--- a/Sources/BlinkCore/SourceFileResolver.swift
+++ b/Sources/BlinkCore/SourceFileResolver.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+public enum SourceFileError: Error, Equatable, Sendable, LocalizedError {
+    case unknownRoot(String)
+    case outsideRoot
+    case missingFile(String)
+    case notRegularFile
+    case tooLarge(maxBytes: Int)
+    case notUTF8
+    case unsupportedFile(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unknownRoot(let root): "Locate the “\(root)” source root to show this file."
+        case .outsideRoot: "The source resolves outside its approved root."
+        case .missingFile(let path): "Source file not found: \(path)"
+        case .notRegularFile: "Only regular files can be previewed."
+        case .tooLarge(let maxBytes): "This file is larger than the \(maxBytes / 1_000_000) MB preview limit."
+        case .notUTF8: "This file is binary or not UTF-8 text."
+        case .unsupportedFile(let name): "\(name) does not look like a source file."
+        }
+    }
+}
+
+public struct SourceDocument: Sendable, Equatable {
+    public let identity: String
+    public let url: URL
+    public let displayName: String
+    public let displayPath: String
+    public let language: String
+    public let text: String
+    public let lines: SourceReference.LineRange?
+    public let revision: String?
+    public let modifiedAt: Date?
+
+    public init(
+        identity: String,
+        url: URL,
+        displayName: String,
+        displayPath: String,
+        language: String,
+        text: String,
+        lines: SourceReference.LineRange? = nil,
+        revision: String? = nil,
+        modifiedAt: Date? = nil
+    ) {
+        self.identity = identity
+        self.url = url
+        self.displayName = displayName
+        self.displayPath = displayPath
+        self.language = language
+        self.text = text
+        self.lines = lines
+        self.revision = revision
+        self.modifiedAt = modifiedAt
+    }
+}
+
+/// Resolves note-portable references without allowing them to escape an
+/// explicitly approved local root. Symlinks are resolved before containment is
+/// checked, so a symlink inside a workspace cannot smuggle reads outside it.
+public struct SourceFileResolver: Sendable {
+    public static let defaultMaxByteSize = 2_000_000
+
+    private let roots: [String: URL]
+    public let maxByteSize: Int
+
+    public init(roots: [String: URL], maxByteSize: Int = defaultMaxByteSize) {
+        self.roots = roots
+        self.maxByteSize = max(1, maxByteSize)
+    }
+
+    public func resolve(_ reference: SourceReference) throws -> SourceDocument {
+        guard let configuredRoot = roots[reference.root] else {
+            throw SourceFileError.unknownRoot(reference.root)
+        }
+        let root = configuredRoot.standardizedFileURL.resolvingSymlinksInPath()
+        let candidate = root
+            .appendingPathComponent(reference.path)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        guard Self.contains(candidate, in: root) else { throw SourceFileError.outsideRoot }
+        return try load(
+            candidate,
+            identity: reference.locator,
+            displayPath: "\(reference.root)/\(reference.path)",
+            lines: reference.lines,
+            revision: reference.revision
+        )
+    }
+
+    /// Resolve a file the user explicitly chose in `NSOpenPanel`. It is not
+    /// portable and does not become note metadata; the picker is the authority.
+    public func resolvePickedFile(_ url: URL) throws -> SourceDocument {
+        let candidate = url.standardizedFileURL.resolvingSymlinksInPath()
+        return try load(
+            candidate,
+            identity: "file:\(candidate.path)",
+            displayPath: candidate.deletingLastPathComponent().path,
+            lines: nil,
+            revision: nil
+        )
+    }
+
+    private func load(
+        _ url: URL,
+        identity: String,
+        displayPath: String,
+        lines: SourceReference.LineRange?,
+        revision: String?
+    ) throws -> SourceDocument {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw SourceFileError.missingFile(url.path)
+        }
+        let values = try url.resourceValues(forKeys: [
+            .isRegularFileKey, .fileSizeKey, .contentModificationDateKey,
+        ])
+        guard values.isRegularFile == true else { throw SourceFileError.notRegularFile }
+        if let size = values.fileSize, size > maxByteSize {
+            throw SourceFileError.tooLarge(maxBytes: maxByteSize)
+        }
+
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let probeSize = maxByteSize == .max ? Int.max : maxByteSize + 1
+        let data = try handle.read(upToCount: probeSize) ?? Data()
+        guard data.count <= maxByteSize else {
+            throw SourceFileError.tooLarge(maxBytes: maxByteSize)
+        }
+        guard let text = String(data: data, encoding: .utf8), !text.contains("\0") else {
+            throw SourceFileError.notUTF8
+        }
+        guard let language = Self.language(for: url, text: text) else {
+            throw SourceFileError.unsupportedFile(url.lastPathComponent)
+        }
+
+        return SourceDocument(
+            identity: identity,
+            url: url,
+            displayName: url.lastPathComponent,
+            displayPath: displayPath,
+            language: language,
+            text: text,
+            lines: lines,
+            revision: revision,
+            modifiedAt: values.contentModificationDate
+        )
+    }
+
+    private static func contains(_ candidate: URL, in root: URL) -> Bool {
+        let rootPath = root.path.hasSuffix("/") ? root.path : root.path + "/"
+        return candidate.path == root.path || candidate.path.hasPrefix(rootPath)
+    }
+
+    /// Broad on purpose: Blink is a reading surface, so common source, data,
+    /// config, build, prose, and patch formats all qualify. Unknown extensions
+    /// still get an honest plain-text viewer when their content looks like code.
+    public static func language(for url: URL, text: String) -> String? {
+        let name = url.lastPathComponent.lowercased()
+        let ext = url.pathExtension.lowercased()
+        let names: [String: String] = [
+            "dockerfile": "dockerfile", "makefile": "makefile", "gemfile": "ruby",
+            "podfile": "ruby", "rakefile": "ruby", "cmakelists.txt": "cmake",
+            ".gitignore": "shell", ".gitattributes": "plaintext", ".env": "shell",
+        ]
+        if let language = names[name] { return language }
+
+        let extensions: [String: String] = [
+            "swift": "swift", "m": "objective-c", "mm": "objective-cpp",
+            "h": "cpp", "hpp": "cpp", "c": "c", "cc": "cpp", "cpp": "cpp",
+            "cs": "csharp", "java": "java", "kt": "kotlin", "kts": "kotlin",
+            "js": "javascript", "jsx": "jsx", "mjs": "javascript", "cjs": "javascript",
+            "ts": "typescript", "tsx": "tsx", "vue": "vue", "svelte": "svelte",
+            "py": "python", "pyi": "python", "rb": "ruby", "php": "php",
+            "rs": "rust", "go": "go", "scala": "scala", "lua": "lua", "r": "r",
+            "sh": "shell", "bash": "shell", "zsh": "shell", "fish": "shell",
+            "ps1": "powershell", "sql": "sql", "graphql": "graphql", "gql": "graphql",
+            "html": "html", "htm": "html", "css": "css", "scss": "scss", "sass": "sass",
+            "less": "less", "xml": "xml", "svg": "xml",
+            "json": "json", "jsonc": "json", "yaml": "yaml", "yml": "yaml",
+            "toml": "toml", "ini": "properties", "cfg": "properties", "conf": "properties",
+            "plist": "xml", "proto": "protobuf", "gradle": "groovy",
+            "md": "markdown", "mdx": "markdown", "markdown": "markdown",
+            "txt": "plaintext", "diff": "diff", "patch": "diff", "log": "plaintext",
+        ]
+        if let language = extensions[ext] { return language }
+        if ext.isEmpty, text.hasPrefix("#!") { return "shell" }
+        return looksLikeCode(text) ? "plaintext" : nil
+    }
+
+    private static func looksLikeCode(_ text: String) -> Bool {
+        let sample = String(text.prefix(16_384))
+        guard !sample.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        let signals = [
+            "import ", "export ", "func ", "function ", "struct ", "class ",
+            "enum ", "protocol ", "const ", "let ", "var ", "def ", "return ",
+            "#include", "package ", "SELECT ", "FROM ", "<?xml", "{\n", "};",
+        ]
+        if signals.contains(where: sample.contains) { return true }
+        let punctuation = sample.reduce(into: 0) { count, character in
+            if "{}[]();=<>".contains(character) { count += 1 }
+        }
+        return punctuation >= 6 && sample.contains("\n")
+    }
+}

--- a/Sources/BlinkCore/SourceReference.swift
+++ b/Sources/BlinkCore/SourceReference.swift
@@ -1,0 +1,230 @@
+import Foundation
+
+/// A portable pointer to a source file under one of Blink's device-local named
+/// roots. The root name and relative path travel with a note; the absolute root
+/// URL is resolved from `config.json` on each device.
+///
+/// Canonical form:
+///
+///     blink/Sources/BlinkCore/Note.swift#L12-28@76fc2d1
+///
+/// Both the line anchor and revision are optional. A revision is provenance,
+/// not a request for Blink to check out or mutate a repository.
+public struct SourceReference: Hashable, Sendable, Codable {
+    public struct LineRange: Hashable, Sendable, Codable {
+        public static let maximumSpan = 1_000
+
+        public let start: Int
+        public let end: Int
+
+        public init?(start: Int, end: Int? = nil) {
+            let resolvedEnd = end ?? start
+            guard start > 0,
+                  resolvedEnd >= start,
+                  resolvedEnd - start < Self.maximumSpan
+            else { return nil }
+            self.start = start
+            self.end = resolvedEnd
+        }
+
+        private enum CodingKeys: String, CodingKey { case start, end }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let start = try container.decode(Int.self, forKey: .start)
+            let end = try container.decode(Int.self, forKey: .end)
+            guard let bounded = Self(start: start, end: end) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .end,
+                    in: container,
+                    debugDescription: "Source line ranges may span at most \(Self.maximumSpan) lines."
+                )
+            }
+            self = bounded
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(start, forKey: .start)
+            try container.encode(end, forKey: .end)
+        }
+    }
+
+    public let root: String
+    public let path: String
+    public let lines: LineRange?
+    public let revision: String?
+
+    public init?(
+        root: String,
+        path: String,
+        lines: LineRange? = nil,
+        revision: String? = nil
+    ) {
+        guard Self.isValidRoot(root), Self.isValidRelativePath(path) else { return nil }
+        if let revision, !Self.isValidRevision(revision) { return nil }
+        self.root = root
+        self.path = path
+        self.lines = lines
+        self.revision = revision
+    }
+
+    public init?(locator: String) {
+        let raw = locator.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return nil }
+
+        let revisionSplit = raw.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: false)
+        let beforeRevision = String(revisionSplit[0])
+        let revision = revisionSplit.count == 2 ? String(revisionSplit[1]) : nil
+        guard revisionSplit.count == 1 || (revision != nil && !revision!.isEmpty) else { return nil }
+
+        let anchorSplit = beforeRevision.components(separatedBy: "#L")
+        guard anchorSplit.count <= 2 else { return nil }
+        let portablePath = anchorSplit[0]
+
+        guard let slash = portablePath.firstIndex(of: "/") else { return nil }
+        let root = String(portablePath[..<slash])
+        let path = String(portablePath[portablePath.index(after: slash)...])
+
+        let lines: LineRange?
+        if anchorSplit.count == 2 {
+            let bounds = anchorSplit[1].split(
+                separator: "-",
+                maxSplits: 1,
+                omittingEmptySubsequences: false
+            )
+            guard let startRaw = bounds.first,
+                  let start = Self.decimal(startRaw)
+            else { return nil }
+            let end: Int?
+            if bounds.count == 2 {
+                let endRaw = bounds[1].hasPrefix("L") ? bounds[1].dropFirst() : bounds[1]
+                guard let parsedEnd = Self.decimal(endRaw) else { return nil }
+                end = parsedEnd
+            } else {
+                end = nil
+            }
+            guard
+                  let parsed = LineRange(
+                    start: start,
+                    end: end
+                  )
+            else { return nil }
+            lines = parsed
+        } else {
+            lines = nil
+        }
+
+        self.init(root: root, path: path, lines: lines, revision: revision)
+    }
+
+    public var locator: String {
+        var value = "\(root)/\(path)"
+        if let lines {
+            value += lines.start == lines.end
+                ? "#L\(lines.start)"
+                : "#L\(lines.start)-\(lines.end)"
+        }
+        if let revision { value += "@\(revision)" }
+        return value
+    }
+
+    private static func isValidRoot(_ value: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        return value.unicodeScalars.allSatisfy {
+            CharacterSet.alphanumerics.contains($0) || $0 == "-" || $0 == "_" || $0 == "."
+        }
+    }
+
+    private static func isValidRelativePath(_ value: String) -> Bool {
+        guard !value.isEmpty, !value.hasPrefix("/"), !value.contains("\\"),
+              !value.contains("#"), !value.contains("@"),
+              value.unicodeScalars.allSatisfy({
+                  !CharacterSet.controlCharacters.contains($0)
+              })
+        else { return false }
+        let components = value.split(separator: "/", omittingEmptySubsequences: false)
+        return !components.contains { $0.isEmpty || $0 == "." || $0 == ".." }
+    }
+
+    private static func isValidRevision(_ value: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        return value.unicodeScalars.allSatisfy {
+            CharacterSet.alphanumerics.contains($0)
+                || $0 == "-" || $0 == "_" || $0 == "." || $0 == "/"
+        }
+    }
+
+    private static func decimal<S: StringProtocol>(_ value: S) -> Int? {
+        guard !value.isEmpty,
+              value.utf8.allSatisfy({ $0 >= 48 && $0 <= 57 })
+        else { return nil }
+        return Int(value)
+    }
+}
+
+/// A note-declared cast of source companions. Exact frames and visibility are
+/// intentionally absent: those remain device-local desktop state.
+public struct NoteCompanions: Equatable, Sendable, Codable {
+    public static let maximumSources = 3
+
+    public var layout: String?
+    public private(set) var sources: [SourceReference]
+    /// Unknown companion fields and invalid source-list entries are retained as
+    /// raw YAML lines so Blink never turns partial understanding into metadata
+    /// loss. They are deliberately separate because list entries must remain
+    /// beneath `sources:` when the known portion is canonicalized.
+    public private(set) var extraLines: [String]
+    public private(set) var extraSourceLines: [String]
+
+    public init(layout: String? = nil, sources: [SourceReference] = []) {
+        self.layout = layout
+        var seen = Set<SourceReference>()
+        var bounded: [SourceReference] = []
+        for source in sources where seen.insert(source).inserted {
+            bounded.append(source)
+            if bounded.count == Self.maximumSources { break }
+        }
+        self.sources = bounded
+        extraLines = []
+        extraSourceLines = []
+    }
+
+    public var isEmpty: Bool {
+        layout == nil && sources.isEmpty && extraLines.isEmpty && extraSourceLines.isEmpty
+    }
+
+    @discardableResult
+    mutating func append(_ source: SourceReference) -> Bool {
+        guard sources.count < Self.maximumSources, !sources.contains(source) else { return false }
+        sources.append(source)
+        return true
+    }
+
+    mutating func preserveExtraLine(_ line: String) { extraLines.append(line) }
+    mutating func preserveExtraSourceLine(_ line: String) { extraSourceLines.append(line) }
+
+    private enum CodingKeys: String, CodingKey {
+        case layout, sources, extraLines, extraSourceLines
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            layout: try container.decodeIfPresent(String.self, forKey: .layout),
+            sources: try container.decodeIfPresent([SourceReference].self, forKey: .sources) ?? []
+        )
+        extraLines = try container.decodeIfPresent([String].self, forKey: .extraLines) ?? []
+        extraSourceLines = try container.decodeIfPresent(
+            [String].self, forKey: .extraSourceLines
+        ) ?? []
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(layout, forKey: .layout)
+        try container.encode(sources, forKey: .sources)
+        try container.encode(extraLines, forKey: .extraLines)
+        try container.encode(extraSourceLines, forKey: .extraSourceLines)
+    }
+}

--- a/Tests/BlinkCoreTests/FrontmatterTests.swift
+++ b/Tests/BlinkCoreTests/FrontmatterTests.swift
@@ -370,6 +370,96 @@ struct FrontmatterTests {
         #expect(!encoded.contains("blink:"))
     }
 
+    @Test("Source companions decode and round-trip as portable note intent")
+    func sourceCompanionsRoundTrip() throws {
+        let raw = """
+        ---
+        id: review
+        created: 2023-11-14T22:13:20.123Z
+        updated: 2023-11-14T22:13:20.123Z
+        blink:
+          companions:
+            layout: review-bench
+            sources:
+              - "blink/Sources/BlinkCore/Note.swift#L12-28@76fc2d1"
+              - "blink/Sources/BlinkApp/WebBridge.swift"
+        ---
+        # Review
+        """
+
+        let decoded = try Frontmatter.decode(raw)
+        let companions = try #require(decoded.presentation.companions)
+        #expect(companions.layout == "review-bench")
+        #expect(companions.sources.count == 2)
+        #expect(companions.sources[0].lines?.start == 12)
+
+        let encoded = Frontmatter.encode(decoded)
+        #expect(encoded.contains("  companions:"))
+        #expect(encoded.contains("    layout: review-bench"))
+        #expect(encoded.contains("      - \"blink/Sources/BlinkApp/WebBridge.swift\""))
+        #expect(try Frontmatter.decode(encoded).presentation.companions == companions)
+    }
+
+    @Test("Invalid companion entries survive without becoming viewer authority")
+    func invalidCompanionsSurvive() throws {
+        let raw = """
+        ---
+        id: future
+        created: 2023-11-14T22:13:20.123Z
+        updated: 2023-11-14T22:13:20.123Z
+        blink:
+          companions:
+            layout: review-bench
+            futureMode: stacked
+            sources:
+              - "blink/../Secrets.swift"
+              - "blink/Sources/Safe.swift"
+        ---
+        body
+        """
+        let decoded = try Frontmatter.decode(raw)
+        #expect(decoded.presentation.companions?.sources.map(\.path) == ["Sources/Safe.swift"])
+        let encoded = Frontmatter.encode(decoded)
+        #expect(encoded.contains("futureMode: stacked"))
+        #expect(encoded.contains("blink/../Secrets.swift"))
+        let lines = encoded.split(separator: "\n").map(String.init)
+        let invalidIndex = try #require(
+            lines.firstIndex(of: "      - \"blink/../Secrets.swift\"")
+        )
+        let futureIndex = try #require(lines.firstIndex(of: "    futureMode: stacked"))
+        #expect(invalidIndex < futureIndex)
+
+        let reDecoded = try Frontmatter.decode(encoded)
+        #expect(reDecoded.presentation.companions?.sources.map(\.path) == ["Sources/Safe.swift"])
+        #expect(reDecoded.presentation.companions?.extraSourceLines == [
+            "      - \"blink/../Secrets.swift\""
+        ])
+        #expect(reDecoded.presentation.companions?.extraLines == ["    futureMode: stacked"])
+    }
+
+    @Test("Nested foreign companion-shaped data never grants source authority")
+    func nestedForeignCompanionsStayForeign() throws {
+        let raw = """
+        ---
+        id: foreign-companions
+        created: 2023-11-14T22:13:20.123Z
+        updated: 2023-11-14T22:13:20.123Z
+        blink:
+          futureSurface:
+            companions:
+              sources:
+                - "blink/Sources/ShouldNotOpen.swift"
+        ---
+        body
+        """
+
+        let decoded = try Frontmatter.decode(raw)
+        #expect(decoded.presentation.companions == nil)
+        let encoded = Frontmatter.encode(decoded)
+        #expect(encoded.contains("    companions:"))
+        #expect(encoded.contains("        - \"blink/Sources/ShouldNotOpen.swift\""))
+    }
+
     @Test("Foreign keys survive a decode → edit → encode cycle alongside blink")
     func foreignSurvivesWithBlink() throws {
         let raw = """

--- a/Tests/BlinkCoreTests/SourceReferenceTests.swift
+++ b/Tests/BlinkCoreTests/SourceReferenceTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+@testable import BlinkCore
+
+@Suite("Source references")
+struct SourceReferenceTests {
+    @Test("Portable locator parses and canonicalizes line and revision anchors")
+    func locatorRoundTrip() throws {
+        let reference = try #require(
+            SourceReference(locator: "blink/Sources/BlinkCore/Note.swift#L12-L28@76fc2d1")
+        )
+        #expect(reference.root == "blink")
+        #expect(reference.path == "Sources/BlinkCore/Note.swift")
+        #expect(reference.lines?.start == 12)
+        #expect(reference.lines?.end == 28)
+        #expect(reference.revision == "76fc2d1")
+        #expect(reference.locator == "blink/Sources/BlinkCore/Note.swift#L12-28@76fc2d1")
+    }
+
+    @Test("Unsafe and malformed portable paths are rejected", arguments: [
+        "blink/../Secrets.txt",
+        "blink//Sources/File.swift",
+        "/absolute/File.swift",
+        "blink/File.swift#L0",
+        "blink/File.swift#L9-2",
+        "blink/File.swift#L1-1001",
+        "blink/File.swift#L12-foo",
+        "blink/File.swift#L12-",
+        "blink/File.swift#L1L2",
+        "blink/File.swift@",
+        "blink/Line\nBreak.swift",
+    ])
+    func rejectsUnsafeLocator(locator: String) {
+        #expect(SourceReference(locator: locator) == nil)
+    }
+
+    @Test("Source casts deduplicate and cap portable work")
+    func boundedCompanionCast() throws {
+        let first = try #require(SourceReference(locator: "blink/One.swift"))
+        let second = try #require(SourceReference(locator: "blink/Two.swift"))
+        let third = try #require(SourceReference(locator: "blink/Three.swift"))
+        let fourth = try #require(SourceReference(locator: "blink/Four.swift"))
+        let cast = NoteCompanions(sources: [first, first, second, third, fourth])
+
+        #expect(cast.sources == [first, second, third])
+    }
+
+    @Test("Named-root resolution reads a small UTF-8 source file")
+    func resolvesSource() throws {
+        let root = makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let file = root.appendingPathComponent("Sources/Feature.swift")
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try "import Foundation\nstruct Feature {}\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let resolver = SourceFileResolver(roots: ["blink": root])
+        let reference = try #require(SourceReference(locator: "blink/Sources/Feature.swift#L2"))
+        let document = try resolver.resolve(reference)
+
+        #expect(document.displayName == "Feature.swift")
+        #expect(document.displayPath == "blink/Sources/Feature.swift")
+        #expect(document.language == "swift")
+        #expect(document.lines?.start == 2)
+        #expect(document.text.contains("struct Feature"))
+    }
+
+    @Test("A symlink cannot escape an approved source root")
+    func rejectsSymlinkEscape() throws {
+        let root = makeDirectory()
+        let outside = makeDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: outside)
+        }
+        let secret = outside.appendingPathComponent("Secret.swift")
+        try "let secret = true\n".write(to: secret, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("Secret.swift"), withDestinationURL: secret
+        )
+
+        let resolver = SourceFileResolver(roots: ["blink": root])
+        let reference = try #require(SourceReference(locator: "blink/Secret.swift"))
+        #expect(throws: SourceFileError.outsideRoot) {
+            _ = try resolver.resolve(reference)
+        }
+    }
+
+    @Test("Preview size is bounded")
+    func rejectsLargeFile() throws {
+        let root = makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let file = root.appendingPathComponent("Large.swift")
+        try Data(repeating: 65, count: 64).write(to: file)
+        let resolver = SourceFileResolver(roots: ["blink": root], maxByteSize: 32)
+        let reference = try #require(SourceReference(locator: "blink/Large.swift"))
+
+        #expect(throws: SourceFileError.tooLarge(maxBytes: 32)) {
+            _ = try resolver.resolve(reference)
+        }
+    }
+
+    private func makeDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BlinkSourceTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/design/studio/src/studio/StudioPages.tsx
+++ b/design/studio/src/studio/StudioPages.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { type ReactNode } from "react";
-import { AppWindow, ArrowRight, Command, FileText, Grid3x3, Layers, MenuSquare } from "lucide-react";
+import { AppWindow, ArrowRight, Code2, Command, FileText, Grid3x3, Layers, MenuSquare } from "lucide-react";
 import {
   AnnotatableDoc,
   annotationsToDecisions,
@@ -18,6 +18,7 @@ import { IOSDesignDirectionsStudy } from "@/studio/studies/IOSDesignDirectionsSt
 import { MenubarPopoverStudy } from "@/studio/studies/MenubarPopoverStudy";
 import { NotePanelStudy } from "@/studio/studies/NotePanelStudy";
 import { SettingsStudy } from "@/studio/studies/SettingsStudy";
+import { SpatialCodeReviewStudy } from "@/studio/studies/SpatialCodeReviewStudy";
 import { StacksStudy } from "@/studio/studies/StacksStudy";
 import { StylePermutationsStudy } from "@/studio/studies/StylePermutationsStudy";
 import {
@@ -79,6 +80,29 @@ const STUDIES: Record<string, Study> = {
     open: [
       "Does the resting panel keep the traffic lights, or do those also fade until hover?",
       "Shade interaction: middle-click vs double-click the title bar (or both)?",
+    ],
+  },
+  "/studio/studies/review-bench": {
+    component: SpatialCodeReviewStudy,
+    intent:
+      "The Markdown note is the activation unit. Its blink.companions frontmatter carries portable intent: named-root source references and a preferred arrangement. Activating the note resolves those references into immutable CodeMirror views, but exact frames and the user's Code Auto/Hidden control stay device-local. When companions are hidden, clicking a citation opens one ephemeral peek without rewriting metadata or rearranging the desk. The active note, bundle, source, and anchor become coding-agent context; Cursor or Xcode remains the editing handoff.",
+    specs: [
+      ["driver", "Markdown note · blink.companions frontmatter"],
+      ["portable", "named-root refs · revisions/anchors · preferred arrangement"],
+      ["device", "Code Auto/Hidden · exact frames · current peek"],
+      ["identity", "named root + relative path + revision hash + line range"],
+      ["activation", "Auto lays out cast · Hidden stays quiet · citation peeks"],
+      ["renderer", "CodeMirror 6 view state · parsers/search/selection/decorations"],
+      ["bridge", "no write methods · no contentChanged/saveRequested messages"],
+      ["agent", "bundle + active source + anchor are context · additions require admission"],
+      ["handoff", "Open in Cursor/Xcode for edit, build, debug, deep project work"],
+      ["review", "Opus via Scout · ref:c-kzbjmw"],
+    ],
+    open: [
+      "Should an agent-authored companion addition write frontmatter immediately, or first appear as a local proposal until the user admits it?",
+      "Does a full tree appear only as a temporary source picker, or can a user deliberately pin one without changing Blink's default posture?",
+      "Should revision hashes remain visible in raw citation prose, or be written by Blink and collapsed in rendered Markdown?",
+      "When source drifts, is a visible stale anchor enough, or should a later tool offer an explicit, never-silent rebind?",
     ],
   },
   "/studio/studies/menubar-popover": {
@@ -303,6 +327,7 @@ function HomePage() {
 }
 
 function studyIcon(href: string) {
+  if (href.endsWith("review-bench")) return <Code2 size={16} />;
   if (href.endsWith("menubar-popover")) return <MenuSquare size={16} />;
   if (href.endsWith("command-palette")) return <Command size={16} />;
   if (href.endsWith("grid-overlay")) return <Grid3x3 size={16} />;

--- a/design/studio/src/studio/studies/SpatialCodeReviewStudy.module.css
+++ b/design/studio/src/studio/studies/SpatialCodeReviewStudy.module.css
@@ -1,0 +1,1124 @@
+.study {
+  --study-rule: color-mix(in srgb, var(--studio-ink-faint) 28%, transparent);
+  width: 100%;
+}
+
+.studyHeader,
+.ladderHeader {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.studyHeader {
+  margin-bottom: 14px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--study-rule);
+}
+
+.kicker {
+  margin: 0;
+  color: var(--studio-ink-faint);
+  font: 600 10px/1.2 var(--studio-font-mono), ui-monospace, monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.studyHeader h2,
+.ladderHeader h3 {
+  margin: 6px 0 0;
+  color: var(--studio-ink-strong);
+  font-family: var(--studio-font-serif), ui-serif, serif;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+}
+
+.studyHeader h2 {
+  font-size: 30px;
+  line-height: 1.08;
+}
+
+.studyCopy,
+.ladderHeader p:last-child {
+  margin: 5px 0 0;
+  color: var(--studio-ink);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.model {
+  display: flex;
+  min-height: 34px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 11px;
+  border: 1px solid var(--study-rule);
+  border-radius: 10px;
+  background: var(--studio-canvas-alt);
+  color: var(--studio-ink-faint);
+  font: 600 10px/1 var(--studio-font-mono), ui-monospace, monospace;
+  text-transform: uppercase;
+}
+
+.model svg:first-child {
+  color: #4b78c3;
+}
+
+.sceneFocus {
+  border-radius: 12px;
+  outline: none;
+}
+
+.sceneFocus:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, #78a6f3 70%, transparent);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sceneLabel {
+  position: absolute;
+  top: 39px;
+  right: 24px;
+  left: 24px;
+  display: flex;
+  justify-content: space-between;
+  color: rgba(235, 242, 255, 0.5);
+  font: 600 9px/1 var(--studio-font-mono), ui-monospace, monospace;
+  letter-spacing: 0.1em;
+}
+
+.activationTrace {
+  position: absolute;
+  top: 60px;
+  right: 286px;
+  left: 22px;
+  display: flex;
+  min-height: 31px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 10px;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 9px;
+  background: rgba(17, 21, 33, 0.56);
+  color: rgba(218, 229, 248, 0.58);
+  backdrop-filter: blur(16px);
+}
+
+.activationTrace strong {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 9px;
+}
+
+.activationTrace code {
+  min-width: 0;
+  overflow: hidden;
+  font: 600 7.5px/1 var(--studio-font-mono), ui-monospace, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activationTrace > span {
+  flex: none;
+  margin-left: auto;
+  color: #78c49f;
+  font: 700 7px/1 var(--studio-font-mono), ui-monospace, monospace;
+  letter-spacing: 0.06em;
+}
+
+.activationTrace > span[data-mode="hidden"] {
+  color: #9ba8ba;
+}
+
+.bench {
+  position: absolute;
+  top: 101px;
+  right: 286px;
+  bottom: 24px;
+  left: 22px;
+}
+
+.hiddenState {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  padding: 24px;
+  color: rgba(218, 229, 248, 0.48);
+  text-align: center;
+}
+
+.hiddenState strong,
+.hiddenState span {
+  display: block;
+}
+
+.hiddenState strong {
+  margin-top: 10px;
+  color: rgba(239, 244, 253, 0.78);
+  font-size: 11px;
+}
+
+.hiddenState span {
+  max-width: 34ch;
+  margin-top: 5px;
+  font-size: 9px;
+  line-height: 1.45;
+}
+
+.sourcePanel,
+.reviewNote {
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 22px 58px rgba(2, 5, 12, 0.48);
+  backdrop-filter: blur(28px) saturate(125%);
+  -webkit-backdrop-filter: blur(28px) saturate(125%);
+}
+
+.sourcePanel {
+  position: absolute;
+  top: var(--home-y);
+  left: var(--home-x);
+  z-index: 1;
+  display: grid;
+  width: 48.5%;
+  height: 48.5%;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  border-radius: 13px;
+  background: rgba(17, 21, 33, 0.76);
+  color: #d7dfed;
+  transition:
+    top 340ms cubic-bezier(0.16, 1, 0.3, 1),
+    left 340ms cubic-bezier(0.16, 1, 0.3, 1),
+    width 340ms cubic-bezier(0.16, 1, 0.3, 1),
+    height 340ms cubic-bezier(0.16, 1, 0.3, 1),
+    filter 220ms ease-out,
+    opacity 220ms ease-out,
+    box-shadow 260ms ease-out;
+}
+
+.sourcePanel:not([data-active="true"]) {
+  opacity: 0.74;
+  filter: saturate(0.72) brightness(0.82);
+}
+
+.sourcePanel[data-active="true"] {
+  top: var(--focus-y);
+  left: var(--focus-x);
+  z-index: 3;
+  width: 76%;
+  height: 76%;
+  border-color: rgba(169, 203, 255, 0.28);
+  background: rgba(14, 18, 29, 0.9);
+  box-shadow: 0 28px 72px rgba(2, 5, 12, 0.62);
+}
+
+.bench[data-mode="peek"] .sourcePanel[data-ephemeral="true"] {
+  top: 5%;
+  left: 5%;
+  width: 90%;
+  height: 90%;
+}
+
+.promoteHandle {
+  position: absolute;
+  right: 7px;
+  bottom: 6px;
+  z-index: 5;
+  display: grid;
+  min-width: 25px;
+  height: 19px;
+  place-items: center;
+  padding: 0 5px;
+  border: 1px solid rgba(157, 192, 255, 0.3);
+  border-radius: 6px;
+  background: rgba(12, 17, 28, 0.88);
+  color: rgba(218, 231, 252, 0.78);
+  font: 700 7.5px/1 var(--studio-font-mono), ui-monospace, monospace;
+  cursor: pointer;
+}
+
+.promoteHandle:hover {
+  border-color: rgba(157, 192, 255, 0.58);
+  color: #fff;
+}
+
+.promoteHandle:focus-visible {
+  outline: 2px solid #9dc0ff;
+  outline-offset: 2px;
+}
+
+.sourceHeader {
+  display: flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 11px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(8, 12, 21, 0.24);
+}
+
+.sourceHeader > button {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  border: 0;
+  background: transparent;
+  color: #9fc0f7;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sourceHeader > button:focus-visible,
+.citationList button:focus-visible,
+.segmented button:focus-visible {
+  outline: 2px solid #9dc0ff;
+  outline-offset: 2px;
+}
+
+.sourceHeader > button > span {
+  min-width: 0;
+}
+
+.sourceHeader small,
+.sourceHeader strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sourceHeader small {
+  color: rgba(220, 230, 247, 0.45);
+  font: 500 8px/1.1 var(--studio-font-mono), ui-monospace, monospace;
+}
+
+.sourceHeader strong {
+  margin-top: 4px;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 10.5px;
+  font-weight: 650;
+}
+
+.sourceState {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 5px;
+  color: rgba(210, 226, 250, 0.55);
+  font: 650 7.5px/1 var(--studio-font-mono), ui-monospace, monospace;
+  letter-spacing: 0.06em;
+}
+
+.sourceActions {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 6px;
+}
+
+.peekClose {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid rgba(157, 192, 255, 0.2);
+  border-radius: 6px;
+  background: rgba(10, 14, 24, 0.44);
+  color: rgba(225, 235, 251, 0.68);
+  cursor: pointer;
+}
+
+.peekClose:hover {
+  color: #fff;
+}
+
+.peekClose:focus-visible {
+  outline: 2px solid #9dc0ff;
+  outline-offset: 2px;
+}
+
+.sourceCode {
+  overflow: auto;
+  padding: 10px 0 16px;
+  scrollbar-color: rgba(151, 177, 220, 0.25) transparent;
+  scrollbar-width: thin;
+}
+
+.sourceCode:focus-visible {
+  box-shadow: inset 0 0 0 2px rgba(157, 192, 255, 0.68);
+  outline: none;
+}
+
+.sourcePanel:not([data-active="true"]) .sourceCode {
+  overflow: hidden;
+}
+
+.codeLine {
+  display: grid;
+  grid-template-columns: 34px 16px max-content;
+  min-height: 21px;
+  align-items: center;
+  padding-right: 14px;
+  color: #d7dfed;
+  font: 500 10px/1.5 var(--studio-font-mono), ui-monospace, "SFMono-Regular", monospace;
+}
+
+.sourcePanel:not([data-active="true"]) .codeLine {
+  font-size: 8.5px;
+}
+
+.codeLine[data-anchor="true"] {
+  background: linear-gradient(90deg, rgba(87, 137, 219, 0.2), rgba(87, 137, 219, 0.03));
+}
+
+.sourcePanel[data-state="verify"] .codeLine[data-anchor="true"] {
+  background: linear-gradient(90deg, rgba(224, 184, 113, 0.2), rgba(224, 184, 113, 0.03));
+}
+
+.lineNumber {
+  padding-right: 7px;
+  color: rgba(176, 191, 216, 0.35);
+  text-align: right;
+}
+
+.bandCell {
+  display: grid;
+  height: 100%;
+  place-items: center;
+}
+
+.anchorBand {
+  width: 3px;
+  height: 14px;
+  border-radius: 2px;
+  background: #78a6f3;
+}
+
+.sourcePanel[data-state="verify"] .anchorBand {
+  background: #e0b871;
+}
+
+.codeLine code {
+  white-space: pre;
+}
+
+.keyword {
+  color: #d3a7f4;
+}
+
+.string {
+  color: #a9d5a9;
+}
+
+.number {
+  color: #e8bb7b;
+}
+
+.comment {
+  color: #8296b5;
+  font-style: italic;
+}
+
+.sourceFoot,
+.noteFoot {
+  display: flex;
+  min-height: 29px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 0 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.09);
+  color: rgba(220, 230, 247, 0.46);
+  font: 600 7.5px/1 var(--studio-font-mono), ui-monospace, monospace;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.reviewNote {
+  position: absolute;
+  top: 60px;
+  right: 22px;
+  bottom: 24px;
+  display: grid;
+  width: 252px;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  border-radius: 13px;
+  background: rgba(237, 240, 243, 0.88);
+  color: #18202c;
+}
+
+.noteHeader {
+  display: flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 11px;
+  border-bottom: 1px solid rgba(24, 32, 44, 0.13);
+}
+
+.noteIdentity,
+.noteControls {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+}
+
+.noteIdentity {
+  flex: 1;
+}
+
+.noteIdentity strong {
+  overflow: hidden;
+  font-size: 10px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.noteControls {
+  flex: none;
+}
+
+.noteControls button {
+  display: inline-flex;
+  min-height: 25px;
+  align-items: center;
+  gap: 5px;
+  padding: 0 7px;
+  border: 1px solid rgba(49, 95, 158, 0.2);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.38);
+  color: #526071;
+  font: 700 7px/1 var(--studio-font-mono), ui-monospace, monospace;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.noteControls button[aria-pressed="true"] {
+  border-color: rgba(49, 95, 158, 0.32);
+  background: rgba(70, 113, 178, 0.1);
+  color: #315f9e;
+}
+
+.noteControls button:hover {
+  background: rgba(255, 255, 255, 0.66);
+}
+
+.noteControls button:focus-visible {
+  outline: 2px solid #315f9e;
+  outline-offset: 2px;
+}
+
+.noteBody {
+  overflow: auto;
+  padding: 16px 14px 20px;
+  scrollbar-color: rgba(46, 58, 74, 0.25) transparent;
+  scrollbar-width: thin;
+}
+
+.noteBody h3 {
+  margin: 0;
+  color: #141b25;
+  font: 650 18px/1.15 var(--studio-font-serif), ui-serif, serif;
+  letter-spacing: -0.02em;
+}
+
+.noteBody > p {
+  margin: 9px 0 0;
+  color: #3e4a59;
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.activeFinding {
+  margin-top: 17px;
+  padding: 11px 0;
+  border-top: 1px solid rgba(24, 32, 44, 0.14);
+  border-bottom: 1px solid rgba(24, 32, 44, 0.14);
+}
+
+.activeFinding > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.activeFinding > div > span {
+  color: #376f59;
+  font: 700 8px/1 var(--studio-font-mono), ui-monospace, monospace;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.activeFinding[data-state="verify"] > div > span {
+  color: #8a611e;
+}
+
+.activeFinding[data-state="note"] > div > span {
+  color: #3f649e;
+}
+
+.activeFinding code {
+  color: #526d98;
+  font: 600 8px/1 var(--studio-font-mono), ui-monospace, monospace;
+}
+
+.activeFinding > strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.activeFinding > p {
+  margin: 6px 0 0;
+  color: #44505e;
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.noteBody h4 {
+  margin: 17px 0 0;
+  color: #596574;
+  font: 700 8px/1 var(--studio-font-mono), ui-monospace, monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.citationList {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.citationList li {
+  border-top: 1px solid rgba(24, 32, 44, 0.1);
+}
+
+.citationList li:last-child {
+  border-bottom: 1px solid rgba(24, 32, 44, 0.1);
+}
+
+.citationList li[data-active="true"] {
+  background: rgba(71, 111, 176, 0.07);
+}
+
+.citationList button {
+  display: block;
+  width: 100%;
+  padding: 8px 3px;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.citationList button span,
+.citationList button code {
+  display: block;
+}
+
+.citationList button span {
+  color: #26313f;
+  font-size: 9.5px;
+  font-weight: 650;
+}
+
+.citationList button code {
+  overflow: hidden;
+  margin-top: 4px;
+  color: #526d98;
+  font: 600 7.5px/1.35 var(--studio-font-mono), ui-monospace, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agentPrompt,
+.agentTurn {
+  margin-top: 14px;
+  padding: 10px;
+  border: 1px solid rgba(62, 86, 122, 0.2);
+  border-radius: 10px;
+  background: rgba(77, 112, 167, 0.07);
+}
+
+.agentPrompt > div,
+.agentTurn > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.agentPrompt > div span,
+.agentPrompt > div code,
+.agentTurn > div span,
+.agentTurn > div code {
+  color: #526d98;
+  font: 700 7px/1 var(--studio-font-mono), ui-monospace, monospace;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.agentPrompt > div code,
+.agentTurn > div code {
+  color: #6b7685;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.agentPrompt {
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.agentPrompt > p {
+  margin: 7px 0 0;
+  color: #2b3746;
+  font-size: 9.5px;
+  font-weight: 620;
+  line-height: 1.4;
+}
+
+.agentTurn > strong {
+  display: block;
+  margin-top: 9px;
+  color: #202b39;
+  font-size: 10px;
+}
+
+.agentTurn > p {
+  margin: 5px 0 0;
+  color: #4b5767;
+  font-size: 9px;
+  line-height: 1.45;
+}
+
+.agentTurn > button {
+  display: inline-flex;
+  min-height: 27px;
+  align-items: center;
+  gap: 6px;
+  margin-top: 9px;
+  padding: 0 8px;
+  border: 1px solid rgba(49, 95, 158, 0.28);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.5);
+  color: #315f9e;
+  font: 700 8px/1 var(--studio-font-sans), ui-sans-serif, sans-serif;
+  cursor: pointer;
+}
+
+.agentTurn > button:hover {
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.agentTurn > button:focus-visible {
+  outline: 2px solid #315f9e;
+  outline-offset: 2px;
+}
+
+.agentTurn[data-added="true"] {
+  background: rgba(55, 111, 89, 0.07);
+}
+
+.agentTurn[data-added="true"] > button {
+  border-color: rgba(55, 111, 89, 0.24);
+  color: #376f59;
+}
+
+.noteFoot {
+  border-color: rgba(24, 32, 44, 0.13);
+  color: #637082;
+}
+
+.metadataContract {
+  margin-top: 36px;
+  padding-top: 28px;
+  border-top: 1px solid var(--study-rule);
+}
+
+.metadataContract > header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.metadataContract h3 {
+  margin: 6px 0 0;
+  color: var(--studio-ink-strong);
+  font: 500 22px/1.15 var(--studio-font-serif), ui-serif, serif;
+  letter-spacing: -0.02em;
+}
+
+.metadataContract > header > span {
+  color: var(--studio-ink-faint);
+  font-size: 11px;
+}
+
+.metadataGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 18px;
+  margin-top: 17px;
+}
+
+.metadataGrid > pre {
+  min-width: 0;
+  margin: 0;
+  padding: 17px 18px;
+  overflow: auto;
+  border: 1px solid var(--study-rule);
+  border-radius: 12px;
+  background: var(--studio-canvas-alt);
+  color: var(--studio-ink);
+  font: 500 10px/1.65 var(--studio-font-mono), ui-monospace, monospace;
+}
+
+.metadataGrid dl {
+  margin: 0;
+  border-top: 1px solid var(--study-rule);
+  border-bottom: 1px solid var(--study-rule);
+}
+
+.metadataGrid dl > div {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: 12px;
+  padding: 11px 3px;
+}
+
+.metadataGrid dl > div + div {
+  border-top: 1px solid var(--study-rule);
+}
+
+.metadataGrid dt {
+  color: var(--studio-ink-strong);
+  font: 700 9px/1.45 var(--studio-font-mono), ui-monospace, monospace;
+  text-transform: uppercase;
+}
+
+.metadataGrid dd {
+  margin: 0;
+  color: var(--studio-ink-faint);
+  font-size: 10.5px;
+  line-height: 1.5;
+}
+
+.ladder {
+  margin-top: 36px;
+  padding-top: 28px;
+  border-top: 1px solid var(--study-rule);
+}
+
+.ladderHeader {
+  align-items: start;
+}
+
+.ladderHeader h3 {
+  font-size: 22px;
+  line-height: 1.15;
+}
+
+.ladderControls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.segmented {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--study-rule);
+  border-radius: 10px;
+  background: var(--studio-canvas-alt);
+}
+
+.segmented button {
+  min-height: 30px;
+  padding: 0 9px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--studio-ink-faint);
+  font: 600 10px/1 var(--studio-font-sans), ui-sans-serif, sans-serif;
+  text-transform: capitalize;
+  cursor: pointer;
+}
+
+.segmented button[aria-pressed="true"] {
+  background: var(--studio-surface);
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--studio-ink-strong) 10%, transparent);
+  color: var(--studio-ink-strong);
+}
+
+.ladderGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.ladderCell {
+  min-width: 0;
+  overflow: hidden;
+  border-radius: 12px;
+  box-shadow: 0 16px 36px rgba(7, 10, 18, 0.18);
+}
+
+.ladderCell[data-palette="dark"] {
+  --ladder-bg: #181d29;
+  --ladder-ink: #dbe4f2;
+  --ladder-faint: #91a0b6;
+  --ladder-keyword: #d5a8f3;
+  --ladder-string: #abd5aa;
+}
+
+.ladderCell[data-palette="light"] {
+  --ladder-bg: #f4f1eb;
+  --ladder-ink: #202630;
+  --ladder-faint: #536071;
+  --ladder-keyword: #7d3ba4;
+  --ladder-string: #356d42;
+}
+
+.ladderCell[data-material="glass"] {
+  border: 1px solid rgba(125, 146, 183, 0.28);
+  background:
+    linear-gradient(color-mix(in srgb, var(--ladder-bg) 82%, transparent), color-mix(in srgb, var(--ladder-bg) 82%, transparent)),
+    radial-gradient(circle at 80% 10%, #694d85, #233655 55%, #152330);
+  backdrop-filter: blur(18px);
+}
+
+.ladderCell[data-material="card"] {
+  border: 1px solid color-mix(in srgb, var(--ladder-ink) 13%, transparent);
+  background: var(--ladder-bg);
+}
+
+.ladderCell[data-material="dotted"] {
+  border: 1px solid color-mix(in srgb, var(--ladder-ink) 13%, transparent);
+  background-color: var(--ladder-bg);
+  background-image: radial-gradient(color-mix(in srgb, var(--ladder-faint) 32%, transparent) 0.6px, transparent 0.6px);
+  background-size: 10px 10px;
+}
+
+.ladderCell[data-material="source"] {
+  border: 1px solid color-mix(in srgb, #79a7f2 36%, transparent);
+  background: color-mix(in srgb, var(--ladder-bg) 96%, #07101f);
+}
+
+.ladderCell header {
+  display: flex;
+  min-height: 32px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--ladder-ink) 12%, transparent);
+  color: var(--ladder-faint);
+  font: 650 8px/1 var(--studio-font-mono), ui-monospace, monospace;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.ladderCell pre {
+  min-height: 95px;
+  margin: 0;
+  padding: 15px 12px;
+  overflow: hidden;
+  color: var(--ladder-ink);
+  font-family: var(--studio-font-mono), ui-monospace, monospace;
+  line-height: 1.65;
+  white-space: pre;
+}
+
+.ladderCell .keyword {
+  color: var(--ladder-keyword);
+}
+
+.ladderCell .string {
+  color: var(--ladder-string);
+}
+
+.engine {
+  margin-top: 30px;
+  padding-top: 26px;
+  border-top: 1px solid var(--study-rule);
+}
+
+.engine > header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.engine h3 {
+  margin: 6px 0 0;
+  color: var(--studio-ink-strong);
+  font: 500 22px/1.15 var(--studio-font-serif), ui-serif, serif;
+  letter-spacing: -0.02em;
+}
+
+.engine > header > span {
+  color: var(--studio-ink-faint);
+  font-size: 11px;
+}
+
+.engine dl {
+  margin: 17px 0 0;
+  border-top: 1px solid var(--study-rule);
+  border-bottom: 1px solid var(--study-rule);
+}
+
+.engine dl > div {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 18px;
+  padding: 12px 4px;
+}
+
+.engine dl > div + div {
+  border-top: 1px solid var(--study-rule);
+}
+
+.engine dt {
+  color: var(--studio-ink-strong);
+  font: 700 10px/1.45 var(--studio-font-mono), ui-monospace, monospace;
+  text-transform: uppercase;
+}
+
+.engine dd {
+  margin: 0;
+  color: var(--studio-ink-faint);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.boundary {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin-top: 22px;
+  border-top: 1px solid var(--study-rule);
+  border-bottom: 1px solid var(--study-rule);
+}
+
+.boundary span {
+  padding: 12px 10px;
+  color: var(--studio-ink-faint);
+  font-size: 10.5px;
+  line-height: 1.45;
+  text-align: center;
+}
+
+.boundary span + span {
+  border-left: 1px solid var(--study-rule);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sourcePanel {
+    transition: none;
+  }
+}
+
+@media (max-width: 960px) {
+  .bench {
+    right: 220px;
+  }
+
+  .activationTrace {
+    right: 220px;
+  }
+
+  .reviewNote {
+    width: 230px;
+  }
+
+  .sourcePanel[data-active="true"] {
+    width: 82%;
+  }
+
+  .ladderGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .studyHeader,
+  .ladderHeader,
+  .metadataContract > header,
+  .engine > header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .model,
+  .ladderControls {
+    flex-wrap: wrap;
+  }
+
+  .sceneLabel span:last-child {
+    display: none;
+  }
+
+  .bench {
+    right: 158px;
+    left: 12px;
+  }
+
+  .activationTrace {
+    right: 158px;
+    left: 12px;
+  }
+
+  .reviewNote {
+    right: 12px;
+    width: 180px;
+  }
+
+  .sourcePanel[data-active="true"] {
+    width: 92%;
+  }
+
+  .noteBody {
+    padding-right: 10px;
+    padding-left: 10px;
+  }
+
+  .ladderGrid,
+  .metadataGrid,
+  .boundary {
+    grid-template-columns: 1fr;
+  }
+
+  .engine dl > div {
+    grid-template-columns: 1fr;
+    gap: 5px;
+  }
+
+  .boundary span + span {
+    border-top: 1px solid var(--study-rule);
+    border-left: 0;
+  }
+}

--- a/design/studio/src/studio/studies/SpatialCodeReviewStudy.tsx
+++ b/design/studio/src/studio/studies/SpatialCodeReviewStudy.tsx
@@ -1,0 +1,603 @@
+"use client";
+
+import { useEffect, useRef, useState, type CSSProperties, type KeyboardEvent, type ReactNode } from "react";
+import {
+  ArrowDown,
+  Braces,
+  Check,
+  ChevronRight,
+  Eye,
+  EyeOff,
+  FileCode2,
+  LockKeyhole,
+  MessageSquareText,
+  X,
+} from "lucide-react";
+import { DesktopScene } from "./DesktopScene";
+import styles from "./SpatialCodeReviewStudy.module.css";
+
+/*
+THESIS: The Markdown note activates its metadata-declared source companions; the user can hide the arrangement without losing one-click ephemeral inspection.
+OWN-WORLD: Blink's desktop, translucent panels, disciplined native chrome, and file-backed Markdown truth remain visible.
+STORY: Activating update-ios.md reads blink.companions, lays out three source views, and supplies context to the agent. Code Hidden suppresses the layout; a citation still opens one temporary peek.
+FIRST VIEWPORT: The metadata activation trace, note-level Code control, related source bench, and citation-to-peek path read as one system within ten seconds.
+FORM: Companion arrival/promotion is the single authored motion. Frontmatter carries portable intent; local state carries visibility and exact geometry. Persistent IDE chrome stays outside Blink.
+*/
+
+type Finding = {
+  id: string;
+  fileId: string;
+  line: number;
+  range: string;
+  title: string;
+  body: string;
+  state: "clear" | "verify" | "note";
+};
+
+type SourceFile = {
+  id: string;
+  name: string;
+  directory: string;
+  language: string;
+  revision: string;
+  lines: Array<{ number: number; text: string }>;
+};
+
+const files: SourceFile[] = [
+  {
+    id: "snapshot",
+    name: "BlinkSnapshot.swift",
+    directory: "blink / Sources / BlinkCore",
+    language: "Swift",
+    revision: "76fc2d1",
+    lines: [
+      { number: 6, text: "public struct BlinkSnapshotNote: Codable, Sendable {" },
+      { number: 7, text: "    public var id: String" },
+      { number: 8, text: "    public var revision: String" },
+      { number: 9, text: "    public var markdown: String" },
+      { number: 10, text: "    public var title: String" },
+      { number: 11, text: "    public var updatedAt: Date" },
+      { number: 12, text: "    public var tags: [String]" },
+      { number: 13, text: "    public var pinned: Bool" },
+      { number: 14, text: "}" },
+      { number: 15, text: "" },
+      { number: 16, text: "// Exact payload; frontmatter travels with Markdown." },
+      { number: 17, text: "public struct BlinkSnapshot: Codable, Sendable {" },
+      { number: 18, text: "    public static let currentVersion = 1" },
+      { number: 19, text: "    public var generatedAt: Date" },
+      { number: 20, text: "    public var etag: String" },
+      { number: 21, text: "    public var notes: [BlinkSnapshotNote]" },
+      { number: 22, text: "    public var issues: [BlinkSnapshotIssue]" },
+      { number: 23, text: "}" },
+    ],
+  },
+  {
+    id: "cache",
+    name: "BlinkSnapshotCache.swift",
+    directory: "blink / Sources / BlinkCore",
+    language: "Swift",
+    revision: "76fc2d1",
+    lines: [
+      { number: 18, text: "/// Incoming snapshots are authoritative except for" },
+      { number: 19, text: "/// quarantined IDs whose source bytes were withheld." },
+      { number: 20, text: "public actor BlinkSnapshotCache {" },
+      { number: 21, text: "    private let fileURL: URL" },
+      { number: 22, text: "" },
+      { number: 23, text: "    public func apply(_ incoming: BlinkSnapshot) throws" },
+      { number: 24, text: "        -> BlinkSnapshot {" },
+      { number: 25, text: "        let prior = try load()" },
+      { number: 26, text: "        let heldIDs = Set(incoming.issues.compactMap {" },
+      { number: 27, text: "            $0.expectedID" },
+      { number: 28, text: "        })" },
+      { number: 29, text: "" },
+      { number: 30, text: "        let heldNotes = prior?.notes.filter {" },
+      { number: 31, text: "            heldIDs.contains($0.id)" },
+      { number: 32, text: "        } ?? []" },
+      { number: 33, text: "        return try persist(incoming, holding: heldNotes)" },
+      { number: 34, text: "    }" },
+      { number: 35, text: "}" },
+    ],
+  },
+  {
+    id: "mobile",
+    name: "ContentView.swift",
+    directory: "blink / apps / ios / BlinkMobile",
+    language: "SwiftUI",
+    revision: "76fc2d1",
+    lines: [
+      { number: 104, text: "private var connectionLine: some View {" },
+      { number: 105, text: "    HStack(spacing: 10) {" },
+      { number: 106, text: "        Rectangle()" },
+      { number: 107, text: "            .fill(theme.signal)" },
+      { number: 108, text: "            .frame(width: 8, height: 8)" },
+      { number: 109, text: "" },
+      { number: 110, text: "        Text(connectionLabel)" },
+      { number: 111, text: "            .font(theme.machineFont)" },
+      { number: 112, text: "            .foregroundStyle(theme.secondaryInk)" },
+      { number: 113, text: "    }" },
+      { number: 114, text: "    .accessibilityElement(children: .combine)" },
+      { number: 115, text: "}" },
+      { number: 116, text: "" },
+      { number: 117, text: "private var connectionLabel: String {" },
+      { number: 118, text: "    peerName.map { \"Connected · \\($0)\" }" },
+      { number: 119, text: "        ?? \"On this iPad\"" },
+      { number: 120, text: "}" },
+    ],
+  },
+  {
+    id: "bridge",
+    name: "WebBridge.swift",
+    directory: "blink / Sources / BlinkApp",
+    language: "Swift",
+    revision: "76fc2d1",
+    lines: [
+      { number: 27, text: "/// Hosts the renderer and speaks the native bridge." },
+      { number: 28, text: "@MainActor" },
+      { number: 29, text: "final class RendererWebView: NSObject {" },
+      { number: 30, text: "    let webView: WKWebView" },
+      { number: 31, text: "    private var isReady = false" },
+      { number: 32, text: "    private var pendingContent: String?" },
+      { number: 33, text: "" },
+      { number: 34, text: "    func setContent(_ text: String) {" },
+      { number: 35, text: "        guard isReady else {" },
+      { number: 36, text: "            pendingContent = text" },
+      { number: 37, text: "            return" },
+      { number: 38, text: "        }" },
+      { number: 39, text: "        evaluate(\"window.blink.setContent(...)\")" },
+      { number: 40, text: "    }" },
+      { number: 41, text: "}" },
+    ],
+  },
+];
+
+const findings: Finding[] = [
+  {
+    id: "wire-identity",
+    fileId: "snapshot",
+    line: 8,
+    range: "L8–9",
+    title: "Identity survives transport",
+    body: "Revision and complete Markdown already travel together. A cited source should keep the same exact-payload discipline.",
+    state: "clear",
+  },
+  {
+    id: "quarantine",
+    fileId: "cache",
+    line: 26,
+    range: "L26–33",
+    title: "Keep withheld files visible",
+    body: "Quarantine must never read as deletion. Preserve panel geometry and mark the source temporarily unavailable.",
+    state: "verify",
+  },
+  {
+    id: "trust-copy",
+    fileId: "mobile",
+    line: 117,
+    range: "L117–120",
+    title: "Use state, not narration",
+    body: "“On this iPad” is functional. Reserve offline language for an exceptional state that changes what the user can do.",
+    state: "note",
+  },
+  {
+    id: "bridge-capability",
+    fileId: "bridge",
+    line: 34,
+    range: "L34–40",
+    title: "Split the bridge by capability",
+    body: "Reuse loading, theme, and navigation. The source viewer must not register contentChanged or saveRequested, and should expose no mutation method.",
+    state: "verify",
+  },
+];
+
+const positionStyles: CSSProperties[] = [
+  { "--home-x": "0%", "--home-y": "0%", "--focus-x": "0%", "--focus-y": "0%" } as CSSProperties,
+  { "--home-x": "51.5%", "--home-y": "0%", "--focus-x": "24%", "--focus-y": "0%" } as CSSProperties,
+  { "--home-x": "0%", "--home-y": "51.5%", "--focus-x": "0%", "--focus-y": "24%" } as CSSProperties,
+  { "--home-x": "51.5%", "--home-y": "51.5%", "--focus-x": "24%", "--focus-y": "24%" } as CSSProperties,
+];
+
+const ladderMaterials = ["glass", "card", "dotted", "source"] as const;
+type CompanionVisibility = "auto" | "hidden";
+
+export function SpatialCodeReviewStudy() {
+  const [activeFileId, setActiveFileId] = useState(files[0].id);
+  const [bundleIds, setBundleIds] = useState(() => files.slice(0, 3).map((file) => file.id));
+  const [companionVisibility, setCompanionVisibility] = useState<CompanionVisibility>("auto");
+  const [peekFileId, setPeekFileId] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const [fontSize, setFontSize] = useState<11 | 12 | 13>(12);
+  const [ladderPalette, setLadderPalette] = useState<"light" | "dark">("dark");
+  const peekPanelRef = useRef<HTMLElement | null>(null);
+  const peekReturnFocusRef = useRef<HTMLElement | null>(null);
+  const bundleFiles = files.filter((file) => bundleIds.includes(file.id));
+  const activeIndex = bundleFiles.findIndex((file) => file.id === activeFileId);
+  const activeFile = bundleFiles[activeIndex] ?? bundleFiles[0];
+  const activeFinding = findings.find((finding) => finding.fileId === activeFile.id) ?? findings[0];
+  const peekFile = bundleFiles.find((file) => file.id === peekFileId);
+  const displayedFiles = companionVisibility === "auto" ? bundleFiles : peekFile ? [peekFile] : [];
+
+  useEffect(() => {
+    if (companionVisibility !== "hidden" || !peekFileId) return;
+    window.requestAnimationFrame(() => peekPanelRef.current?.focus());
+  }, [companionVisibility, peekFileId]);
+
+  function openPeek(fileId: string, returnFocus?: HTMLElement | null) {
+    const file = bundleFiles.find((item) => item.id === fileId);
+    peekReturnFocusRef.current = returnFocus
+      ?? (document.activeElement instanceof HTMLElement ? document.activeElement : null);
+    setActiveFileId(fileId);
+    setPeekFileId(fileId);
+    if (file) setAnnouncement(`Temporary source view opened: ${file.name}. Press Escape to close.`);
+  }
+
+  function closePeek() {
+    const fileName = peekFile?.name ?? "source";
+    setPeekFileId(null);
+    setAnnouncement(`Temporary source view closed: ${fileName}.`);
+    window.requestAnimationFrame(() => peekReturnFocusRef.current?.focus());
+  }
+
+  function promote(index: number) {
+    const file = bundleFiles[index];
+    if (!file) return;
+    if (companionVisibility === "hidden") {
+      openPeek(file.id);
+    } else {
+      setActiveFileId(file.id);
+    }
+  }
+
+  function openReference(fileId: string, returnFocus: HTMLElement) {
+    if (companionVisibility === "hidden") {
+      openPeek(fileId, returnFocus);
+    } else {
+      setActiveFileId(fileId);
+    }
+  }
+
+  function toggleCompanions() {
+    setCompanionVisibility((current) => current === "auto" ? "hidden" : "auto");
+    setPeekFileId(null);
+  }
+
+  function handleKeys(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape" && peekFileId) {
+      event.preventDefault();
+      closePeek();
+      return;
+    }
+    if (!event.altKey) return;
+    const number = Number(event.key);
+    if (number >= 1 && number <= bundleFiles.length) {
+      event.preventDefault();
+      promote(number - 1);
+      return;
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const delta = event.key === "ArrowDown" ? 1 : -1;
+      promote((activeIndex + delta + bundleFiles.length) % bundleFiles.length);
+    }
+  }
+
+  function addSuggestedFile(returnFocus: HTMLElement) {
+    const suggestion = files[3];
+    if (!bundleIds.includes(suggestion.id)) setBundleIds((current) => [...current, suggestion.id]);
+    if (companionVisibility === "hidden") {
+      peekReturnFocusRef.current = returnFocus;
+      setActiveFileId(suggestion.id);
+      setPeekFileId(suggestion.id);
+      setAnnouncement(`WebBridge.swift added to the note companions and opened as a temporary source view.`);
+    } else {
+      setActiveFileId(suggestion.id);
+    }
+  }
+
+  return (
+    <div className={styles.study} onKeyDown={handleKeys}>
+      <header className={styles.studyHeader}>
+        <div>
+          <p className={styles.kicker}>Note-driven companions · Opus + owner</p>
+          <p className={styles.studyCopy}>
+            One Markdown note declares the related source cast; one local control decides whether the desk performs the arrangement.
+          </p>
+        </div>
+        <div className={styles.model} aria-label="Note activation model">
+          <MessageSquareText size={15} aria-hidden="true" />
+          <span>note.md</span>
+          <ChevronRight size={13} aria-hidden="true" />
+          <span>frontmatter</span>
+          <ChevronRight size={13} aria-hidden="true" />
+          <span>{bundleFiles.length} companions</span>
+        </div>
+      </header>
+
+      <div className={styles.sceneFocus} role="group" tabIndex={0} aria-label="Interactive Review Bench. Option and a number promotes a source; Option up or down steps findings.">
+        <div className={styles.srOnly} aria-live="polite" aria-atomic="true">{announcement}</div>
+        <DesktopScene menubar height={640}>
+          <div className={styles.sceneLabel}>
+            <span>ILLUSTRATIVE · NOTE ACTIVATION · LOCAL DESK</span>
+            <span>⌥1–4 PROMOTE · ⌥↑↓ STEP ANCHORS</span>
+          </div>
+
+          <div className={styles.activationTrace}>
+            <Braces size={12} aria-hidden="true" />
+            <strong>update-ios.md</strong>
+            <ChevronRight size={11} aria-hidden="true" />
+            <code>blink.companions · review-bench · {bundleFiles.length} refs</code>
+            <span data-mode={companionVisibility}>{companionVisibility === "auto" ? "LAYOUT ACTIVE" : "LAYOUT HIDDEN"}</span>
+          </div>
+
+          <section
+            className={styles.bench}
+            data-mode={companionVisibility === "hidden" && peekFile ? "peek" : companionVisibility}
+            aria-label="Source companions for update-ios.md"
+          >
+            {companionVisibility === "hidden" && !peekFile && (
+              <div className={styles.hiddenState}>
+                <EyeOff size={16} aria-hidden="true" />
+                <strong>Code companions hidden</strong>
+                <span>Select any citation in the note to open a temporary view.</span>
+              </div>
+            )}
+
+            {displayedFiles.map((file) => {
+              const index = bundleFiles.findIndex((item) => item.id === file.id);
+              const finding = findings.find((item) => item.fileId === file.id)!;
+              const active = file.id === activeFileId;
+              const isPeek = companionVisibility === "hidden";
+              return (
+                <article
+                  className={styles.sourcePanel}
+                  data-active={active}
+                  data-ephemeral={isPeek}
+                  data-state={finding.state}
+                  aria-label={isPeek ? `Temporary source view: ${file.name}` : `Source companion: ${file.name}`}
+                  key={file.id}
+                  ref={isPeek ? peekPanelRef : undefined}
+                  style={positionStyles[index]}
+                  tabIndex={isPeek ? -1 : undefined}
+                >
+                  <header className={styles.sourceHeader}>
+                    <button type="button" onClick={() => promote(index)} aria-pressed={active}>
+                      <FileCode2 size={14} aria-hidden="true" />
+                      <span>
+                        <small>{file.directory}</small>
+                        <strong>{file.name}</strong>
+                      </span>
+                    </button>
+                    <div className={styles.sourceActions}>
+                      <span className={styles.sourceState}>
+                        <LockKeyhole size={10} aria-hidden="true" />
+                        {isPeek ? "EPHEMERAL PEEK" : active ? "CM6 VIEW" : `⌥${index + 1}`}
+                      </span>
+                      {isPeek && (
+                        <button type="button" className={styles.peekClose} onClick={closePeek} aria-label="Close temporary source view">
+                          <X size={11} aria-hidden="true" />
+                        </button>
+                      )}
+                    </div>
+                  </header>
+
+                  <div className={styles.sourceCode} role="region" tabIndex={active ? 0 : -1} aria-label={`${file.name} source`}>
+                    {file.lines.map((line) => {
+                      const anchor = line.number === finding.line;
+                      return (
+                        <div className={styles.codeLine} data-anchor={anchor} key={line.number}>
+                          <span className={styles.lineNumber}>{line.number}</span>
+                          <span className={styles.bandCell}>{anchor && <span className={styles.anchorBand} />}</span>
+                          <code>{highlight(line.text)}</code>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  <footer className={styles.sourceFoot}>
+                    <span>{file.language}</span>
+                    <span>{finding.range} · {finding.state}</span>
+                    <span>{file.revision}</span>
+                  </footer>
+                  {!active && (
+                    <button
+                      type="button"
+                      className={styles.promoteHandle}
+                      onClick={() => promote(index)}
+                      aria-label={`Promote ${file.name}`}
+                    >
+                      ⌥{index + 1}
+                    </button>
+                  )}
+                </article>
+              );
+            })}
+          </section>
+
+          <aside className={styles.reviewNote} aria-label="Agent-authored Markdown review note">
+            <header className={styles.noteHeader}>
+              <div className={styles.noteIdentity}>
+                <MessageSquareText size={14} aria-hidden="true" />
+                <strong>update-ios.md</strong>
+              </div>
+              <div className={styles.noteControls}>
+                <button
+                  type="button"
+                  aria-pressed={companionVisibility === "auto"}
+                  aria-label={companionVisibility === "auto" ? "Hide code companions" : "Show code companions automatically"}
+                  onClick={toggleCompanions}
+                >
+                  {companionVisibility === "auto" ? <Eye size={11} aria-hidden="true" /> : <EyeOff size={11} aria-hidden="true" />}
+                  <span>CODE {companionVisibility === "auto" ? "AUTO" : "HIDDEN"}</span>
+                </button>
+              </div>
+            </header>
+
+            <div className={styles.noteBody}>
+              <h3>Review pass</h3>
+              <p>
+                The snapshot path is coherent. Keep cited source exact, local, and visibly immutable.
+              </p>
+
+              <div className={styles.activeFinding} data-state={activeFinding.state}>
+                <div>
+                  <span>{activeFinding.state}</span>
+                  <code>{activeFile.name}:{activeFinding.range}</code>
+                </div>
+                <strong>{activeFinding.title}</strong>
+                <p>{activeFinding.body}</p>
+              </div>
+
+              <h4>Cited paragraphs</h4>
+              <ol className={styles.citationList}>
+                {bundleFiles.map((file, index) => {
+                  const finding = findings.find((item) => item.fileId === file.id)!;
+                  return <li key={finding.id} data-active={index === activeIndex}>
+                    <button type="button" onClick={(event) => openReference(file.id, event.currentTarget)}>
+                      <span>{finding.title}</span>
+                      <code>[[src:blink/{file.name}#{finding.range}@{file.revision}]]</code>
+                    </button>
+                  </li>;
+                })}
+              </ol>
+
+              <div className={styles.agentPrompt}>
+                <div>
+                  <span>YOU</span>
+                  <code>{bundleFiles.length} files · {activeFinding.range}</code>
+                </div>
+                <p>What code decides whether this surface can write?</p>
+              </div>
+
+              <div className={styles.agentTurn} data-added={bundleIds.includes(files[3].id)}>
+                <div>
+                  <span>AGENT FOUND</span>
+                  <code>from current bundle</code>
+                </div>
+                <strong>WebBridge.swift</strong>
+                <p>The renderer boundary decides whether “read only” is structural or merely a mode.</p>
+                <button type="button" onClick={(event) => addSuggestedFile(event.currentTarget)}>
+                  {bundleIds.includes(files[3].id) ? <><Check size={11} /> In bundle</> : <>Add relevant file <ArrowDown size={11} /></>}
+                </button>
+              </div>
+            </div>
+
+            <footer className={styles.noteFoot}>
+              <span>agent://opus</span>
+              <span>{activeIndex + 1} / {bundleFiles.length}</span>
+            </footer>
+          </aside>
+        </DesktopScene>
+      </div>
+
+      <section className={styles.metadataContract} aria-labelledby="metadata-contract-title">
+        <header>
+          <div>
+            <p className={styles.kicker}>Activation contract</p>
+            <h3 id="metadata-contract-title">The note tells Blink what belongs together.</h3>
+          </div>
+          <span>Portable intent in Markdown; physical resolution on this device.</span>
+        </header>
+        <div className={styles.metadataGrid}>
+          <pre aria-label="Illustrative Blink companions frontmatter">{`blink:
+  companions:
+    layout: review-bench
+    sources:
+      - "blink/BlinkSnapshot.swift#L8-9@76fc2d1"
+      - "blink/BlinkSnapshotCache.swift#L26-33@76fc2d1"
+      - "blink/ContentView.swift#L117-120@76fc2d1"`}</pre>
+          <dl>
+            <div>
+              <dt>Frontmatter</dt>
+              <dd>Small source cast, named roots, revision anchors, preferred arrangement.</dd>
+            </div>
+            <div>
+              <dt>Local state</dt>
+              <dd>Code Auto/Hidden, exact frames, z-order, and the current ephemeral peek.</dd>
+            </div>
+            <div>
+              <dt>Agent action</dt>
+              <dd>Propose or revise companions; admission writes the durable note metadata.</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section className={styles.ladder} aria-labelledby="legibility-ladder-title">
+        <header className={styles.ladderHeader}>
+          <div>
+            <p className={styles.kicker}>Pre-implementation gate</p>
+            <h3 id="legibility-ladder-title">Legibility ladder</h3>
+            <p>Same CodeMirror view, four materials. “Source” must earn its own sheet before the renderer ships.</p>
+          </div>
+          <div className={styles.ladderControls}>
+            <div className={styles.segmented} aria-label="Code size">
+              {([11, 12, 13] as const).map((size) => (
+                <button type="button" aria-pressed={fontSize === size} key={size} onClick={() => setFontSize(size)}>{size} pt</button>
+              ))}
+            </div>
+            <div className={styles.segmented} aria-label="Code palette">
+              {(["light", "dark"] as const).map((palette) => (
+                <button type="button" aria-pressed={ladderPalette === palette} key={palette} onClick={() => setLadderPalette(palette)}>{palette}</button>
+              ))}
+            </div>
+          </div>
+        </header>
+
+        <div className={styles.ladderGrid}>
+          {ladderMaterials.map((material) => (
+            <article className={styles.ladderCell} data-material={material} data-palette={ladderPalette} key={material}>
+              <header><span>{material}</span><span>{fontSize} pt</span></header>
+              <pre style={{ fontSize }}><span className={styles.keyword}>public</span> <span className={styles.keyword}>actor</span> BlinkSnapshotCache {"{"}{"\n"}    <span className={styles.keyword}>let</span> revision = <span className={styles.string}>"76fc2d1"</span>{"\n"}{"}"}</pre>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.engine} aria-labelledby="renderer-contract-title">
+        <header>
+          <div>
+            <p className={styles.kicker}>Rendering engine</p>
+            <h3 id="renderer-contract-title">CodeMirror-class, structurally read only</h3>
+          </div>
+          <span>Reuse the host; specialize the renderer.</span>
+        </header>
+        <dl>
+          <div>
+            <dt>Native host</dt>
+            <dd>WKWebView lifecycle · transparent material · theme/sheet · deny-by-default navigation · pending-until-ready queue</dd>
+          </div>
+          <div>
+            <dt>CM6 read kernel</dt>
+            <dd>EditorState.readOnly + EditorView.editable(false) · selection · search · line numbers · viewport rendering · anchor decorations</dd>
+          </div>
+          <div>
+            <dt>Language adapter</dt>
+            <dd>Real parser per declared language; Swift is the first gate. Unsupported source renders honestly as plain text, never counterfeit highlighting.</dd>
+          </div>
+          <div>
+            <dt>Capability wall</dt>
+            <dd>ready · open citation · ask agent are allowed. contentChanged · saveRequested · edit history are absent from both JS and native.</dd>
+          </div>
+        </dl>
+      </section>
+
+      <div className={styles.boundary}>
+        <span>Frontmatter owns the companion cast.</span>
+        <span>Local state owns visibility and frames.</span>
+        <span>Citations can always open a temporary peek.</span>
+        <span>Agent admission updates the durable note.</span>
+      </div>
+    </div>
+  );
+}
+
+function highlight(source: string): ReactNode[] {
+  const tokens = source.split(/(\/\/.*$|\/\/\/.*$|"(?:[^"\\]|\\.)*"|\b(?:public|private|struct|actor|var|let|static|func|return|throws|some|nil)\b|\b\d+\b)/g);
+  return tokens.map((token, index) => {
+    if (!token) return null;
+    if (token.startsWith("//")) return <span className={styles.comment} key={index}>{token}</span>;
+    if (token.startsWith("\"") && token.endsWith("\"")) return <span className={styles.string} key={index}>{token}</span>;
+    if (/^\d+$/.test(token)) return <span className={styles.number} key={index}>{token}</span>;
+    if (/^(public|private|struct|actor|var|let|static|func|return|throws|some|nil)$/.test(token)) return <span className={styles.keyword} key={index}>{token}</span>;
+    return <span key={index}>{token}</span>;
+  });
+}

--- a/design/studio/src/studio/studioRegistry.ts
+++ b/design/studio/src/studio/studioRegistry.ts
@@ -103,6 +103,21 @@ export const pages: readonly BlinkStudioPage[] = [
       "The atomic unit: a glass NSPanel that is nothing but the note. Chrome earned on hover; shade to a 28px bar.",
   },
   {
+    href: "/studio/studies/review-bench",
+    label: "Review Bench",
+    bucket: "studies",
+    surface: "macos",
+    status: "study",
+    blurb:
+      "Blink V2's first non-Markdown surface: a note's frontmatter declares its source companions and preferred bench, local controls decide whether they appear, and any citation can still open a temporary CodeMirror peek.",
+    source: [
+      "design/studio/src/studio/studies/SpatialCodeReviewStudy.tsx",
+      "Sources/BlinkApp/SourcePanelManager.swift",
+      "Sources/BlinkCore/SourceReference.swift",
+      "web/editor/src/source-main.ts",
+    ],
+  },
+  {
     href: "/studio/studies/menubar-popover",
     label: "Menubar popover",
     bucket: "studies",

--- a/docs/config.md
+++ b/docs/config.md
@@ -100,6 +100,11 @@ Rules:
     "h1Size": null,             // px, reader scale; default 20 (editor derives slightly smaller)
     "h2Size": null,             // default 17
     "h3Size": null              // default 15
+  },
+  "sources": {                  // local authority for read-only source companions
+    "roots": {},                // portable name → absolute folder on this device
+    "maxPreviewBytes": 2000000, // regular UTF-8 files only; symlinks may not escape a root
+    "autoOpenCompanions": true  // activate note-declared source casts by default
   }
 }
 ```
@@ -121,6 +126,40 @@ Rules:
   (`--blink-font-size`, `--blink-text`, …) and is pushed over the bridge via
   `window.blink.setTheme`. The full variable table lives in
   `web/editor/README.md`.
+- `sources.roots` is deliberately empty by default. A note stores a portable
+  locator such as `blink/Sources/BlinkCore/Note.swift`; this map supplies the
+  local absolute meaning of `blink`. On first activation of an unknown root,
+  Blink offers a folder picker and records the approved mapping here. Reads are
+  contained after resolving symlinks, limited to regular UTF-8 files, and capped
+  by `maxPreviewBytes`.
+
+## Source companions
+
+Any recognized local code/text file can be opened with **⌘O** (or **Open Source
+File** in the command palette). The picker is explicit, one-shot authority; the
+chosen path is not written into a note.
+
+A note can instead declare a portable source cast:
+
+```yaml
+blink:
+  companions:
+    layout: review-bench
+    sources:
+      - "blink/Sources/BlinkCore/Note.swift#L12-28@76fc2d1"
+      - "blink/Sources/BlinkApp/WebBridge.swift"
+```
+
+A cast contains at most three unique files. Line anchors are capped at 1,000
+lines, keeping agent-authored metadata from turning note activation into
+unbounded window or rendering work.
+
+The optional `#Lstart-end` anchor selects and reveals a line range. The optional
+`@revision` is visible provenance; Blink never checks out or mutates a repository.
+`layout: review-bench` gives a fresh cast a deliberate grid, while each panel's
+eventual exact frame remains local to the device. Right-click the note and choose
+**Hide Code Companions** or **Show Code Companions**; that preference is local
+and never changes the Markdown.
 
 ## Examples
 

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -57,10 +57,16 @@ fi
 
 # Editor web bundle (built separately: cd web/editor && bun run build).
 editor_html="$repo_root/web/editor/dist/editor.html"
+source_viewer_html="$repo_root/web/editor/dist/source-viewer.html"
 if [[ -f "$editor_html" ]]; then
   cp "$editor_html" "$app_path/Contents/Resources/editor.html"
 else
   echo "warning: web/editor/dist/editor.html missing — note panels will not load an editor" >&2
+fi
+if [[ -f "$source_viewer_html" ]]; then
+  cp "$source_viewer_html" "$app_path/Contents/Resources/source-viewer.html"
+else
+  echo "warning: web/editor/dist/source-viewer.html missing — source panels will not render" >&2
 fi
 
 # Keep local bundles truthful: the same package version drives the CLI, npm,

--- a/tools/release/build-dmg.sh
+++ b/tools/release/build-dmg.sh
@@ -52,7 +52,8 @@ echo "==> Building Blink v$VERSION (release)"
 
 # The note panels load this bundle from Resources; build it if it's stale/missing.
 EDITOR_HTML="$ROOT/web/editor/dist/editor.html"
-if [ ! -f "$EDITOR_HTML" ]; then
+SOURCE_VIEWER_HTML="$ROOT/web/editor/dist/source-viewer.html"
+if [ ! -f "$EDITOR_HTML" ] || [ ! -f "$SOURCE_VIEWER_HTML" ]; then
     echo "==> Building editor bundle..."
     (cd "$ROOT/web/editor" && bun install && bun run build)
 fi
@@ -75,6 +76,7 @@ for resource_bundle in "$(dirname "$BIN_PATH")"/*.bundle; do
     ditto "$resource_bundle" "$BUNDLE/Contents/Resources/$(basename "$resource_bundle")"
 done
 cp "$EDITOR_HTML" "$BUNDLE/Contents/Resources/editor.html"
+cp "$SOURCE_VIEWER_HTML" "$BUNDLE/Contents/Resources/source-viewer.html"
 ICON="$ROOT/assets/AppIcon.icns"
 [ -f "$ICON" ] && cp "$ICON" "$BUNDLE/Contents/Resources/AppIcon.icns"
 

--- a/web/editor/README.md
+++ b/web/editor/README.md
@@ -32,6 +32,19 @@ bun run build       # esbuild -> dist/editor.html (single file, guardrailed)
 read-mode surface (`#reader` element, `.blink-reader` styles, empty-note
 placeholder).
 
+The same command also emits `dist/source-viewer.html`. That bundle is a separate
+CodeMirror surface for source companions: line numbers, real Swift and common
+language modes, selection, search, viewport rendering, and anchored line-range
+decoration. Its contract is structurally read-only:
+
+- CodeMirror installs both `EditorState.readOnly.of(true)` and
+  `EditorView.editable.of(false)`.
+- JS → native posts only `{ type: "ready" }` on the `blinkSource` handler.
+- Native → JS exposes `setDocument`, `setTheme`, `focus`, and `showFind` on
+  `window.blinkSource`.
+- There is no content getter, change message, save request, or native write
+  callback. Source viewing cannot enter the note bridge by configuration error.
+
 ## Native bridge contract
 
 Two directions. `JS -> native` posts to the WKWebView message handler; when that

--- a/web/editor/build-source.mjs
+++ b/web/editor/build-source.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { build } from "esbuild";
+import { mkdir, writeFile, stat } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const outHtml = resolve(root, "dist/source-viewer.html");
+const PAGE_CSS = `
+:root {
+  --blink-source-color-scheme: dark;
+  color-scheme: var(--blink-source-color-scheme);
+  --blink-font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+  --blink-mono-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Monaco, monospace;
+  --blink-source-font-size: 12px;
+  --blink-source-line-height: 1.62;
+  --blink-text: rgba(235, 241, 251, 0.88);
+  --blink-text-strong: rgba(255, 255, 255, 0.96);
+  --blink-text-muted: rgba(197, 210, 232, 0.48);
+  --blink-accent: #9fc0f7;
+  --blink-code-bg: rgba(255, 255, 255, 0.07);
+  --blink-selection: rgba(122, 166, 238, 0.26);
+  --blink-source-anchor: rgba(89, 137, 211, 0.16);
+  --blink-source-match: rgba(214, 174, 91, 0.24);
+  --blink-source-panel: rgba(12, 17, 28, 0.96);
+  --blink-source-rule: rgba(255, 255, 255, 0.12);
+  --blink-source-keyword: #8db8ff;
+  --blink-source-type: #7fd7d0;
+  --blink-source-function: #d8b5ff;
+  --blink-source-string: #9bd49b;
+  --blink-source-literal: #e7bd86;
+  --blink-source-meta: #b8c7df;
+}
+* { box-sizing: border-box; }
+html, body, #source { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+html, body { background: transparent; }
+#source, .cm-editor, .cm-scroller, .cm-content, .cm-gutters { background: transparent !important; }
+.cm-editor { height: 100%; }
+`;
+
+async function main() {
+  const result = await build({
+    entryPoints: [resolve(root, "src/source-main.ts")],
+    bundle: true,
+    write: false,
+    minify: true,
+    format: "iife",
+    platform: "browser",
+    target: ["safari17"],
+  });
+  const js = result.outputFiles[0].text;
+  const html = `<!doctype html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><style>${PAGE_CSS}</style></head>
+<body><main id="source" aria-label="Read-only source file"></main><script>${js}</script></body></html>`;
+
+  if (/contentChanged|saveRequested|getContent/.test(html)) {
+    throw new Error("Source viewer contains a mutating editor bridge capability");
+  }
+  for (const required of ["readOnly", "editable", "lineNumbers", "setDocument", "showFind"]) {
+    if (!html.includes(required)) throw new Error(`Source viewer is missing ${required}`);
+  }
+  await mkdir(dirname(outHtml), { recursive: true });
+  await writeFile(outHtml, html, "utf8");
+  const { size } = await stat(outHtml);
+  if (size > 1.5 * 1024 * 1024) throw new Error("source-viewer.html exceeds 1.5 MB");
+  console.log(`[BLINK] Wrote ${outHtml} (${(size / 1024).toFixed(1)} KB, self-contained, read-only)`);
+}
+
+main().catch((error) => { console.error(error); process.exit(1); });

--- a/web/editor/bun.lock
+++ b/web/editor/bun.lock
@@ -8,6 +8,8 @@
         "@codemirror/commands": "^6.6.0",
         "@codemirror/lang-markdown": "^6.3.0",
         "@codemirror/language": "^6.10.2",
+        "@codemirror/legacy-modes": "^6.5.3",
+        "@codemirror/search": "^6.7.1",
         "@codemirror/state": "^6.4.1",
         "@codemirror/view": "^6.28.0",
         "@lezer/highlight": "^1.2.0",
@@ -34,7 +36,11 @@
 
     "@codemirror/language": ["@codemirror/language@6.12.4", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A=="],
 
+    "@codemirror/legacy-modes": ["@codemirror/legacy-modes@6.5.3", "", { "dependencies": { "@codemirror/language": "^6.0.0" } }, "sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg=="],
+
     "@codemirror/lint": ["@codemirror/lint@6.9.7", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.42.0", "crelt": "^1.0.5" } }, "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg=="],
+
+    "@codemirror/search": ["@codemirror/search@6.7.1", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA=="],
 
     "@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
 

--- a/web/editor/package.json
+++ b/web/editor/package.json
@@ -5,13 +5,15 @@
   "type": "module",
   "description": "Vanilla CodeMirror 6 editor surface for Blink v2 native panels (WKWebView host).",
   "scripts": {
-    "build": "node build.mjs",
+    "build": "node build.mjs && node build-source.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@codemirror/commands": "^6.6.0",
     "@codemirror/lang-markdown": "^6.3.0",
     "@codemirror/language": "^6.10.2",
+    "@codemirror/legacy-modes": "^6.5.3",
+    "@codemirror/search": "^6.7.1",
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.28.0",
     "@lezer/highlight": "^1.2.0",

--- a/web/editor/src/source-languages.ts
+++ b/web/editor/src/source-languages.ts
@@ -1,0 +1,87 @@
+import type { Extension } from "@codemirror/state";
+import { StreamLanguage } from "@codemirror/language";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { swift } from "@codemirror/legacy-modes/mode/swift";
+import {
+  c,
+  cpp,
+  csharp,
+  java,
+  kotlin,
+  objectiveC,
+  objectiveCpp,
+  scala,
+} from "@codemirror/legacy-modes/mode/clike";
+import {
+  javascript,
+  json,
+  typescript,
+} from "@codemirror/legacy-modes/mode/javascript";
+import { python } from "@codemirror/legacy-modes/mode/python";
+import { ruby } from "@codemirror/legacy-modes/mode/ruby";
+import { rust } from "@codemirror/legacy-modes/mode/rust";
+import { go } from "@codemirror/legacy-modes/mode/go";
+import { shell } from "@codemirror/legacy-modes/mode/shell";
+import { standardSQL } from "@codemirror/legacy-modes/mode/sql";
+import { yaml } from "@codemirror/legacy-modes/mode/yaml";
+import { toml } from "@codemirror/legacy-modes/mode/toml";
+import { css, less, sCSS } from "@codemirror/legacy-modes/mode/css";
+import { html, xml } from "@codemirror/legacy-modes/mode/xml";
+import { diff } from "@codemirror/legacy-modes/mode/diff";
+import { dockerFile } from "@codemirror/legacy-modes/mode/dockerfile";
+import { lua } from "@codemirror/legacy-modes/mode/lua";
+import { r } from "@codemirror/legacy-modes/mode/r";
+import { powerShell } from "@codemirror/legacy-modes/mode/powershell";
+import { properties } from "@codemirror/legacy-modes/mode/properties";
+import { protobuf } from "@codemirror/legacy-modes/mode/protobuf";
+import { groovy } from "@codemirror/legacy-modes/mode/groovy";
+import { cmake } from "@codemirror/legacy-modes/mode/cmake";
+
+const stream = (parser: Parameters<typeof StreamLanguage.define>[0]): Extension =>
+  StreamLanguage.define(parser);
+
+/** Honest language routing. Unknown formats remain selectable plain text. */
+export function sourceLanguage(name: string): Extension {
+  switch (name.toLowerCase()) {
+    case "markdown": return markdown({ base: markdownLanguage });
+    case "swift": return stream(swift);
+    case "c": return stream(c);
+    case "cpp": return stream(cpp);
+    case "csharp": return stream(csharp);
+    case "java": return stream(java);
+    case "kotlin": return stream(kotlin);
+    case "objective-c": return stream(objectiveC);
+    case "objective-cpp": return stream(objectiveCpp);
+    case "scala": return stream(scala);
+    case "javascript":
+    case "jsx": return stream(javascript);
+    case "typescript":
+    case "tsx": return stream(typescript);
+    case "json": return stream(json);
+    case "python": return stream(python);
+    case "ruby": return stream(ruby);
+    case "rust": return stream(rust);
+    case "go": return stream(go);
+    case "shell":
+    case "makefile": return stream(shell);
+    case "powershell": return stream(powerShell);
+    case "sql": return stream(standardSQL);
+    case "yaml": return stream(yaml);
+    case "toml": return stream(toml);
+    case "css": return stream(css);
+    case "scss":
+    case "sass": return stream(sCSS);
+    case "less": return stream(less);
+    case "html": return stream(html);
+    case "xml": return stream(xml);
+    case "diff": return stream(diff);
+    case "dockerfile": return stream(dockerFile);
+    case "lua": return stream(lua);
+    case "r": return stream(r);
+    case "properties": return stream(properties);
+    case "protobuf": return stream(protobuf);
+    case "groovy": return stream(groovy);
+    case "cmake": return stream(cmake);
+    default: return [];
+  }
+}

--- a/web/editor/src/source-main.ts
+++ b/web/editor/src/source-main.ts
@@ -1,0 +1,121 @@
+import { EditorState, type Extension } from "@codemirror/state";
+import {
+  Decoration,
+  EditorView,
+  drawSelection,
+  highlightActiveLineGutter,
+  keymap,
+  lineNumbers,
+} from "@codemirror/view";
+import { defaultKeymap } from "@codemirror/commands";
+import {
+  highlightSelectionMatches,
+  openSearchPanel,
+  search,
+  searchKeymap,
+} from "@codemirror/search";
+import { syntaxHighlighting, defaultHighlightStyle } from "@codemirror/language";
+import { sourceLanguage } from "./source-languages";
+import { blinkSourceTheme } from "./source-theme";
+
+type SourcePayload = {
+  text: string;
+  language: string;
+  lineStart?: number | null;
+  lineEnd?: number | null;
+};
+
+type SourceGlobal = {
+  setDocument(payload: SourcePayload): void;
+  setTheme(vars: Record<string, string>): void;
+  focus(): void;
+  showFind(): void;
+};
+
+declare global {
+  interface Window {
+    blinkSource?: SourceGlobal;
+  }
+}
+
+function postReady(): void {
+  const host = window as unknown as {
+    webkit?: { messageHandlers?: { blinkSource?: { postMessage(message: unknown): void } } };
+  };
+  host.webkit?.messageHandlers?.blinkSource?.postMessage({ type: "ready" });
+}
+
+function anchorExtension(start?: number | null, end?: number | null): Extension {
+  if (!start || start < 1) return [];
+  return EditorView.decorations.compute([], (state) => {
+    if (start > state.doc.lines) return Decoration.none;
+    const boundedEnd = Math.min(Math.max(end ?? start, start), start + 999);
+    const last = Math.min(boundedEnd, state.doc.lines);
+    const decorations = [];
+    for (let number = start; number <= last; number += 1) {
+      decorations.push(Decoration.line({ class: "blink-source-anchor" }).range(state.doc.line(number).from));
+    }
+    return Decoration.set(decorations);
+  });
+}
+
+function extensions(payload: SourcePayload): Extension[] {
+  return [
+    sourceLanguage(payload.language),
+    EditorState.readOnly.of(true),
+    EditorView.editable.of(false),
+    lineNumbers(),
+    highlightActiveLineGutter(),
+    drawSelection(),
+    search({ top: true }),
+    highlightSelectionMatches(),
+    anchorExtension(payload.lineStart, payload.lineEnd),
+    syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+    keymap.of([
+      {
+        key: "Mod-f",
+        preventDefault: true,
+        run: openSearchPanel,
+      },
+      ...searchKeymap,
+      ...defaultKeymap,
+    ]),
+    blinkSourceTheme,
+  ];
+}
+
+function createState(payload: SourcePayload): EditorState {
+  return EditorState.create({ doc: payload.text, extensions: extensions(payload) });
+}
+
+function mount(): void {
+  const parent = document.getElementById("source");
+  if (!parent) throw new Error("[BLINK] #source mount point not found");
+
+  const empty: SourcePayload = { text: "", language: "plaintext" };
+  const view = new EditorView({ parent, state: createState(empty) });
+
+  window.blinkSource = {
+    setDocument(payload: SourcePayload): void {
+      view.setState(createState(payload));
+      if (payload.lineStart && payload.lineStart <= view.state.doc.lines) {
+        const position = view.state.doc.line(payload.lineStart).from;
+        view.dispatch({ effects: EditorView.scrollIntoView(position, { y: "center" }) });
+      }
+    },
+    setTheme(vars: Record<string, string>): void {
+      const root = document.documentElement.style;
+      for (const [key, value] of Object.entries(vars)) root.setProperty(key, value);
+    },
+    focus(): void { view.focus(); },
+    showFind(): void { openSearchPanel(view); },
+  };
+
+  postReady();
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", mount, { once: true });
+} else {
+  mount();
+}

--- a/web/editor/src/source-theme.ts
+++ b/web/editor/src/source-theme.ts
@@ -1,0 +1,99 @@
+import { EditorView } from "@codemirror/view";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags as t } from "@lezer/highlight";
+import type { Extension } from "@codemirror/state";
+
+const sourceViewTheme: Extension = EditorView.theme({
+  "&": {
+    height: "100%",
+    color: "var(--blink-text)",
+    backgroundColor: "transparent",
+    fontFamily: "var(--blink-mono-family)",
+    fontSize: "var(--blink-source-font-size)",
+  },
+  "&.cm-focused": { outline: "none" },
+  ".cm-scroller": {
+    overflow: "auto",
+    fontFamily: "var(--blink-mono-family)",
+    lineHeight: "var(--blink-source-line-height)",
+    padding: "10px 0 22px",
+  },
+  ".cm-content": {
+    padding: "0 18px 0 8px",
+    caretColor: "transparent",
+  },
+  ".cm-line": { padding: "0 4px" },
+  ".cm-gutters": {
+    backgroundColor: "transparent",
+    border: "none",
+    color: "var(--blink-text-muted)",
+    paddingLeft: "10px",
+  },
+  ".cm-lineNumbers .cm-gutterElement": {
+    minWidth: "34px",
+    padding: "0 9px 0 0",
+  },
+  ".cm-activeLine, .cm-activeLineGutter": { backgroundColor: "transparent" },
+  ".blink-source-anchor": {
+    backgroundColor: "var(--blink-source-anchor)",
+    boxShadow: "inset 2px 0 0 var(--blink-accent)",
+  },
+  ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
+    backgroundColor: "var(--blink-selection) !important",
+  },
+  ".cm-selectionMatch": { backgroundColor: "var(--blink-source-match)" },
+  ".cm-panels": {
+    backgroundColor: "var(--blink-source-panel)",
+    color: "var(--blink-text)",
+    borderBottom: "1px solid var(--blink-source-rule)",
+  },
+  ".cm-search": {
+    display: "flex",
+    alignItems: "center",
+    gap: "6px",
+    padding: "7px 10px",
+    fontFamily: "var(--blink-font-family)",
+    fontSize: "11px",
+  },
+  ".cm-search input": {
+    minWidth: "180px",
+    color: "var(--blink-text)",
+    backgroundColor: "var(--blink-code-bg)",
+    border: "1px solid var(--blink-source-rule)",
+    borderRadius: "6px",
+    padding: "4px 7px",
+    outline: "none",
+  },
+  ".cm-search input:focus": { borderColor: "var(--blink-accent)" },
+  ".cm-search button": {
+    color: "var(--blink-text-muted)",
+    background: "transparent",
+    border: "0",
+    borderRadius: "5px",
+    padding: "4px 6px",
+  },
+  ".cm-search button:hover": {
+    color: "var(--blink-text)",
+    backgroundColor: "var(--blink-code-bg)",
+  },
+  ".cm-tooltip": {
+    backgroundColor: "var(--blink-source-panel)",
+    border: "1px solid var(--blink-source-rule)",
+    color: "var(--blink-text)",
+  },
+}, { dark: true });
+
+const sourceHighlight = syntaxHighlighting(HighlightStyle.define([
+  { tag: [t.keyword, t.modifier, t.operatorKeyword], color: "var(--blink-source-keyword)" },
+  { tag: [t.typeName, t.className, t.namespace], color: "var(--blink-source-type)" },
+  { tag: [t.function(t.variableName), t.function(t.propertyName)], color: "var(--blink-source-function)" },
+  { tag: [t.string, t.special(t.string)], color: "var(--blink-source-string)" },
+  { tag: [t.number, t.bool, t.null], color: "var(--blink-source-literal)" },
+  { tag: [t.comment, t.docComment], color: "var(--blink-text-muted)", fontStyle: "italic" },
+  { tag: [t.meta, t.processingInstruction], color: "var(--blink-source-meta)" },
+  { tag: [t.punctuation, t.bracket], color: "var(--blink-text-muted)" },
+  { tag: [t.heading, t.strong], color: "var(--blink-text-strong)", fontWeight: "650" },
+  { tag: [t.link, t.url], color: "var(--blink-accent)" },
+]));
+
+export const blinkSourceTheme: Extension = [sourceViewTheme, sourceHighlight];


### PR DESCRIPTION
## Summary

- add portable `blink.companions` metadata with bounded, never-erase parsing
- resolve named local source roots with symlink containment, UTF-8/type checks, and strict preview limits
- add one-panel-per-path read-only source windows, standalone/companion ownership, note lifecycle integration, and local visibility/frame state
- build and package a renderer-only CodeMirror source bundle with search, line anchors, language modes, and light/dark theming
- document the config/bridge contract and add the Review Bench Studio study

## Safety

- source viewing has no content getter, change callback, save request, or native write path
- nested foreign companion-shaped metadata cannot grant source authority
- current `main` peer identity, Keychain, `BLINK_HOME`, privacy, and mobile hardening remain untouched
- standalone source panels survive release of the same file by a note companion

## Verification

- `swift test` — 163 tests passed; BlinkApp compiled
- `cd web/editor && bun run typecheck && bun run build`
- Studio TypeScript check and production build
- `git diff --check`
- Scout independent review completed; both actionable findings fixed and follow-up review reported no remaining must-fix issues (`ref:z-yv4wx7`, `ref:j-n1lx5a`)
