### PR TITLE
✨ Lift note chrome off the page and add a popover quit

### DIFF
--- a/Sources/BlinkApp/AppDelegate.swift
+++ b/Sources/BlinkApp/AppDelegate.swift
@@ -507,6 +507,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                     self?.popover?.performClose(nil)
                     self?.panelManager.toggleGridOverlay()
                 },
+                quit: {
+                    NSApp.terminate(nil)
+                },
                 beginDictation: { [weak self] in
                     self?.beginPopoverDictation()
                 },

--- a/Sources/BlinkApp/BlinkConfig.swift
+++ b/Sources/BlinkApp/BlinkConfig.swift
@@ -32,6 +32,9 @@ struct BlinkConfig: Codable, Equatable {
         var grid: String = "hyper+c"
         var toggleMode: String = "cmd+shift+p"
         var focus: String = "cmd+."
+        /// Pin the detached chrome rail so it stays up after hover leaves.
+        /// Panel-local, like `toggleMode` and `focus`.
+        var toggleChrome: String = "cmd+shift+t"
 
         init() {}
         init(from decoder: Decoder) throws {
@@ -41,6 +44,7 @@ struct BlinkConfig: Codable, Equatable {
             grid = try c.decodeIfPresent(String.self, forKey: .grid) ?? "hyper+c"
             toggleMode = try c.decodeIfPresent(String.self, forKey: .toggleMode) ?? "cmd+shift+p"
             focus = try c.decodeIfPresent(String.self, forKey: .focus) ?? "cmd+."
+            toggleChrome = try c.decodeIfPresent(String.self, forKey: .toggleChrome) ?? "cmd+shift+t"
         }
     }
 
@@ -51,8 +55,8 @@ struct BlinkConfig: Codable, Equatable {
         var sheet: String = "glass"
         var material: String = "hud"  // hud | underWindow | popover | sidebar | menu
         var cornerRadius: Double = 12
-        var tintRead: Double = 0.18
-        var tintEdit: Double = 0.28
+        var tintRead: Double = 0.28
+        var tintEdit: Double = 0.38
         var shadow: Bool = true
         var defaultWidth: Double = 420
         var defaultHeight: Double = 340
@@ -63,15 +67,25 @@ struct BlinkConfig: Codable, Equatable {
         /// paths resolve under `$BLINK_HOME/attachments`; note markdown never
         /// needs to carry presentation-only brand assets.
         var mark: String?
+        /// Where the ✕ and the mode toggle live.
+        ///
+        /// - "rail": lifted out of the note into a detached strip above it, so
+        ///   no control ever sits on the page. Shown on hover (or pinned with
+        ///   hotkeys.toggleChrome). Crossing onto the strip keeps it up; idle
+        ///   notes stay bare. Edit mode does not force it.
+        /// - "inside": the original hover-earned chrome floating over the note's
+        ///   own top corners.
+        var chrome: String = "rail"
 
         init() {}
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             sheet = try c.decodeIfPresent(String.self, forKey: .sheet) ?? "glass"
+            chrome = try c.decodeIfPresent(String.self, forKey: .chrome) ?? "rail"
             material = try c.decodeIfPresent(String.self, forKey: .material) ?? "hud"
             cornerRadius = try c.decodeIfPresent(Double.self, forKey: .cornerRadius) ?? 12
-            tintRead = try c.decodeIfPresent(Double.self, forKey: .tintRead) ?? 0.18
-            tintEdit = try c.decodeIfPresent(Double.self, forKey: .tintEdit) ?? 0.28
+            tintRead = try c.decodeIfPresent(Double.self, forKey: .tintRead) ?? 0.28
+            tintEdit = try c.decodeIfPresent(Double.self, forKey: .tintEdit) ?? 0.38
             shadow = try c.decodeIfPresent(Bool.self, forKey: .shadow) ?? true
             defaultWidth = try c.decodeIfPresent(Double.self, forKey: .defaultWidth) ?? 420
             defaultHeight = try c.decodeIfPresent(Double.self, forKey: .defaultHeight) ?? 340
@@ -392,12 +406,68 @@ struct BlinkConfig: Codable, Equatable {
         if let v = editor.h3Size { vars["--blink-h3-size"] = "\(v)px" }
         return vars
     }
+
+    /// Signal color for native chrome. Treatments set `editor.accentColor`;
+    /// otherwise the scheme default — cool paper-blue in light, signal-blue
+    /// in dark. Same hex the editor CSS uses.
+    func chromeAccent(scheme: AppScheme) -> NSColor {
+        if let raw = editor.accentColor, let color = NSColor(blinkCSS: raw) {
+            return color
+        }
+        return scheme.isDark
+            ? NSColor(srgbRed: 93 / 255, green: 158 / 255, blue: 250 / 255, alpha: 1)
+            : NSColor(srgbRed: 45 / 255, green: 93 / 255, blue: 175 / 255, alpha: 1)
+    }
+
 }
 
 /// Clamp a value into `[lo, hi]` — defensive bound for resolved presentation.
 private func clamp(_ v: Double, _ lo: Double, _ hi: Double) -> Double {
     min(max(v, lo), hi)
 }
+
+extension NSColor {
+    /// `#rgb`, `#rrggbb`, or `rgba(r,g,b,a)` — the shapes config.json already
+    /// accepts for editor colors.
+    convenience init?(blinkCSS raw: String) {
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasPrefix("#") {
+            var hex = String(value.dropFirst())
+            if hex.count == 3 {
+                hex = hex.map { "\($0)\($0)" }.joined()
+            }
+            guard hex.count == 6, let n = UInt64(hex, radix: 16) else { return nil }
+            self.init(
+                srgbRed: CGFloat((n >> 16) & 0xFF) / 255,
+                green: CGFloat((n >> 8) & 0xFF) / 255,
+                blue: CGFloat(n & 0xFF) / 255,
+                alpha: 1
+            )
+            return
+        }
+        if value.lowercased().hasPrefix("rgba("), value.hasSuffix(")") {
+            let inner = value.dropFirst(5).dropLast()
+            let parts = inner.split(separator: ",").map {
+                $0.trimmingCharacters(in: .whitespaces)
+            }
+            guard parts.count == 4,
+                  let r = Double(parts[0]),
+                  let g = Double(parts[1]),
+                  let b = Double(parts[2]),
+                  let a = Double(parts[3])
+            else { return nil }
+            self.init(
+                srgbRed: r / 255,
+                green: g / 255,
+                blue: b / 255,
+                alpha: a
+            )
+            return
+        }
+        return nil
+    }
+}
+
 
 /// Loads, saves, and hot-reloads the config file. Agent-first: any process may
 /// edit the file; a directory watcher picks the change up and re-applies it

--- a/Sources/BlinkApp/CapturePopoverView.swift
+++ b/Sources/BlinkApp/CapturePopoverView.swift
@@ -32,6 +32,7 @@ struct CapturePopoverView: View {
     var showCommands: () -> Void
     var toggleBlink: () -> Void
     var showGrid: () -> Void
+    var quit: () -> Void
     var beginDictation: () -> Void
     var trustedPeerCount: Int
     @ObservedObject var peerSyncStatus: PeerSyncStatus
@@ -493,6 +494,16 @@ struct CapturePopoverView: View {
             FooterUtilitiesMenu(
                 openHelp: openGuide,
                 openSettings: openSettings
+            )
+
+            footerSeparator
+
+            FooterActionButton(
+                icon: "power",
+                label: "Quit",
+                shortcut: "⌘Q",
+                help: "Quit Blink (⌘Q)",
+                action: quit
             )
         }
         .padding(.horizontal, 18)

--- a/Sources/BlinkApp/NotePanel.swift
+++ b/Sources/BlinkApp/NotePanel.swift
@@ -111,6 +111,27 @@ final class NotePanel: NSPanel {
     private var focusGlyphView: NSView?
     private var closeButtonView: NSView?
     private var isHovered = false
+    /// Pointer is over the detached rail. Combined with `isHovered` so crossing
+    /// the seam does not count as leaving the note.
+    private var railPointerInside = false
+    /// Grace after the pointer leaves note+rail so you can reach the strip.
+    private var railLinger = false
+    private var railHideWork: DispatchWorkItem?
+
+    /// "rail" lifts the ✕ and mode toggle off the page into `chromeRail`;
+    /// "inside" keeps the original hover-earned corner chrome. Config-owned, so
+    /// it flips on hot reload.
+    private var chromeStyle: String
+    private var chromeRail: PanelChromeRail?
+    /// Keeps the rail up even after hover leaves.
+    private var railPinned = false
+
+
+
+    /// The note's title drives the rail's label, so a rename has to reach it.
+    override var title: String {
+        didSet { chromeRail?.setTitle(title) }
+    }
 
     init(
         noteID: String,
@@ -129,6 +150,7 @@ final class NotePanel: NSPanel {
         self.sheetTemplate = theme.panel.sheet
         self.readTint = theme.panel.tintRead
         self.editTint = theme.panel.tintEdit
+        self.chromeStyle = theme.panel.chrome
 
         super.init(
             contentRect: NSRect(
@@ -354,6 +376,10 @@ final class NotePanel: NSPanel {
         }
         setFrameAutosaveName(autosaveName)
 
+        // After the frame is restored: the rail positions itself off the note's
+        // real geometry, so building it earlier would park it at the origin.
+        syncChromeRail()
+
         // Derive the panel's surface from the sheet template: glass-visible for
         // glass/card, fully flat (no glass, no shadow) for the cut-out sheets.
         applySheetAppearance(theme)
@@ -423,11 +449,23 @@ final class NotePanel: NSPanel {
             container.layer?.cornerRadius = config.panel.cornerRadius
             hasShadow = config.panel.shadow
         }
+        applySeamCorners()
     }
 
     /// Nonactivating borderless panels must opt in to becoming key so the
     /// editor can type.
     override var canBecomeKey: Bool { true }
+
+    override func becomeKey() {
+        super.becomeKey()
+        updateChromeVisibility()
+    }
+
+    override func resignKey() {
+        super.resignKey()
+        updateChromeVisibility()
+    }
+
 
     /// Mode flip (⌘⇧P) and focus (⌘.) — chords come from config so they follow
     /// hot reloads. Handled natively so they work even when the webview never
@@ -441,6 +479,10 @@ final class NotePanel: NSPanel {
         }
         if let chord = KeyChord.parse(hotkeys.focus), chord.matches(event) {
             toggleFocus()
+            return true
+        }
+        if let chord = KeyChord.parse(hotkeys.toggleChrome), chord.matches(event) {
+            toggleChromeRail()
             return true
         }
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
@@ -490,24 +532,155 @@ final class NotePanel: NSPanel {
     }
 
     private func syncHoveredFromPointer() {
-        setHovered(frame.contains(NSEvent.mouseLocation))
+        let mouse = NSEvent.mouseLocation
+        let overNote = frame.contains(mouse)
+        let overRail = chromeRail?.isShowing == true
+            && (chromeRail?.frame.contains(mouse) ?? false)
+        setHovered(overNote)
+        setRailPointerInside(overRail)
     }
 
     private func setHovered(_ hovered: Bool) {
         guard hovered != isHovered else { return }
         isHovered = hovered
+        refreshChromeHover()
+    }
+
+    func setRailPointerInside(_ inside: Bool) {
+        guard inside != railPointerInside else { return }
+        railPointerInside = inside
+        refreshChromeHover()
+    }
+
+    /// Show immediately on enter; hide only after a short linger so the pointer
+    /// can leave the page and land on the rail without the strip vanishing.
+    private func refreshChromeHover() {
+        if isHovered || railPointerInside {
+            railHideWork?.cancel()
+            railHideWork = nil
+            railLinger = false
+            updateChromeVisibility()
+            return
+        }
+        guard !railLinger else { return }
+        railLinger = true
+        updateChromeVisibility()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.railHideWork = nil
+            self.railLinger = false
+            self.updateChromeVisibility()
+        }
+        railHideWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.22, execute: work)
+    }
+
+
+    // MARK: - Detached chrome rail
+
+    /// Build or tear down the rail to match `chromeStyle`, then re-evaluate what
+    /// should be showing. Safe to call repeatedly — hot reload does.
+    private func syncChromeRail() {
+        let wantsRail = chromeStyle == "rail"
+        if wantsRail, chromeRail == nil {
+            let theme = BlinkConfigStore.shared.config.resolved(for: notePresentation)
+            let scheme = AppearanceManager.shared.scheme
+            let rail = PanelChromeRail(
+                panel: self,
+                state: modeState,
+                title: title,
+                cornerRadius: theme.panel.cornerRadius,
+                material: Self.glassMaterial(theme, scheme),
+                tint: currentMode == "edit" ? editTint : readTint,
+                accent: theme.chromeAccent(scheme: scheme),
+                onClose: { [weak self] in self?.close() },
+                onSelectMode: { [weak self] mode in self?.selectMode(mode) },
+                onToggleFocus: { [weak self] in self?.toggleFocus() }
+            )
+            rail.onHoverChanged = { [weak self] inside in
+                self?.setRailPointerInside(inside)
+            }
+            rail.onPlacementChanged = { [weak self] _ in self?.applySeamCorners() }
+            chromeRail = rail
+        } else if !wantsRail, let rail = chromeRail {
+            rail.dismantle()
+            chromeRail = nil
+            railPinned = false
+            railPointerInside = false
+            railHideWork?.cancel()
+            railHideWork = nil
+            railLinger = false
+        }
+        applySeamCorners()
         updateChromeVisibility()
     }
 
+
+    /// The page keeps all four rounded corners whether the rail is up or not.
+    /// Chrome docks onto that silhouette; it must not mutate the note's shape.
+    private func applySeamCorners() {
+        let all: CACornerMask = [
+            .layerMinXMinYCorner, .layerMaxXMinYCorner,
+            .layerMinXMaxYCorner, .layerMaxXMaxYCorner,
+        ]
+        container.layer?.maskedCorners = all
+        glassView.layer?.maskedCorners = all
+    }
+
+
+    /// Earned chrome, not mode chrome: hover (or pin) shows the rail. Edit
+    /// mode does not keep it up — a writing note that is not under the hand
+    /// should look like a page, not a selected window.
+    private var railShouldShow: Bool {
+        railPinned || isHovered || railPointerInside || railLinger
+    }
+
+    /// Pin/unpin the rail (⌘⇧T by default) so it stays up after hover leaves.
+    func toggleChromeRail() {
+        guard chromeRail != nil else { return }
+        railPinned.toggle()
+        updateChromeVisibility()
+    }
+
+
+    /// Push this note's resolved glass + mode tint onto the rail. One path for
+    /// open, key flips, mode flips, and hot reload — never a second config
+    /// lookup inside the rail.
+    private func applyRailSurface() {
+        guard chromeRail != nil else { return }
+        let theme = BlinkConfigStore.shared.config.resolved(for: notePresentation)
+        let scheme = AppearanceManager.shared.scheme
+        chromeRail?.applySurface(
+            material: Self.glassMaterial(theme, scheme),
+            tint: currentMode == "edit" ? editTint : readTint,
+            accent: theme.chromeAccent(scheme: scheme)
+        )
+    }
+
     private func updateChromeVisibility() {
+        // With the rail carrying the ✕ and the toggle, the in-note copies would
+        // be duplicate controls sitting on the page — the thing being fixed.
+        let railActive = chromeRail != nil
+        let showRail = railActive && railShouldShow
+        chromeRail?.setVisible(showRail)
+        if showRail {
+            applyRailSurface()
+        }
+        applySeamCorners()
+
+
         // NSHostingView can fail to animate out of an initial zero alpha; make
         // the mode control deterministic and reserve animation for the
         // same-cell brand/close crossfade.
-        modePillView?.alphaValue = isHovered ? 1 : 0
+        modePillView?.alphaValue = !railActive && isHovered ? 1 : 0
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.15
-            closeButtonView?.animator().alphaValue = isHovered ? 1 : 0
-            themeMarkView?.animator().alphaValue = isHovered || !modeState.hasThemeMark ? 0 : 0.94
+            closeButtonView?.animator().alphaValue = !railActive && isHovered ? 1 : 0
+            // The brand mark keeps its cell to itself once close moves out, so
+            // it no longer has to yield on hover.
+            themeMarkView?.animator().alphaValue = modeState.hasThemeMark
+                ? (railActive ? 0.94 : (isHovered ? 0 : 0.94))
+                : 0
             noteIDView?.animator().alphaValue = currentMode == "edit"
                 ? (isHovered ? 1 : 0.55)
                 : 0
@@ -518,7 +691,9 @@ final class NotePanel: NSPanel {
                 ? (isHovered ? 1 : 0.75)
                 : 0
             // Active focus leaves a faint trace so the state stays legible.
-            focusGlyphView?.animator().alphaValue = isHovered ? 1 : (modeState.focus ? 0.35 : 0)
+            focusGlyphView?.animator().alphaValue = railActive
+                ? 0
+                : (isHovered ? 1 : (modeState.focus ? 0.35 : 0))
         }
     }
 
@@ -531,6 +706,7 @@ final class NotePanel: NSPanel {
     /// (their mode contrast comes from the sheet's own CSS if needed).
     func reflectMode(_ mode: String) {
         modeState.mode = mode
+        updateChromeVisibility()
         noteIDView?.isHidden = mode != "edit"
         noteIDView?.alphaValue = mode == "edit" ? (isHovered ? 1 : 0.55) : 0
         styleMetadataView?.isHidden = mode != "edit"
@@ -554,6 +730,15 @@ final class NotePanel: NSPanel {
         readTint = theme.panel.tintRead
         editTint = theme.panel.tintEdit
         updateMetadata(theme)
+
+        if theme.panel.chrome != chromeStyle {
+            chromeStyle = theme.panel.chrome
+            syncChromeRail()
+        }
+        chromeRail?.applyAppearance(appearance)
+        chromeRail?.applyCornerRadius(theme.panel.cornerRadius)
+        applyRailSurface()
+
 
         if theme.panel.sheet != sheetTemplate {
             sheetTemplate = theme.panel.sheet
@@ -593,7 +778,7 @@ final class NotePanel: NSPanel {
         modeState.font = Self.displayFontName(theme.editor.fontFamily)
         modeState.fontSize = theme.editor.fontSize
         modeState.mark = theme.panel.mark
-        themeMarkView?.alphaValue = isHovered || !modeState.hasThemeMark ? 0 : 0.94
+        updateChromeVisibility()
     }
 
     private static func displayFontName(_ cssFamily: String?) -> String {
@@ -1246,6 +1431,14 @@ final class NotePanel: NSPanel {
 
     override func close() {
         cancelFling()
+        railHideWork?.cancel()
+        railHideWork = nil
+        railLinger = false
+        railPointerInside = false
+        // A child window outlives its parent's close unless detached, which
+        // would strand a rail floating over nothing.
+        chromeRail?.dismantle()
+        chromeRail = nil
         super.close()
     }
 
@@ -1298,10 +1491,15 @@ final class PanelModeState: ObservableObject {
     }
 }
 
-/// ✎/◧ mode segments; the active segment is lit. Hover-revealed, top-right.
-private struct ModeToggle: View {
+/// ✎/◧ mode segments; the active segment is lit. Hover-revealed, top-right —
+/// or carried by the detached rail when `panel.chrome` is "rail".
+struct ModeToggle: View {
     @ObservedObject var state: PanelModeState
     @ObservedObject private var configStore = BlinkConfigStore.shared
+    /// Ink for the glyphs. In-note chrome sits on the panel's darkened glass and
+    /// wants white; the detached rail floats over whatever is on the desktop, so
+    /// it passes an appearance-adaptive color instead.
+    var ink: Color = .white
     var onSelect: (String) -> Void
 
     private var shortcut: String {
@@ -1315,8 +1513,12 @@ private struct ModeToggle: View {
             segment(icon: "book", mode: "read", help: "Read (\(shortcut))")
         }
         .padding(2)
-        .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+        .background(ink.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
     }
+
+    var accent: Color?
+
+    private var lit: Color { accent ?? ink }
 
     private func segment(icon: String, mode: String, help: String) -> some View {
         Button {
@@ -1324,10 +1526,10 @@ private struct ModeToggle: View {
         } label: {
             Image(systemName: icon)
                 .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(state.mode == mode ? .white : .white.opacity(0.4))
+                .foregroundStyle(state.mode == mode ? lit : ink.opacity(0.42))
                 .frame(width: 22, height: 18)
                 .background(
-                    state.mode == mode ? Color.white.opacity(0.18) : .clear,
+                    state.mode == mode ? lit.opacity(0.20) : .clear,
                     in: RoundedRectangle(cornerRadius: 4)
                 )
         }
@@ -1466,9 +1668,11 @@ private struct StyleMetadataBadge: View {
 
 /// The focus ring: a small dashed circle, alone in the bottom-right corner —
 /// deliberately not a peer of the mode segments. Fills in while focus is on.
-private struct FocusGlyph: View {
+struct FocusGlyph: View {
     @ObservedObject var state: PanelModeState
     @ObservedObject private var configStore = BlinkConfigStore.shared
+    var ink: Color = .white
+    var accent: Color?
     var onTap: () -> Void
 
     private var shortcut: String {
@@ -1480,7 +1684,7 @@ private struct FocusGlyph: View {
         Button(action: onTap) {
             Image(systemName: state.focus ? "circle.dashed.inset.filled" : "circle.dashed")
                 .font(.system(size: 11))
-                .foregroundStyle(state.focus ? .white : .white.opacity(0.5))
+                .foregroundStyle(state.focus ? (accent ?? ink) : ink.opacity(0.50))
         }
         .buttonStyle(.plain)
         .help("Focus — quiet everything else (\(shortcut))")
@@ -1496,7 +1700,7 @@ private struct FocusGlyph: View {
 /// momentum fling) and a shake signature (folds the panel into the band).
 /// The move math is the classic grab-relative offset, so an ordinary drag
 /// feels exactly like the native one — the cursor keeps its grip point.
-private final class DragHandle: NSView {
+final class DragHandle: NSView {
     private var isDragging = false
     private var isHovering = false
     private var tracking: NSTrackingArea?
@@ -1504,6 +1708,17 @@ private final class DragHandle: NSView {
     private var grabOrigin = NSPoint.zero  // window origin at mouseDown
     private var tracker = DragVelocityTracker()
     private var shake = ShakeDetector()
+
+    /// The in-panel strip paints a hairline grip to advertise itself. The
+    /// detached rail is already visibly grabbable, so it opts out.
+    var showsGrip = true
+
+    /// The note this handle moves. Inside the panel that is the handle's own
+    /// window; on the detached chrome rail it is the rail's parent, so the
+    /// gesture moves the note rather than the strip sitting on top of it.
+    private var notePanel: NotePanel? {
+        window as? NotePanel ?? window?.parent as? NotePanel
+    }
 
     override var isOpaque: Bool { false }
 
@@ -1523,6 +1738,7 @@ private final class DragHandle: NSView {
         super.draw(dirtyRect)
         // A hairline grip keeps the borderless panel discoverably movable
         // without turning the strip into visible window chrome.
+        guard showsGrip else { return }
         let alpha: CGFloat = isDragging ? 0.38 : (isHovering ? 0.24 : 0.08)
         NSColor.labelColor.withAlphaComponent(alpha).setFill()
         let grip = NSRect(x: bounds.midX - 12, y: bounds.maxY - 5, width: 24, height: 2)
@@ -1545,7 +1761,7 @@ private final class DragHandle: NSView {
     }
 
     override func mouseDown(with event: NSEvent) {
-        guard let panel = window as? NotePanel else { return }
+        guard let panel = notePanel else { return }
         // Double-click on the band toggles the shade — the classic windowshade
         // gesture. The click that opened the pair already ran a movement-less
         // drag begin/end, so nothing here is left in flight; the paired
@@ -1565,7 +1781,7 @@ private final class DragHandle: NSView {
     }
 
     override func mouseDragged(with event: NSEvent) {
-        guard isDragging, let panel = window as? NotePanel else { return }
+        guard isDragging, let panel = notePanel else { return }
         let mouse = NSEvent.mouseLocation
         let origin = NSPoint(
             x: grabOrigin.x + mouse.x - grabMouse.x,
@@ -1586,7 +1802,7 @@ private final class DragHandle: NSView {
     }
 
     override func mouseUp(with event: NSEvent) {
-        guard isDragging, let panel = window as? NotePanel else { return }
+        guard isDragging, let panel = notePanel else { return }
         isDragging = false
         NSCursor.openHand.set()
         needsDisplay = true
@@ -1597,16 +1813,17 @@ private final class DragHandle: NSView {
 
 /// The close glyph: a small ✕ alone in the top-left corner, mirroring the mode
 /// pill top-right. Hover-revealed. Replaces the hidden traffic-light close.
-private struct CloseGlyph: View {
+struct CloseGlyph: View {
+    var ink: Color = .white
     var onTap: () -> Void
 
     var body: some View {
         Button(action: onTap) {
             Image(systemName: "xmark")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(.white.opacity(0.55))
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(ink.opacity(0.70))
                 .frame(width: 20, height: 20)
-                .background(.white.opacity(0.08), in: Circle())
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .frame(width: 24, height: 24)

--- a/Sources/BlinkApp/PanelChromeRail.swift
+++ b/Sources/BlinkApp/PanelChromeRail.swift
@@ -1,0 +1,389 @@
+import AppKit
+import HudsonObservability
+import SwiftUI
+
+/// The note's title bar, lifted out of the note's own rectangle: ✕, title,
+/// focus ring, and mode toggle in a strip sitting flush on top of the page.
+///
+/// Why a separate window rather than a band inside the panel: the note's frame
+/// is load-bearing twice over. It is autosaved per note and has to restore
+/// exactly, and the webview's content rect is what decides where the prose
+/// wraps. Growing the panel to make room for chrome would drift the remembered
+/// geometry; insetting the webview would reflow the note every time the rail
+/// appeared. A child window leaves the panel's frame untouched, so the chrome
+/// is genuinely off the page instead of merely looking like it.
+///
+/// It should not *read* as a separate window, though. The rail sits flush
+/// against the note and rounds only its outer corners, while the note squares
+/// the corners along the shared seam — together they form one silhouette.
+///
+/// AppKit moves child windows with their parent, so dragging, flinging, and
+/// shading need no bookkeeping here — only width changes and screen edges do.
+@MainActor
+final class PanelChromeRail {
+    /// Slim enough to read as a title bar, tall enough for a 24pt hit target —
+    /// the point of moving these controls off the page is that they stop being
+    /// fiddly.
+    static let height: CGFloat = 26
+    /// Minimum tab width — title + controls. Wider notes keep a centered tab
+    /// rather than a second full-width story.
+    static let minTabWidth: CGFloat = 220
+    /// Gap from the note's sides so the page corners stay the silhouette.
+    static let sideGutter: CGFloat = 14
+    /// How far the tab sits on the page. Locks onto the existing top edge
+    /// without covering the first line of prose.
+    static let seat: CGFloat = 6
+
+    /// Where the rail ended up relative to the note. Normally above; a note
+    /// parked against the top of the screen gets it tucked underneath instead.
+    enum Placement { case above, below }
+
+    private weak var panel: NotePanel?
+    private let window: RailPanel
+    private let host: NSHostingView<PanelChromeRailView>
+    private let glass: NSVisualEffectView
+    private let backdrop: NSView
+    private let drag: DragHandle
+    private var observers: [NSObjectProtocol] = []
+    private var isVisible = false
+    private var cornerRadius: CGFloat
+    private(set) var placement: Placement = .above
+    private let log = HudLogger(category: "blink.chrome")
+
+    /// Screen frame of the rail window. Used by the note to treat the strip as
+    /// part of the hover target when crossing the seam.
+    var frame: NSRect { window.frame }
+    var isShowing: Bool { isVisible }
+
+    /// Fired when the pointer enters or leaves the rail, so the note can keep
+    /// the strip up while you reach for it.
+    var onHoverChanged: ((Bool) -> Void)?
+
+    /// Fired when the rail flips sides, so the note can move its squared corners
+    /// to whichever edge now carries the seam.
+    var onPlacementChanged: ((Placement) -> Void)?
+
+    init(
+        panel: NotePanel,
+        state: PanelModeState,
+        title: String,
+        cornerRadius: CGFloat,
+        material: NSVisualEffectView.Material,
+        tint: CGFloat,
+        accent: NSColor,
+        onClose: @escaping () -> Void,
+        onSelectMode: @escaping (String) -> Void,
+        onToggleFocus: @escaping () -> Void
+    ) {
+        self.panel = panel
+        self.cornerRadius = cornerRadius
+
+        let rail = RailPanel(
+            contentRect: NSRect(x: 0, y: 0, width: panel.frame.width, height: Self.height),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        rail.isFloatingPanel = true
+        rail.hidesOnDeactivate = false
+        rail.isOpaque = false
+        rail.backgroundColor = .clear
+        rail.hasShadow = false
+        rail.appearance = panel.appearance
+        rail.alphaValue = 0
+        // The strip has to see mouse-moved or crossing the seam never marks
+        // railPointerInside, and the linger expires before you can click it.
+        rail.acceptsMouseMovedEvents = true
+        // Invisible chrome must not swallow clicks meant for whatever is behind
+        // it; `setVisible` re-arms this in step with the fade.
+        rail.ignoresMouseEvents = true
+
+        let glass = NSVisualEffectView()
+        // Match the note's glass so the rail is a continuation of the page,
+        // not a separate hud pill parked above it. Material comes from the
+        // panel's resolved theme — never a second global lookup.
+        glass.material = material
+        glass.blendingMode = .behindWindow
+        glass.state = .active
+        glass.wantsLayer = true
+        glass.translatesAutoresizingMaskIntoConstraints = false
+        // No surrounding hairline — the rail is selected chrome, not a framed
+        // box. Silhouette comes from the shared glass + outer corner radii.
+        glass.layer?.borderWidth = 0
+
+
+        // Same contrast job the note's tint layer performs: deepen/lift the
+        // glass so glyphs stay legible over the desktop. Kept light enough that
+        // the strip still reads as one material with the page.
+        let backdrop = NSView()
+        backdrop.wantsLayer = true
+        backdrop.translatesAutoresizingMaskIntoConstraints = false
+        glass.addSubview(backdrop)
+        NSLayoutConstraint.activate([
+            backdrop.topAnchor.constraint(equalTo: glass.topAnchor),
+            backdrop.leadingAnchor.constraint(equalTo: glass.leadingAnchor),
+            backdrop.trailingAnchor.constraint(equalTo: glass.trailingAnchor),
+            backdrop.bottomAnchor.constraint(equalTo: glass.bottomAnchor),
+        ])
+
+
+        // The whole strip is the grab surface — the one job a title bar has
+        // always had. The controls live *inside* the handle rather than beside
+        // it, so AppKit offers them the click first and anything they decline
+        // (title, padding, empty space) falls through to the drag.
+        let drag = DragHandle()
+        drag.showsGrip = false
+        drag.translatesAutoresizingMaskIntoConstraints = false
+        glass.addSubview(drag)
+        NSLayoutConstraint.activate([
+            drag.topAnchor.constraint(equalTo: glass.topAnchor),
+            drag.leadingAnchor.constraint(equalTo: glass.leadingAnchor),
+            drag.trailingAnchor.constraint(equalTo: glass.trailingAnchor),
+            drag.bottomAnchor.constraint(equalTo: glass.bottomAnchor),
+        ])
+
+        let host = NSHostingView(
+            rootView: PanelChromeRailView(
+                state: state,
+                title: title,
+                onClose: onClose,
+                onSelectMode: onSelectMode,
+                onToggleFocus: onToggleFocus
+            )
+        )
+        host.translatesAutoresizingMaskIntoConstraints = false
+        drag.addSubview(host)
+        NSLayoutConstraint.activate([
+            host.topAnchor.constraint(equalTo: drag.topAnchor),
+            host.leadingAnchor.constraint(equalTo: drag.leadingAnchor),
+            host.trailingAnchor.constraint(equalTo: drag.trailingAnchor),
+            host.bottomAnchor.constraint(equalTo: drag.bottomAnchor),
+        ])
+
+        let hover = RailHoverView()
+        hover.translatesAutoresizingMaskIntoConstraints = false
+        hover.addSubview(glass)
+        NSLayoutConstraint.activate([
+            glass.topAnchor.constraint(equalTo: hover.topAnchor),
+            glass.leadingAnchor.constraint(equalTo: hover.leadingAnchor),
+            glass.trailingAnchor.constraint(equalTo: hover.trailingAnchor),
+            glass.bottomAnchor.constraint(equalTo: hover.bottomAnchor),
+        ])
+        rail.contentView = hover
+        self.window = rail
+        self.host = host
+        self.glass = glass
+        self.backdrop = backdrop
+        self.drag = drag
+        hover.onChanged = { [weak self] inside in
+            self?.onHoverChanged?(inside)
+        }
+        applySurface(material: material, tint: tint, accent: accent)
+        applyCorners()
+
+        panel.addChildWindow(rail, ordered: .above)
+        syncFrame()
+
+        // The parent carries the rail on moves for free. Resizes change only the
+        // width, and a screen change can invalidate the above/below choice.
+        let center = NotificationCenter.default
+        observers = [
+            center.addObserver(
+                forName: NSWindow.didResizeNotification, object: panel, queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.syncFrame() }
+            },
+            center.addObserver(
+                forName: NSWindow.didMoveNotification, object: panel, queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.syncFrame() }
+            },
+        ]
+    }
+
+    /// Track the note's width and the edge the rail is attached to. Called on
+    /// every parent move/resize, so it stays cheap and allocation-free.
+    func syncFrame() {
+        guard let panel else { return }
+        let noteFrame = panel.frame
+        let maxWidth = max(noteFrame.width - Self.sideGutter * 2, Self.minTabWidth)
+        let width = min(max(Self.minTabWidth, noteFrame.width * 0.62), maxWidth)
+        var origin = NSPoint(
+            x: noteFrame.midX - width / 2,
+            y: noteFrame.maxY - Self.seat
+        )
+        var next = Placement.above
+
+        if let visible = (panel.screen ?? NSScreen.main)?.visibleFrame,
+           origin.y + Self.height > visible.maxY {
+            origin.y = noteFrame.minY - Self.height + Self.seat
+            next = .below
+        }
+
+        window.setFrame(
+            NSRect(origin: origin, size: NSSize(width: width, height: Self.height)),
+            display: true
+        )
+
+        if next != placement {
+            placement = next
+            applyCorners()
+            onPlacementChanged?(next)
+        }
+    }
+
+    func setTitle(_ title: String) {
+        host.rootView.title = title
+    }
+
+    func applyAppearance(_ appearance: NSAppearance?) {
+        window.appearance = appearance
+    }
+
+    /// Paint the note's own glass material and mode tint onto the rail so the
+    /// two share one surface. Callers pass the already-resolved theme values —
+    /// the rail must not re-resolve config or per-note presentation drifts.
+    func applySurface(material: NSVisualEffectView.Material, tint: CGFloat, accent: NSColor) {
+        glass.material = material
+        let scheme = AppearanceManager.shared.scheme
+        let paper = NSColor(cgColor: NotePanel.tintColor(scheme))
+            ?? (scheme.isDark ? .black : .white)
+        let wash = scheme.isDark ? 0.10 : 0.04
+        let washed = paper.blended(withFraction: wash, of: accent) ?? paper
+        backdrop.layer?.backgroundColor = washed.cgColor
+        backdrop.alphaValue = min(tint + (scheme.isDark ? 0.18 : 0.30), 0.84)
+        glass.layer?.borderWidth = 0
+        var view = host.rootView
+        view.accent = Color(nsColor: accent)
+        host.rootView = view
+    }
+
+    func applyCornerRadius(_ radius: CGFloat) {
+        guard radius != cornerRadius else { return }
+        cornerRadius = radius
+        applyCorners()
+    }
+
+    /// Capsule — the rail is a tab, not a second box sharing the note's edge.
+    private func applyCorners() {
+        let radius = Self.height / 2
+        glass.layer?.cornerRadius = radius
+        glass.layer?.maskedCorners = [
+            .layerMinXMinYCorner, .layerMaxXMinYCorner,
+            .layerMinXMaxYCorner, .layerMaxXMaxYCorner,
+        ]
+        backdrop.layer?.cornerRadius = radius
+        backdrop.layer?.maskedCorners = glass.layer?.maskedCorners
+            ?? [
+                .layerMinXMinYCorner, .layerMaxXMinYCorner,
+                .layerMinXMaxYCorner, .layerMaxXMaxYCorner,
+            ]
+    }
+
+
+    func setVisible(_ visible: Bool) {
+        guard visible != isVisible else { return }
+        isVisible = visible
+        if visible {
+            syncFrame()
+            window.ignoresMouseEvents = false
+        }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.14
+            context.completionHandler = { [weak self] in
+                guard let self, !self.isVisible else { return }
+                self.window.ignoresMouseEvents = true
+            }
+            window.animator().alphaValue = visible ? 1 : 0
+        }
+    }
+
+    /// Detach and close. The rail is a child window, so leaving it behind would
+    /// strand a floating strip with no note under it.
+    func dismantle() {
+        for observer in observers { NotificationCenter.default.removeObserver(observer) }
+        observers.removeAll()
+        panel?.removeChildWindow(window)
+        window.orderOut(nil)
+        window.close()
+    }
+
+}
+
+private final class RailHoverView: NSView {
+    var onChanged: ((Bool) -> Void)?
+    private var tracking: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+        if let tracking { removeTrackingArea(tracking) }
+        let next = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self
+        )
+        addTrackingArea(next)
+        tracking = next
+        super.updateTrackingAreas()
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        onChanged?(true)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        onChanged?(false)
+    }
+}
+
+private final class RailPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    override func sendEvent(_ event: NSEvent) {
+        switch event.type {
+        case .mouseMoved, .leftMouseDragged, .rightMouseDragged, .otherMouseDragged,
+             .mouseEntered, .mouseExited:
+            if let note = parent as? NotePanel {
+                note.setRailPointerInside(frame.contains(NSEvent.mouseLocation))
+            }
+        default:
+            break
+        }
+        super.sendEvent(event)
+    }
+}
+
+/// Blinkified title bar: identity on the left, instruments on the right, and no
+/// OS furniture anywhere. Deliberately not an `NSToolbar` — this belongs to the
+/// note, not to a document window.
+private struct PanelChromeRailView: View {
+    @ObservedObject var state: PanelModeState
+    var title: String
+    var accent: Color = Color(
+        nsColor: NSColor(srgbRed: 93 / 255, green: 158 / 255, blue: 250 / 255, alpha: 1)
+    )
+    var onClose: () -> Void
+    var onSelectMode: (String) -> Void
+    var onToggleFocus: () -> Void
+
+    /// Adaptive rather than the in-note chrome's fixed white: the rail follows
+    /// the app scheme, so its ink has to flip with it or vanish in light mode.
+    private var ink: Color { .primary }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            CloseGlyph(ink: ink, onTap: onClose)
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(ink.opacity(0.78))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            FocusGlyph(state: state, ink: ink, accent: accent, onTap: onToggleFocus)
+                .frame(width: 24, height: 24)
+            ModeToggle(state: state, ink: ink, onSelect: onSelectMode, accent: accent)
+        }
+        .padding(.horizontal, 6)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -39,20 +39,28 @@ Rules:
     "blink": "hyper+b",         // global — show all notes / hide all
     "grid": "hyper+c",          // global — grid/constellation overlay ("c" — hyper+g collides with Lattices)
     "toggleMode": "cmd+shift+p",// per-panel — flip read/edit
-    "focus": "cmd+."            // per-panel — quiet everything else
+    "focus": "cmd+.",           // per-panel — quiet everything else
+    "toggleChrome": "cmd+shift+t" // per-panel — pin the chrome rail after hover leaves
   },
   "panel": {
     "sheet": "glass",           // sheet template: "glass" | "card" | "dotted" | "bracket" | "marginalia"
                                 // per-note override: a `sheet:` frontmatter key in the note file
     "material": "hud",          // glass material: "hud" | "underWindow" | "popover" | "sidebar" | "menu"
     "cornerRadius": 12,
-    "tintRead": 0.18,           // 0–1 black tint over the glass in read mode (contrast floor)
-    "tintEdit": 0.28,           // 0–1 tint in edit mode (focused writing surface)
+    "tintRead": 0.28,           // 0–1 black tint over the glass in read mode (contrast floor)
+    "tintEdit": 0.38,           // 0–1 tint in edit mode (focused writing surface)
     "shadow": true,             // window drop shadow
     "defaultWidth": 420,        // size for panels opening for the first time
     "defaultHeight": 340,
     "background": null,         // optional CSS color; null keeps the glass sheet transparent
-    "mark": null                // optional identity mark from $BLINK_HOME/attachments
+    "mark": null,               // optional identity mark from $BLINK_HOME/attachments
+    "chrome": "rail"            // where the ✕ and mode toggle live:
+                                // "rail"   — a detached strip above the note, off the page.
+                                //            Shown on hover (or pinned with hotkeys.toggleChrome);
+                                //            the strip stays reachable across the seam. Idle notes
+                                //            stay bare. Edit mode does not force it.
+                                // "inside" — the original hover-earned chrome floating over
+                                //            the note's own top corners.
   },
   "focus": {
     "dim": 0.30                 // 0–1 strength of the focus-mode veil over everything else

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -20,6 +20,10 @@ Options:
 Environment:
   BLINK_APP_PATH        Override output .app path (default: dist/Blink.app)
   BLINK_HUDSON_SOURCE   "path" (default, ../hudson checkout) or "git"
+  BLINK_SIGN_IDENTITY   Code-signing identity for the local bundle. Defaults to
+                        a "Blink Dev" certificate if one exists. A stable
+                        identity stops macOS re-prompting for the login password
+                        on every rebuild (Keychain ACLs key off code identity).
 EOF
 }
 
@@ -110,6 +114,44 @@ cat > "$app_path/Contents/Info.plist" <<PLIST
 </dict>
 </plist>
 PLIST
+
+# Keychain ACLs bind to designated requirement + bundle id. Prefer Developer
+# ID (or BLINK_SIGN_IDENTITY) so rebuilds keep one identity. If none is
+# available, launch unsigned and warn — agents without a cert can still run.
+sign_identity="${BLINK_SIGN_IDENTITY:-}"
+if [[ -z "$sign_identity" ]]; then
+  sign_identity="$(
+    security find-identity -v -p codesigning 2>/dev/null \
+      | sed -n 's/^[[:space:]]*[0-9]*)[[:space:]]*\([A-F0-9]\{40\}\)[[:space:]]*"Developer ID Application:[^"]*".*/\1/p' \
+      | head -n 1
+  )"
+fi
+entitlements="$repo_root/tools/release/Blink.entitlements"
+if [[ -n "$sign_identity" && -f "$entitlements" ]]; then
+  sign_bundle() {
+    local bundle="$1"
+    local binary="$bundle/Contents/MacOS/$app_name"
+    codesign --force --options runtime --timestamp \
+      --entitlements "$entitlements" --sign "$sign_identity" \
+      "$binary"
+    codesign --force --options runtime --timestamp \
+      --entitlements "$entitlements" --identifier "dev.arach.blink" --sign "$sign_identity" \
+      "$bundle"
+    codesign --verify --strict --deep "$bundle"
+  }
+  if sign_bundle "$app_path"; then
+    echo "Signed $app_path as \"$sign_identity\""
+  else
+    echo "warning: codesign as \"$sign_identity\" failed — Keychain may re-prompt" >&2
+  fi
+elif [[ -n "$sign_identity" ]]; then
+  echo "warning: missing entitlements at $entitlements — launched unsigned" >&2
+else
+  echo "warning: no Developer ID / BLINK_SIGN_IDENTITY — launched unsigned; Keychain will re-prompt each rebuild" >&2
+fi
+
+
+
 
 if [[ "$restart_existing" == true ]]; then
   # Precise kill: only processes running from this exact bundle path.


### PR DESCRIPTION
Detached hover-earned title rail, Developer ID local signing when available, and a popover Quit that flushes saves via NSApp.terminate.