### PR TITLE
Refine the landing page palette and chrome

### DIFF
--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -197,6 +197,13 @@ body {
 [data-theme="black"] .corner-frame::after {
   display: block;
 }
+[data-theme="black"] .corner-frame > :first-child {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+[data-theme="black"] .corner-frame > :last-child {
+  border-bottom-right-radius: 0;
+}
 
 @layer base {
   * {

--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 @layer base {
-  /* Default: warm parchment with bottle-green interaction. Optional: forest dark. */
+  /* Default: warm parchment with bottle-green interaction. Optional: neutral dark. */
   :root {
     color-scheme: light;
     --bg: #efe8d8;
@@ -65,37 +65,37 @@
     --radius: 0.375rem;
   }
 
-  /* Forest dark keeps the same parchment/botanical material world after sunset. */
+  /* Dark mode is deliberately safe: black, stepped neutral grays, and one cool signal. */
   [data-theme="black"] {
     color-scheme: dark;
-    --bg: #07100b;
-    --bg-2: #0b1710;
-    --panel: #102118;
-    --panel-2: #162b20;
-    --line: #284334;
-    --line-2: #3f5e4b;
-    --text: #f4eddd;
-    --dim: #c7bda9;
-    --faint: #928875;
-    --ghost: #625b4f;
-    --acc: #93c6a2;
-    --acc-rgb: 147, 198, 162;
-    --acc-soft: rgba(147, 198, 162, 0.12);
-    --on-acc: #07110b;
-    --amber: #d6b96c;
-    --cyan: #a8cbb2;
-    --red: #93c6a2;
-    --bg-rgb: 7, 16, 11;
-    --line-rgb: 40, 67, 52;
-    --grid: rgba(172, 210, 182, 0.045);
-    --demo-surface: #08110d;
-    --demo-surface-mid: #101d16;
-    --demo-surface-hi: #1a2a20;
+    --bg: #09090b;
+    --bg-2: #0e0e11;
+    --panel: #141417;
+    --panel-2: #1b1b1f;
+    --line: #2b2b31;
+    --line-2: #45454d;
+    --text: #f4f4f5;
+    --dim: #c4c4c8;
+    --faint: #929298;
+    --ghost: #626269;
+    --acc: #8fb4ff;
+    --acc-rgb: 143, 180, 255;
+    --acc-soft: rgba(143, 180, 255, 0.1);
+    --on-acc: #090a0d;
+    --amber: #aaaab0;
+    --cyan: #b3b3b8;
+    --red: #8fb4ff;
+    --bg-rgb: 9, 9, 11;
+    --line-rgb: 43, 43, 49;
+    --grid: rgba(255, 255, 255, 0.035);
+    --demo-surface: #0b0b0d;
+    --demo-surface-mid: #141417;
+    --demo-surface-hi: #1d1d21;
     --demo-vignette: rgba(0, 0, 0, 0.75);
-    --demo-glow: rgba(147, 198, 162, 0.1);
-    --demo-grid-line: rgba(172, 210, 182, 0.09);
-    --demo-chrome: linear-gradient(180deg, #17291f 0%, #0d1711 100%);
-    --demo-chrome-border: #35513f;
+    --demo-glow: rgba(255, 255, 255, 0.06);
+    --demo-grid-line: rgba(255, 255, 255, 0.07);
+    --demo-chrome: linear-gradient(180deg, #1d1d21 0%, #101012 100%);
+    --demo-chrome-border: #3b3b42;
     /* mono syntax — white / gray only */
     --syn-key: #fafafa;
     --syn-str: #ffffff;
@@ -103,25 +103,25 @@
     --syn-bool: #fafafa;
     --syn-punct: #b3b3b3;
     --syn-comment: #8a8a8a;
-    --background: 143 39% 5%;
-    --foreground: 42 50% 91%;
-    --card: 145 35% 10%;
-    --card-foreground: 42 50% 91%;
-    --popover: 145 35% 10%;
-    --popover-foreground: 42 50% 91%;
-    --primary: 140 31% 68%;
-    --primary-foreground: 145 42% 5%;
-    --secondary: 144 32% 13%;
-    --secondary-foreground: 42 50% 91%;
-    --muted: 144 32% 13%;
-    --muted-foreground: 40 20% 72%;
-    --accent: 144 32% 13%;
-    --accent-foreground: 140 31% 68%;
+    --background: 240 10% 4%;
+    --foreground: 240 5% 96%;
+    --card: 240 7% 8%;
+    --card-foreground: 240 5% 96%;
+    --popover: 240 7% 8%;
+    --popover-foreground: 240 5% 96%;
+    --primary: 220 100% 78%;
+    --primary-foreground: 230 18% 5%;
+    --secondary: 240 6% 11%;
+    --secondary-foreground: 240 5% 96%;
+    --muted: 240 6% 11%;
+    --muted-foreground: 240 4% 72%;
+    --accent: 240 6% 11%;
+    --accent-foreground: 220 100% 78%;
     --destructive: 0 70% 50%;
     --destructive-foreground: 0 0% 100%;
-    --border: 142 25% 21%;
-    --input: 142 25% 21%;
-    --ring: 140 31% 68%;
+    --border: 240 7% 18%;
+    --input: 240 7% 18%;
+    --ring: 220 100% 78%;
   }
 }
 
@@ -136,10 +136,10 @@
     0 1px 2px rgba(57, 45, 25, 0.12);
 }
 [data-theme="black"] .kbd {
-  background: linear-gradient(180deg, #17291f, #08110d);
-  border-color: #35513f;
-  color: #e8e1d2;
-  box-shadow: inset 0 1px 0 rgba(240, 232, 214, 0.08), 0 2px 0 rgba(0, 0, 0, 0.8);
+  background: linear-gradient(180deg, #202024, #0d0d0f);
+  border-color: #3c3c43;
+  color: #ececef;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.07), 0 2px 0 rgba(0, 0, 0, 0.8);
 }
 
 /* Cream default: no CRT flicker; warm wash + light frame on demo */
@@ -184,8 +184,8 @@ body {
 [data-theme="black"] ::-webkit-scrollbar-thumb:hover { background: #454545; }
 [data-theme="black"] body {
   background-image:
-    radial-gradient(92% 62% at 82% -18%, rgba(var(--acc-rgb), 0.16), transparent 70%),
-    linear-gradient(180deg, rgba(241, 226, 188, 0.024), transparent 34rem);
+    radial-gradient(92% 62% at 82% -18%, rgba(255, 255, 255, 0.04), transparent 70%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent 34rem);
   background-size: 100% 100%;
   background-attachment: fixed;
 }
@@ -318,6 +318,10 @@ body {
   }
 }
 
+/* In dark mode, typographic emphasis stays neutral. The blue signal is reserved
+   for controls, focus, status dots, borders, and other genuinely active states. */
+[data-theme="black"] .text-acc { color: var(--text); }
+
 /* caret blink */
 @keyframes caretBlink {
   0%, 49% { opacity: 1; }
@@ -410,7 +414,7 @@ body {
 }
 [data-theme="black"] .hero-art {
   opacity: 0.38;
-  filter: brightness(0.46) saturate(0.88) contrast(1.08);
+  filter: grayscale(1) brightness(0.42) contrast(1.08);
 }
 [data-theme="black"] .hero-art-wash {
   background:
@@ -418,8 +422,11 @@ body {
     linear-gradient(180deg, rgba(var(--bg-rgb), 0.1), transparent 42%, var(--bg) 100%);
 }
 [data-theme="black"] .hero-dither {
+  background-image:
+    radial-gradient(circle, rgba(255, 255, 255, 0.26) 0 0.55px, transparent 0.75px),
+    radial-gradient(circle, rgba(143, 180, 255, 0.2) 0 0.5px, transparent 0.72px);
   mix-blend-mode: screen;
-  opacity: 0.14;
+  opacity: 0.1;
 }
 
 /* scroll reveal — armed on the client by <Reveal>, plays once */

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -17,9 +17,9 @@ export default function Home() {
       <main>
         <Hero />
         <SpecStrip />
+        <AgentFilm />
         <FilesystemAPI />
         <AgentGuide />
-        <AgentFilm />
         <AgentCaseStudy />
         <Sheets />
         <Keys />

--- a/landing/components/homepage/AgentCaseStudy.tsx
+++ b/landing/components/homepage/AgentCaseStudy.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { SectionHeader, Reveal } from './shared'
+import { DemoChromeBar, MockTitleBar, SectionHeader, Reveal } from './shared'
 
 /** Distilled priority note placed on the desk. */
 type DeskNote = {
@@ -184,13 +184,15 @@ export function AgentFilm() {
         <Reveal>
           <div className="corner-frame">
             <div className="overflow-hidden rounded-[8px] border border-linex bg-panelx">
-              <div className="demo-chrome flex min-h-10 items-center justify-between gap-3 border-b px-3 py-1.5 text-[10px] text-dimx">
-                <div className="flex min-w-0 items-center gap-2">
-                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--acc)]" aria-hidden />
-                  <span className="truncate">Pi → CLI → spatial desk</span>
-                </div>
-                <span className="shrink-0 text-faintx">00:47 · sound on</span>
-              </div>
+              <MockTitleBar
+                title={
+                  <span className="inline-flex items-center gap-2">
+                    <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--acc)]" aria-hidden />
+                    Pi → CLI → spatial desk
+                  </span>
+                }
+                trailing={<span className="text-faintx">00:47 · sound on</span>}
+              />
 
               <div className="aspect-video bg-[#050708]">
                 <video
@@ -238,14 +240,14 @@ function TicketPanel({ note, active }: { note: DeskNote; active: boolean }) {
         transition: 'opacity 0.85s ease',
       }}
     >
-      <div className="flex items-center justify-between gap-2 border-b border-[rgba(255,255,255,0.12)] px-2 py-1">
-        <span className="truncate text-[9px] font-medium text-[rgba(250,250,250,0.92)]">{note.file}</span>
+      <div className="flex items-center justify-between gap-2 border-b border-[rgba(255,255,255,0.12)] px-2.5 py-1.5">
+        <span className="truncate text-[9px] font-medium leading-none text-[rgba(250,250,250,0.92)]">{note.file}</span>
         <span className="shrink-0 text-[8px] uppercase tracking-[0.12em] text-[rgba(220,220,220,0.65)]">
           {note.stack}
         </span>
       </div>
-      <div className="px-2 py-1.5">
-        <p className="text-[10px] leading-[1.45] text-[rgba(240,240,240,0.92)] line-clamp-2">{note.line}</p>
+      <div className="px-2.5 py-2">
+        <p className="line-clamp-2 text-[10px] leading-[1.45] text-[rgba(240,240,240,0.92)]">{note.line}</p>
       </div>
     </div>
   )
@@ -369,20 +371,20 @@ export default function AgentCaseStudy() {
           }
         />
 
-        <Reveal className="grid gap-5 lg:grid-cols-[0.95fr_1.15fr] items-start">
+        <Reveal className="grid items-start gap-5 lg:grid-cols-[0.95fr_1.15fr]">
           {/* coding-agent transcript — conversation leads; tools whisper */}
-          <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden flex flex-col h-[380px] sm:h-[420px]">
-            <div className="flex shrink-0 items-center justify-between border-b border-linex bg-panel2x px-3.5 py-2">
-              <div className="flex min-w-0 items-center gap-2">
-                <span className="text-[11px] font-semibold text-[var(--text)]">claude</span>
-                <span className="text-[10px] text-dimx truncate">~/Notes · last 24h</span>
-              </div>
-              <div className="flex shrink-0 items-center gap-2 text-[10px]">
-                {status === 'working' && <span className="text-dimx">working</span>}
-                {status === 'done' && <span className="text-acc font-medium">done</span>}
-                {status === 'idle' && <span className="text-dimx">ready</span>}
-              </div>
-            </div>
+          <div className="flex h-[380px] flex-col overflow-hidden rounded-[8px] border border-linex bg-panelx sm:h-[420px]">
+            <MockTitleBar
+              title="claude"
+              detail="~/Notes · last 24h"
+              trailing={
+                <>
+                  {status === 'working' && <span className="text-dimx">working</span>}
+                  {status === 'done' && <span className="font-medium text-acc">done</span>}
+                  {status === 'idle' && <span className="text-dimx">ready</span>}
+                </>
+              }
+            />
 
             <div
               ref={logBoxRef}
@@ -415,22 +417,22 @@ export default function AgentCaseStudy() {
           </div>
 
           {/* desktop with priority stacks */}
-          <div className="corner-frame flex flex-col h-[380px] sm:h-[420px]">
-            <div className="demo-chrome flex shrink-0 items-center justify-between gap-2 border border-b-0 rounded-t-[8px] px-3 min-h-10 py-1.5">
-              <div className="flex min-w-0 items-center gap-2 text-[11px]">
-                <span className="text-[var(--text)] font-semibold truncate">~/Desktop</span>
-                <span className="hidden sm:inline shrink-0 text-dimx">— prioritized board</span>
-              </div>
-              <div className="flex shrink-0 items-center gap-2 text-[10px] text-dimx">
-                <span>
-                  p0 <span className="text-acc font-semibold tabular-nums">{p0Count}</span>
-                </span>
-                <span className="text-faintx">·</span>
-                <span>
-                  p1 <span className="text-acc font-semibold tabular-nums">{p1Count}</span>
-                </span>
-              </div>
-            </div>
+          <div className="corner-frame flex h-[380px] flex-col sm:h-[420px]">
+            <DemoChromeBar
+              title="~/Desktop"
+              detail="— prioritized board"
+              trailing={
+                <>
+                  <span>
+                    p0 <span className="font-semibold tabular-nums text-acc">{p0Count}</span>
+                  </span>
+                  <span className="text-faintx">·</span>
+                  <span>
+                    p1 <span className="font-semibold tabular-nums text-acc">{p1Count}</span>
+                  </span>
+                </>
+              }
+            />
 
             <div
               className="demo-desktop relative flex-1 min-h-0 overflow-hidden rounded-b-[8px] border border-linex"

--- a/landing/components/homepage/AgentGuide.tsx
+++ b/landing/components/homepage/AgentGuide.tsx
@@ -1,4 +1,4 @@
-import { Reveal, SectionHeader } from './shared'
+import { MockTitleBar, Reveal, SectionHeader } from './shared'
 
 const DOCS = [
   {
@@ -88,10 +88,10 @@ export default function AgentGuide() {
 
           <div className="mt-8 grid items-start gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:gap-12">
             <div className="overflow-hidden rounded-[8px] border border-linex bg-panelx">
-              <div className="flex items-center justify-between border-b border-linex bg-panel2x px-4 py-2.5">
-                <span className="text-[11px] font-medium text-[var(--text)]">zero → spatial note</span>
-                <span className="text-[10px] text-faintx">macOS 14+ · arm64</span>
-              </div>
+              <MockTitleBar
+                title="zero → spatial note"
+                trailing={<span className="text-faintx">macOS 14+ · arm64</span>}
+              />
               <div className="p-4 md:p-5">
                 <pre className="whitespace-pre-wrap break-words text-[11.5px] leading-[1.9] text-dimx">
                   <code>{`npm install -g @arach/blink

--- a/landing/components/homepage/Chrome.tsx
+++ b/landing/components/homepage/Chrome.tsx
@@ -12,40 +12,43 @@ const LINKS = [
 export function TopBar() {
   return (
     <header className="fixed top-0 inset-x-0 z-50 border-b border-linex bg-[rgba(var(--bg-rgb),0.82)] backdrop-blur-md">
-      <div className="mx-auto flex h-12 max-w-5xl items-center justify-between px-4 md:px-6">
+      <div className="mx-auto flex h-12 max-w-5xl items-center gap-3 px-4 md:gap-4 md:px-6">
         <a
           href="#top"
-          className="font-display flex items-center gap-2.5 text-[19px] font-semibold tracking-[-0.015em] text-[var(--text)]"
+          className="font-display flex shrink-0 items-center gap-2 text-[17px] font-semibold leading-none tracking-[-0.015em] text-[var(--text)]"
         >
-          <BlinkMark className="h-[18px] w-[18px] text-acc" />
-          blink
+          <BlinkMark className="h-4 w-4 shrink-0 text-acc" />
+          <span>blink</span>
         </a>
 
-        <nav className="hidden sm:flex items-center gap-5" aria-label="Page">
+        <nav
+          className="hidden min-w-0 flex-1 items-center justify-center gap-1 sm:flex md:gap-0.5"
+          aria-label="Page"
+        >
           {LINKS.map((l) => (
             <a
               key={l.href}
               href={l.href}
-              className="text-[11px] text-dimx hover:text-acc transition-colors"
+              className="rounded-[4px] px-2.5 py-1.5 text-[11px] text-dimx transition-colors hover:bg-[var(--acc-soft)] hover:text-acc"
             >
               {l.label}
             </a>
           ))}
         </nav>
 
-        <div className="flex items-center gap-3">
+        <div className="ml-auto flex shrink-0 items-center gap-2">
           <ThemeSwitcher />
           <a
             href="https://github.com/arach/blink"
             target="_blank"
             rel="noreferrer"
-            aria-label="GitHub"
-            className="inline-flex h-11 min-w-11 items-center justify-center gap-1.5 rounded-[5px] border border-line2x bg-panelx px-0 text-[11px] text-dimx hover:text-[var(--text)] hover:border-[var(--line-2)] hover:bg-panel2x transition-colors min-[360px]:px-3"
+            aria-label="GitHub repository"
+            className="inline-flex h-8 items-center justify-center gap-1.5 rounded-[6px] border border-line2x bg-panelx px-2 text-[11px] text-dimx transition-colors hover:border-[var(--line-2)] hover:bg-panel2x hover:text-[var(--text)] min-[380px]:px-2.5"
           >
-            <svg viewBox="0 0 16 16" className="h-3.5 w-3.5 fill-current" aria-hidden>
+            <svg viewBox="0 0 16 16" className="h-3.5 w-3.5 shrink-0 fill-current" aria-hidden>
               <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
             </svg>
-            <span className="hidden min-[360px]:inline">github</span>
+            <span className="hidden min-[380px]:inline">github</span>
           </a>
         </div>
       </div>

--- a/landing/components/homepage/FilesystemAPI.tsx
+++ b/landing/components/homepage/FilesystemAPI.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { SectionHeader, Reveal } from './shared'
+import { SectionHeader, Reveal, MockTitleBar } from './shared'
 
 interface TermLine {
   kind: 'cmd' | 'out' | 'json'
@@ -104,16 +104,11 @@ export default function FilesystemAPI() {
           sub="Notes are markdown files in a folder you own. Agents and the CLI write the same files the panels render — live, no plugins."
         />
 
-        <Reveal className="grid gap-5 lg:grid-cols-2 items-stretch">
-          <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden flex flex-col">
-            <div className="flex min-h-8 items-center gap-2 border-b border-linex bg-panel2x px-3 py-1">
-              <span className="h-[7px] w-[7px] rounded-full bg-[var(--ghost)]" />
-              <span className="h-[7px] w-[7px] rounded-full bg-[var(--faint)]" />
-              <span className="h-[7px] w-[7px] rounded-full bg-[var(--dim)]" />
-              <span className="ml-1.5 text-[10px] text-faintx">blink CLI</span>
-            </div>
+        <Reveal className="grid items-stretch gap-5 lg:grid-cols-2">
+          <div className="flex flex-col overflow-hidden rounded-[8px] border border-linex bg-panelx">
+            <MockTitleBar dots title="blink CLI" />
             <div
-              className="flex-1 p-4 md:p-5 text-[12px] md:text-[12.5px] leading-[1.9] min-h-[200px]"
+              className="min-h-[200px] flex-1 p-4 text-[12px] leading-[1.9] md:p-5 md:text-[12.5px]"
               aria-live="polite"
               aria-atomic="false"
             >
@@ -139,16 +134,18 @@ export default function FilesystemAPI() {
             </div>
           </div>
 
-          <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden flex flex-col">
-            <div className="flex min-h-8 items-center justify-between border-b border-linex bg-panel2x px-3 py-1">
-              <span className="text-[10px] font-medium text-dimx">standup.md</span>
-              <span className={`transition-opacity duration-300 ${badge ? 'opacity-100' : 'opacity-0'}`}>
-                <span className="inline-flex h-5 items-center gap-1.5 rounded-[4px] border border-[rgba(var(--acc-rgb),0.35)] bg-[var(--acc-soft)] px-2 text-[9px] text-acc">
-                  <span className="inline-block h-1 w-1 rounded-full bg-[var(--acc)]" />
-                  typed by agent
+          <div className="flex flex-col overflow-hidden rounded-[8px] border border-linex bg-panelx">
+            <MockTitleBar
+              title="standup.md"
+              trailing={
+                <span className={`transition-opacity duration-300 ${badge ? 'opacity-100' : 'opacity-0'}`}>
+                  <span className="inline-flex h-5 items-center gap-1.5 rounded-[4px] border border-[rgba(var(--acc-rgb),0.35)] bg-[var(--acc-soft)] px-2 text-[9px] text-acc">
+                    <span className="inline-block h-1 w-1 rounded-full bg-[var(--acc)]" />
+                    typed by agent
+                  </span>
                 </span>
-              </span>
-            </div>
+              }
+            />
             <div className="flex-1 p-4 md:p-5 min-h-[200px]">
               {note.map((l, i) => (
                 <div

--- a/landing/components/homepage/Hero.tsx
+++ b/landing/components/homepage/Hero.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 import SpatialDemo from './SpatialDemo'
-import { Chord, PrimaryButton, GhostButton } from './shared'
+import { GhostButton, HyperChord, PrimaryButton } from './shared'
 
 export default function Hero() {
   return (
@@ -38,11 +38,11 @@ export default function Hero() {
 
             <div className="mt-7 space-y-2.5 text-[13px] text-dimx">
               <div className="flex items-center gap-3 flex-wrap">
-                <Chord keys={['⌃', '⌥', '⇧', '⌘', 'N']} />
+                <HyperChord letter="N" action="New note" />
                 <span className="text-faintx">new note</span>
               </div>
               <div className="flex items-center gap-3 flex-wrap">
-                <Chord keys={['⌃', '⌥', '⇧', '⌘', 'B']} />
+                <HyperChord letter="B" action="Blink all panels" />
                 <span className="text-faintx">blink all panels</span>
               </div>
             </div>

--- a/landing/components/homepage/Install.tsx
+++ b/landing/components/homepage/Install.tsx
@@ -1,4 +1,4 @@
-import { SectionHeader, PrimaryButton, GhostButton, Reveal } from './shared'
+import { SectionHeader, PrimaryButton, GhostButton, Reveal, MockTitleBar } from './shared'
 import { BlinkMark } from './BlinkMark'
 
 export function Install() {
@@ -17,29 +17,27 @@ export function Install() {
 
         <Reveal>
           <div className="corner-frame">
-            <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden">
-          <div className="border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] tracking-[0.14em] uppercase text-faintx">
-            release — latest
-          </div>
-          <div className="flex flex-col gap-6 p-5 md:flex-row md:items-center md:justify-between md:gap-8 md:p-6">
-            <div className="min-w-0">
-              <div className="text-[15px] font-bold text-[var(--text)]">Blink.dmg</div>
-              <div className="mt-1 text-[11px] text-faintx">
-                Apple Silicon · macOS 14+ · notarized · no account
+            <div className="overflow-hidden rounded-[8px] border border-linex bg-panelx">
+              <MockTitleBar title="release — latest" />
+              <div className="flex flex-col gap-6 p-5 md:flex-row md:items-center md:justify-between md:gap-8 md:p-6">
+                <div className="min-w-0">
+                  <div className="text-[15px] font-bold text-[var(--text)]">Blink.dmg</div>
+                  <div className="mt-1 text-[11px] text-faintx">
+                    Apple Silicon · macOS 14+ · notarized · no account
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-3 shrink-0">
+                  <PrimaryButton href="https://github.com/arach/blink/releases/latest">
+                    <span className="text-[15px] leading-none" aria-hidden>
+                      ↓
+                    </span>{' '}
+                    download for macOS
+                  </PrimaryButton>
+                  <GhostButton href="https://github.com/arach/blink">
+                    source <span className="text-faintx" aria-hidden>↗</span>
+                  </GhostButton>
+                </div>
               </div>
-            </div>
-            <div className="flex flex-wrap gap-3 shrink-0">
-              <PrimaryButton href="https://github.com/arach/blink/releases/latest">
-                <span className="text-[15px] leading-none" aria-hidden>
-                  ↓
-                </span>{' '}
-                download for macOS
-              </PrimaryButton>
-              <GhostButton href="https://github.com/arach/blink">
-                source <span className="text-faintx" aria-hidden>↗</span>
-              </GhostButton>
-            </div>
-          </div>
             </div>
           </div>
         </Reveal>
@@ -48,49 +46,54 @@ export function Install() {
   )
 }
 
+const FOOTER_LINKS = [
+  { href: 'https://github.com/arach/blink', label: 'GitHub', external: true },
+  { href: 'https://github.com/arach/blink/releases/latest', label: 'Releases', external: true },
+  { href: '/agents.md', label: 'AGENTS.md', external: false },
+  { href: '/llms.txt', label: 'llms.txt', external: false },
+  {
+    href: 'https://github.com/arach/blink/blob/main/docs/cli.md',
+    label: 'CLI docs',
+    external: true,
+  },
+] as const
+
 export function Footer() {
   return (
     <footer className="border-t border-linex pb-12 pt-8">
       <div className="mx-auto max-w-5xl px-4 md:px-6">
-        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div className="flex items-center gap-2 text-[12px] font-bold text-[var(--text)]">
-            <BlinkMark className="h-[16px] w-[16px] text-acc" />
-            blink
-            <span className="font-normal text-faintx">· spatial notes for your Mac</span>
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between sm:gap-8">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-[12px] font-bold text-[var(--text)]">
+              <BlinkMark className="h-4 w-4 shrink-0 text-acc" />
+              <span>blink</span>
+            </div>
+            <p className="mt-1.5 text-[11px] leading-relaxed text-faintx">
+              spatial notes for your Mac
+            </p>
           </div>
-          <div className="flex items-center gap-5 text-[11px] text-dimx">
-            <a
-              href="/agents.md"
-              className="hover:text-acc transition-colors"
-            >
-              agents.md
-            </a>
-            <a
-              href="/llms.txt"
-              className="hover:text-acc transition-colors"
-            >
-              llms.txt
-            </a>
-            <a
-              href="https://github.com/arach/blink"
-              target="_blank"
-              rel="noreferrer"
-              className="hover:text-acc transition-colors"
-            >
-              github
-            </a>
-            <a
-              href="https://github.com/arach/blink/releases/latest"
-              target="_blank"
-              rel="noreferrer"
-              className="hover:text-acc transition-colors"
-            >
-              releases
-            </a>
-          </div>
+
+          <nav
+            aria-label="Footer"
+            className="flex flex-wrap items-center gap-x-4 gap-y-2 text-[11px] text-dimx sm:justify-end sm:max-w-md"
+          >
+            {FOOTER_LINKS.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                {...(link.external
+                  ? { target: '_blank', rel: 'noreferrer' }
+                  : {})}
+                className="rounded-[3px] py-0.5 transition-colors hover:text-acc"
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
         </div>
-        <div className="mt-6 text-[10px] text-[var(--ghost)]">
-          JetBrains Mono · blink.arach.dev
+        <div className="mt-6 flex flex-wrap items-center justify-between gap-2 text-[10px] text-[var(--ghost)]">
+          <span>JetBrains Mono</span>
+          <span>blink.arach.dev</span>
         </div>
       </div>
     </footer>

--- a/landing/components/homepage/Keys.tsx
+++ b/landing/components/homepage/Keys.tsx
@@ -1,11 +1,57 @@
-import { SectionHeader, Chord, Reveal } from './shared'
+import {
+  SectionHeader,
+  Chord,
+  HyperChord,
+  HYPER_EXPAND,
+  HYPER_GLYPH,
+  Reveal,
+} from './shared'
 
-const KEYS: { action: string; keys: string[]; scope: 'global' | 'panel' }[] = [
-  { action: 'new note, anywhere', keys: ['⌃', '⌥', '⇧', '⌘', 'N'], scope: 'global' },
-  { action: 'blink all notes', keys: ['⌃', '⌥', '⇧', '⌘', 'B'], scope: 'global' },
-  { action: 'grid overlay', keys: ['⌃', '⌥', '⇧', '⌘', 'C'], scope: 'global' },
-  { action: 'flip read / edit', keys: ['⌘', '⇧', 'P'], scope: 'panel' },
-  { action: 'close panel', keys: ['⌘', 'W'], scope: 'panel' },
+const KEYS: {
+  action: string
+  scope: 'global' | 'panel'
+  /** Accessible full shortcut name */
+  spoken: string
+  /** Visual chord */
+  visual: 'hyper' | 'chord'
+  letter?: string
+  keys?: string[]
+}[] = [
+  {
+    action: 'new note, anywhere',
+    scope: 'global',
+    spoken: 'Control Option Shift Command N',
+    visual: 'hyper',
+    letter: 'N',
+  },
+  {
+    action: 'blink all notes',
+    scope: 'global',
+    spoken: 'Control Option Shift Command B',
+    visual: 'hyper',
+    letter: 'B',
+  },
+  {
+    action: 'grid overlay',
+    scope: 'global',
+    spoken: 'Control Option Shift Command C',
+    visual: 'hyper',
+    letter: 'C',
+  },
+  {
+    action: 'flip read / edit',
+    scope: 'panel',
+    spoken: 'Command Shift P',
+    visual: 'chord',
+    keys: ['⌘', '⇧', 'P'],
+  },
+  {
+    action: 'close panel',
+    scope: 'panel',
+    spoken: 'Command W',
+    visual: 'chord',
+    keys: ['⌘', 'W'],
+  },
 ]
 
 export default function Keys() {
@@ -19,37 +65,59 @@ export default function Keys() {
               Everything is <span className="text-acc">a keystroke away</span>.
             </>
           }
-          sub={
-            <span className="inline-flex flex-wrap items-center gap-x-1.5 gap-y-1">
-              <span>Hyper is</span>
-              <Chord keys={['⌃', '⌥', '⇧', '⌘']} />
-              <span>— a modifier no app already owns. Every binding is rewritable in config.json.</span>
-            </span>
-          }
+          sub="A modifier no app already owns. Every binding is rewritable in config.json."
         />
 
-        <Reveal className="border border-linex rounded-[8px] bg-panelx overflow-hidden">
-          <div className="hidden sm:grid grid-cols-[1fr_5.5rem_auto] gap-6 border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] tracking-[0.14em] uppercase text-faintx">
-            <span>action</span>
-            <span>scope</span>
-            <span className="text-right">chord</span>
-          </div>
-          {KEYS.map((r) => (
-            <div
-              key={r.action}
-              className="grid grid-cols-1 sm:grid-cols-[1fr_5.5rem_auto] items-center gap-2 sm:gap-6 border-b border-[rgba(var(--line-rgb),0.55)] last:border-b-0 px-4 py-3.5 transition-colors hover:bg-[rgba(var(--acc-rgb),0.03)]"
+        <Reveal>
+          <p className="mb-4">
+            <span
+              className="inline-flex flex-wrap items-center gap-x-1.5 gap-y-1 rounded-[6px] border border-linex bg-panelx px-2.5 py-1.5 text-[12px]"
+              role="note"
+              aria-label={`${HYPER_GLYPH} Hyper equals Control Option Shift Command`}
             >
-              <div className="text-[13px] text-[var(--text)]">{r.action}</div>
-              <div>
-                <span className="inline-flex items-center rounded-[3px] border border-linex px-1.5 py-[2px] text-[9px] tracking-[0.12em] uppercase text-faintx">
-                  {r.scope}
-                </span>
-              </div>
-              <div className="sm:justify-self-end">
-                <Chord keys={r.keys} />
-              </div>
+              <span className="font-semibold text-[var(--text)]" aria-hidden>
+                {HYPER_GLYPH}
+              </span>
+              <span className="text-dimx" aria-hidden>
+                Hyper
+              </span>
+              <span className="text-faintx" aria-hidden>
+                =
+              </span>
+              <Chord keys={[...HYPER_EXPAND]} />
+            </span>
+          </p>
+
+          <div className="overflow-hidden rounded-[8px] border border-linex bg-panelx">
+            <div
+              className="hidden grid-cols-[minmax(0,1fr)_4.75rem_auto] gap-x-6 border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] uppercase tracking-[0.14em] text-faintx sm:grid"
+              role="row"
+            >
+              <span>action</span>
+              <span className="text-left">scope</span>
+              <span className="text-right">chord</span>
             </div>
-          ))}
+            {KEYS.map((r) => (
+              <div
+                key={r.action}
+                className="grid grid-cols-1 items-center gap-2 border-b border-[rgba(var(--line-rgb),0.55)] px-4 py-3.5 transition-colors last:border-b-0 hover:bg-[rgba(var(--acc-rgb),0.03)] sm:grid-cols-[minmax(0,1fr)_4.75rem_auto] sm:gap-x-6"
+              >
+                <div className="text-[13px] text-[var(--text)]">{r.action}</div>
+                <div className="sm:justify-self-start">
+                  <span className="inline-flex min-w-[3.25rem] items-center justify-center rounded-[3px] border border-linex px-1.5 py-[2px] text-[9px] uppercase tracking-[0.12em] text-faintx">
+                    {r.scope}
+                  </span>
+                </div>
+                <div className="sm:justify-self-end">
+                  {r.visual === 'hyper' && r.letter ? (
+                    <HyperChord letter={r.letter} action={r.action} />
+                  ) : (
+                    <Chord keys={r.keys!} label={`${r.action}: ${r.spoken}`} />
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
         </Reveal>
       </div>
     </section>

--- a/landing/components/homepage/Sheets.tsx
+++ b/landing/components/homepage/Sheets.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { SectionHeader, Reveal } from './shared'
+import { useEffect, useId, useState } from 'react'
+import { SectionHeader, Reveal, MockTitleBar } from './shared'
 
 type SheetId = 'glass' | 'card' | 'dotted' | 'bracket' | 'marginalia'
 
@@ -104,6 +104,8 @@ function SheetSurface({ id, compact = false }: { id: SheetId; compact?: boolean 
 export default function Sheets() {
   const [active, setActive] = useState<SheetId>('glass')
   const [touched, setTouched] = useState(false)
+  const baseId = useId()
+  const panelId = `${baseId}-panel`
 
   useEffect(() => {
     if (touched) return
@@ -134,34 +136,40 @@ export default function Sheets() {
           sub="Five render sheets, per note or as default. One key in config — hot-applied to every open panel."
         />
 
-        <Reveal className="grid gap-8 lg:grid-cols-[minmax(0,14rem)_1fr] lg:gap-10 items-start">
+        <Reveal className="grid items-start gap-6 lg:grid-cols-[minmax(0,13.5rem)_1fr] lg:gap-8">
           <div
-            className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1 lg:mx-0 lg:px-0 lg:flex-col lg:overflow-visible lg:pb-0 lg:gap-1"
+            className="flex gap-1.5 overflow-x-auto pb-1 -mx-1 px-1 lg:mx-0 lg:flex-col lg:overflow-visible lg:px-0 lg:pb-0 lg:gap-1"
             role="tablist"
             aria-label="Sheet styles"
+            aria-orientation="horizontal"
           >
             {SHEETS.map((s) => {
               const on = active === s.id
+              const tabId = `${baseId}-tab-${s.id}`
               return (
                 <button
                   key={s.id}
+                  id={tabId}
                   type="button"
                   role="tab"
                   aria-selected={on}
+                  aria-controls={panelId}
+                  tabIndex={on ? 0 : -1}
                   onClick={() => {
                     setActive(s.id)
                     setTouched(true)
                   }}
-                  className={`shrink-0 text-left rounded-[6px] border px-3.5 py-2.5 transition-colors ${
+                  className={[
+                    'shrink-0 rounded-[6px] border px-3 py-2 text-left transition-[color,background-color,border-color,box-shadow] duration-150',
                     on
-                      ? 'border-[rgba(var(--acc-rgb),0.45)] bg-[rgba(var(--acc-rgb),0.05)]'
-                      : 'border-linex bg-panelx hover:border-line2x lg:border-transparent lg:bg-transparent lg:hover:border-linex'
-                  }`}
+                      ? 'border-[rgba(var(--acc-rgb),0.45)] bg-[var(--acc-soft)] shadow-[inset_0_0_0_1px_rgba(var(--acc-rgb),0.12)]'
+                      : 'border-linex bg-panelx hover:border-line2x hover:bg-panel2x lg:border-transparent lg:bg-transparent lg:hover:border-linex lg:hover:bg-[var(--acc-soft)]',
+                  ].join(' ')}
                 >
-                  <span className={`text-[13px] font-bold ${on ? 'text-acc' : 'text-[var(--text)]'}`}>
+                  <span className={`block text-[12.5px] font-bold leading-none ${on ? 'text-acc' : 'text-[var(--text)]'}`}>
                     {s.name}
                   </span>
-                  <span className="mt-0.5 block text-[11px] text-dimx whitespace-nowrap lg:whitespace-normal">
+                  <span className="mt-1 block text-[10.5px] leading-[1.45] text-dimx whitespace-nowrap lg:whitespace-normal">
                     {s.desc}
                   </span>
                 </button>
@@ -169,12 +177,17 @@ export default function Sheets() {
             })}
           </div>
 
-          <div className="border border-linex rounded-[8px] bg-panelx overflow-hidden min-w-0">
-            <div className="flex items-center justify-between border-b border-linex bg-panel2x px-4 py-2.5 text-[10px] text-faintx">
-              <span>preview</span>
-              <span className="text-acc">sheet: {current.name}</span>
-            </div>
-            <div className="demo-desktop h-[220px] md:h-[260px] p-5 md:p-7">
+          <div
+            id={panelId}
+            role="tabpanel"
+            aria-labelledby={`${baseId}-tab-${active}`}
+            className="min-w-0 overflow-hidden rounded-[8px] border border-linex bg-panelx"
+          >
+            <MockTitleBar
+              title="preview"
+              trailing={<span className="text-acc">sheet: {current.name}</span>}
+            />
+            <div className="demo-desktop h-[220px] p-5 md:h-[260px] md:p-7">
               <div className="mx-auto h-full max-w-[560px]">
                 <div key={active} className="sheet-swap h-full">
                   <SheetSurface id={active} />

--- a/landing/components/homepage/SpatialDemo.tsx
+++ b/landing/components/homepage/SpatialDemo.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Chord } from './shared'
+import { DemoChromeBar, HyperChord, HYPER_GLYPH } from './shared'
 
 interface DemoNote {
   id: number
@@ -17,7 +17,7 @@ const SAMPLES: { title: string; lines: string[] }[] = [
   { title: 'standup.md', lines: ['## Fri', '- ship the landing', '- port the palette'] },
   { title: 'roadmap.md', lines: ['## v2.1', '- [[sheets]] per note', '- cli: blink watch'] },
   { title: 'inbox.md', lines: ['- read: NSPanel docs', '- atomic writes, again'] },
-  { title: 'scratch.md', lines: ['π ≈ 3.14159', 'hyper = ⌃⌥⇧⌘'] },
+  { title: 'scratch.md', lines: ['π ≈ 3.14159', 'plain markdown, always'] },
   { title: 'reading.md', lines: ['- the unix philosophy', '- codemirror 6 guide'] },
   { title: 'ideas.md', lines: ['- grid snap ±8px', '- sheet: marginalia'] },
 ]
@@ -180,57 +180,59 @@ export default function SpatialDemo() {
   }
 
   const demoBtn =
-    'rounded-[4px] border px-2 py-1 text-[10px] transition-colors border-line2x bg-[var(--panel)] text-dimx hover:text-acc hover:border-[rgba(var(--acc-rgb),0.4)]'
+    'inline-flex h-7 items-center rounded-[4px] border border-line2x bg-[var(--panel)] px-2 text-[10px] leading-none text-dimx transition-colors hover:border-[rgba(var(--acc-rgb),0.4)] hover:text-acc'
   const demoBtnOn =
-    'rounded-[4px] border px-2 py-1 text-[10px] transition-colors border-[rgba(var(--acc-rgb),0.45)] text-acc bg-[var(--acc-soft)]'
+    'inline-flex h-7 items-center rounded-[4px] border border-[rgba(var(--acc-rgb),0.45)] bg-[var(--acc-soft)] px-2 text-[10px] leading-none text-acc transition-colors'
 
   return (
     <div className="corner-frame select-none" role="region" aria-label="Spatial notes demo">
-      {/* window chrome */}
-      <div className="demo-chrome flex min-h-9 items-center justify-between gap-2 rounded-t-[8px] border border-b-0 px-3 py-1">
-        <div className="flex min-w-0 items-center gap-2 text-[11px] text-faintx">
-          <span className="inline-block h-[7px] w-[7px] shrink-0 rounded-full bg-[var(--acc)] pulse-dot" aria-hidden />
-          <span className="text-dimx font-semibold truncate">~/Desktop</span>
-          <span className="hidden md:inline shrink-0 text-faintx">— live demo</span>
-        </div>
-        <div className="flex shrink-0 items-center gap-1">
-          <button type="button" onClick={() => spawn()} title="New note (N)" aria-label="New note" className={demoBtn}>
-            <span className="sm:hidden">N</span>
-            <span className="hidden sm:inline">⌃⌥⇧⌘N</span>
-          </button>
-          <button
-            type="button"
-            onClick={toggleBlink}
-            title="Blink all / none (B)"
-            aria-label="Blink all panels"
-            aria-pressed={allHidden}
-            className={allHidden ? demoBtnOn : demoBtn}
-          >
-            <span className="sm:hidden">B</span>
-            <span className="hidden sm:inline">⌃⌥⇧⌘B</span>
-          </button>
-          <button
-            type="button"
-            onClick={() => setGrid((g) => !g)}
-            title="Grid overlay (C)"
-            aria-label="Toggle grid overlay"
-            aria-pressed={grid}
-            className={grid ? demoBtnOn : demoBtn}
-          >
-            <span className="sm:hidden">C</span>
-            <span className="hidden sm:inline">⌃⌥⇧⌘C</span>
-          </button>
-          <button
-            type="button"
-            onClick={resetScene}
-            title="Reset surface"
-            aria-label="Reset demo"
-            className="rounded-[4px] border border-line2x bg-[var(--panel)] px-2 py-1 text-[10px] text-faintx hover:text-[var(--text)] hover:border-[rgba(var(--acc-rgb),0.35)] transition-colors"
-          >
-            reset
-          </button>
-        </div>
-      </div>
+      <DemoChromeBar
+        statusDot
+        title="~/Desktop"
+        detail="— live demo"
+        trailing={
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => spawn()}
+              title="New note — Control Option Shift Command N"
+              aria-label="New note, Control Option Shift Command N"
+              className={demoBtn}
+            >
+              {HYPER_GLYPH}N
+            </button>
+            <button
+              type="button"
+              onClick={toggleBlink}
+              title="Blink all / none — Control Option Shift Command B"
+              aria-label="Blink all panels, Control Option Shift Command B"
+              aria-pressed={allHidden}
+              className={allHidden ? demoBtnOn : demoBtn}
+            >
+              {HYPER_GLYPH}B
+            </button>
+            <button
+              type="button"
+              onClick={() => setGrid((g) => !g)}
+              title="Grid overlay — Control Option Shift Command C"
+              aria-label="Toggle grid overlay, Control Option Shift Command C"
+              aria-pressed={grid}
+              className={grid ? demoBtnOn : demoBtn}
+            >
+              {HYPER_GLYPH}C
+            </button>
+            <button
+              type="button"
+              onClick={resetScene}
+              title="Reset surface"
+              aria-label="Reset demo"
+              className="inline-flex h-7 items-center rounded-[4px] border border-line2x bg-[var(--panel)] px-2 text-[10px] leading-none text-faintx transition-colors hover:border-[rgba(var(--acc-rgb),0.35)] hover:text-[var(--text)]"
+            >
+              reset
+            </button>
+          </div>
+        }
+      />
 
       {/* surface — premium layered desktop */}
       <div
@@ -277,8 +279,8 @@ export default function SpatialDemo() {
             notes.length === 0 ? 'opacity-100' : 'opacity-0'
           }`}
         >
-          <div className="flex items-center gap-2 text-faintx text-[12px]">
-            <Chord keys={['⌃', '⌥', '⇧', '⌘', 'N']} />
+          <div className="flex items-center gap-2 text-[12px] text-faintx">
+            <HyperChord letter="N" action="New note" />
           </div>
           <p className="text-[11px] text-faintx text-center max-w-[18rem] leading-relaxed">
             click anywhere — or press <span className="text-acc">N</span> — to drop a note
@@ -302,9 +304,9 @@ export default function SpatialDemo() {
               transition: 'opacity 0.22s ease, transform 0.22s ease',
             }}
           >
-            <div className="flex min-h-7 items-center justify-between border-b border-[rgba(255,248,236,0.1)] px-2.5 py-1">
-              <span className="text-[10px] font-medium text-[rgba(245,242,236,0.82)]">{n.title}</span>
-              <span className="text-[9px] tabular-nums text-[rgba(200,196,188,0.55)]">
+            <div className="flex min-h-7 items-center justify-between gap-2 border-b border-[rgba(255,248,236,0.12)] px-2.5 py-1.5">
+              <span className="truncate text-[10px] font-medium leading-none text-[rgba(245,242,236,0.88)]">{n.title}</span>
+              <span className="shrink-0 text-[9px] tabular-nums leading-none text-[rgba(200,196,188,0.55)]">
                 {dragInfo?.id === n.id ? (
                   <span className="text-[rgba(245,242,236,0.9)]">
                     x:{String(dragInfo.x).padStart(3, '0')} y:{String(dragInfo.y).padStart(3, '0')}
@@ -314,7 +316,7 @@ export default function SpatialDemo() {
                 )}
               </span>
             </div>
-            <div className="px-2.5 py-2 space-y-[3px]">
+            <div className="space-y-[3px] px-2.5 py-2">
               {n.lines.map((l, i) => (
                 <div
                   key={i}
@@ -334,7 +336,7 @@ export default function SpatialDemo() {
         {/* bottom-left readout */}
         <div className="absolute bottom-2 left-3 text-[9px] text-faintx pointer-events-none">
           panels: {notes.filter((n) => !n.hidden).length}/{notes.length}
-          {allHidden && <span className="text-acc"> · blinked out — ⌃⌥⇧⌘B to recall</span>}
+          {allHidden && <span className="text-acc"> · blinked out — {HYPER_GLYPH}B to recall</span>}
         </div>
         <div className="absolute bottom-2 right-3 text-[9px] text-faintx pointer-events-none hidden sm:block">
           drag panels · state persists (x, y, w, h)

--- a/landing/components/homepage/ThemeSwitcher.tsx
+++ b/landing/components/homepage/ThemeSwitcher.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 
 const THEMES = [
   { id: 'light', label: 'Light', detail: 'Parchment light' },
-  { id: 'dark', label: 'Dark', detail: 'Forest dark' },
+  { id: 'dark', label: 'Dark', detail: 'Neutral dark' },
   { id: 'auto', label: 'Auto', detail: 'Follow macOS' },
 ] as const
 
@@ -126,7 +126,7 @@ export function ThemeSwitcher() {
 
   return (
     <div
-      className="inline-flex items-center rounded-[6px] border border-line2x bg-panelx p-0.5"
+      className="inline-flex h-8 items-center rounded-[6px] border border-line2x bg-panelx p-0.5"
       role="radiogroup"
       aria-label="Color theme"
     >
@@ -141,13 +141,13 @@ export function ThemeSwitcher() {
             type="button"
             role="radio"
             aria-checked={selected}
-            aria-label={`${theme.label} theme`}
+            aria-label={`${theme.label} theme — ${theme.detail}`}
             title={`${theme.label} — ${theme.detail}`}
             tabIndex={selected ? 0 : -1}
             onClick={() => pick(theme.id)}
             onKeyDown={(event) => onKeyDown(event, index)}
             className={[
-              'inline-flex h-11 w-11 items-center justify-center rounded-[4px] transition-[color,background-color,box-shadow] duration-150',
+              'inline-flex h-7 w-7 items-center justify-center rounded-[4px] transition-[color,background-color,box-shadow] duration-150',
               selected
                 ? 'bg-[var(--acc-soft)] text-acc shadow-[inset_0_0_0_1px_rgba(var(--acc-rgb),0.28)]'
                 : 'text-faintx hover:bg-[var(--acc-soft)] hover:text-[var(--text)]',

--- a/landing/components/homepage/shared.tsx
+++ b/landing/components/homepage/shared.tsx
@@ -48,6 +48,11 @@ export function Reveal({
 
 /* ---------------------------------- kbd ---------------------------------- */
 
+/** Visual stand-in for the Hyper modifier cluster (⌃⌥⇧⌘). */
+export const HYPER_GLYPH = '◆'
+export const HYPER_EXPAND = '⌃⌥⇧⌘'
+export const HYPER_SPOKEN = 'Control Option Shift Command'
+
 export function Kbd({ children, wide }: { children: ReactNode; wide?: boolean }) {
   return (
     <span
@@ -61,15 +66,114 @@ export function Kbd({ children, wide }: { children: ReactNode; wide?: boolean })
   )
 }
 
-export function Chord({ keys }: { keys: string[] }) {
+export function Chord({ keys, label }: { keys: string[]; label?: string }) {
   return (
-    <span className="inline-flex items-center gap-[4px]">
+    <span
+      className="inline-flex items-center gap-[4px]"
+      role={label ? 'img' : undefined}
+      aria-label={label}
+    >
       {keys.map((k, i) => (
-        <Kbd key={i} wide={k.length > 1}>
+        <Kbd key={i} wide={k.length > 1 && k !== HYPER_GLYPH}>
           {k}
         </Kbd>
       ))}
     </span>
+  )
+}
+
+/** Global Hyper chord: diamond glyph + final letter; full shortcut in accessible label. */
+export function HyperChord({ letter, action }: { letter: string; action?: string }) {
+  const full = `${HYPER_SPOKEN} ${letter}`
+  return (
+    <Chord
+      keys={[HYPER_GLYPH, letter]}
+      label={action ? `${action}: ${full}` : full}
+    />
+  )
+}
+
+/* --------------------------- mock window chrome --------------------------- */
+
+/** Shared title bar for in-page terminal / file / preview mocks. */
+export function MockTitleBar({
+  title,
+  detail,
+  trailing,
+  dots = false,
+  className = '',
+}: {
+  title: ReactNode
+  detail?: ReactNode
+  trailing?: ReactNode
+  dots?: boolean
+  className?: string
+}) {
+  return (
+    <div
+      className={[
+        'flex min-h-9 shrink-0 items-center justify-between gap-3 border-b border-linex bg-panel2x px-3 py-1.5',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        {dots && (
+          <span className="flex items-center gap-1" aria-hidden>
+            <span className="h-[7px] w-[7px] rounded-full bg-[var(--ghost)]" />
+            <span className="h-[7px] w-[7px] rounded-full bg-[var(--faint)]" />
+            <span className="h-[7px] w-[7px] rounded-full bg-[var(--dim)]" />
+          </span>
+        )}
+        <span className="truncate text-[11px] font-medium text-[var(--text)]">{title}</span>
+        {detail != null && detail !== '' && (
+          <span className="hidden min-w-0 truncate text-[10px] text-faintx sm:inline">{detail}</span>
+        )}
+      </div>
+      {trailing != null && (
+        <div className="flex shrink-0 items-center gap-2 text-[10px] text-dimx">{trailing}</div>
+      )}
+    </div>
+  )
+}
+
+/** Shared desk / live-demo chrome strip (uses --demo-chrome tokens). */
+export function DemoChromeBar({
+  title,
+  detail,
+  trailing,
+  statusDot = false,
+  className = '',
+}: {
+  title: ReactNode
+  detail?: ReactNode
+  trailing?: ReactNode
+  statusDot?: boolean
+  className?: string
+}) {
+  return (
+    <div
+      className={[
+        'demo-chrome flex min-h-9 shrink-0 items-center justify-between gap-2 border border-b-0 rounded-t-[8px] px-3 py-1.5',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="flex min-w-0 items-center gap-2 text-[11px]">
+        {statusDot && (
+          <span className="inline-block h-[7px] w-[7px] shrink-0 rounded-full bg-[var(--acc)] pulse-dot" aria-hidden />
+        )}
+        <span className="truncate font-semibold text-[var(--text)]">{title}</span>
+        {detail != null && (
+          <span className="hidden shrink-0 text-faintx md:inline">{detail}</span>
+        )}
+      </div>
+      {trailing != null && (
+        <div className="flex shrink-0 items-center gap-1.5 text-[10px] text-dimx">{trailing}</div>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- replace the green-heavy dark theme with a neutral black and gray palette plus restrained blue interaction accents
- refine header controls, shared mock-window chrome, sheet tabs, keyboard shorthand, and footer links
- move the Pi/CLI film directly before the agent-first story and square bracket-adjacent dark-mode corners

## Verification
- `cd landing && bunx tsc --noEmit`
- `cd landing && bun run build`
- desktop and mobile visual review in light and dark modes
- browser accessibility snapshot and console error check

## Notes
- light-mode palette and typography remain unchanged
- unrelated untracked workspace files are excluded